### PR TITLE
Fix matko pop/rock Keyword id issue

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -609,6 +609,7 @@ def _filter_event_queryset(queryset, params, srs=None):
     # Filter only super or sub events if recurring has value
     val = params.get('recurring', None)
     if val:
+        val = val.lower()
         if val == 'super':
             queryset = queryset.filter(is_recurring_super=True)
         elif val == 'sub':

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -268,7 +268,8 @@ class MatkoImporter(Importer):
         keywords = []
         for t in event_types:
             # Save original keyword in the raw too
-            _id = 'matko:{}'.format(t)
+            # Note: / in keyword id breaks URL resolver so we replace it with _
+            _id = 'matko:{}'.format(t.replace('/', '_'))
             kwargs = {
                 'id': _id,  # id like matko:konsertti
                 'data_source_id': 'matko',

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -265,6 +265,13 @@ class MatkoImporter(Importer):
                 event_types.update(
                     map(lambda x: x.lower(), t.split(",")))
 
+        # Save offers.is_free if 'ilmaistapahtumat' tag is present
+        if 'ilmaistapahtumat' in event_types:
+            if 'offers' not in event:
+                event['offers'] = [recur_dict()]
+            offer = event['offers'][0]
+            offer['is_free'] = True
+
         keywords = []
         for t in event_types:
             # Save original keyword in the raw too


### PR DESCRIPTION
Fix error which occurs when an event has a Keyword having slash '/' in the name, e.g. "pop/rock". 

Example event:
http://api.hel.fi/linkedevents/v0.1/event/matko%3A1487528138/
