### PR TITLE
Use SQL for caching n_events

### DIFF
--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -3,6 +3,7 @@ import requests
 import requests_cache
 
 import rdflib
+from django.core.exceptions import ObjectDoesNotExist
 from rdflib import URIRef
 from rdflib import RDF
 from rdflib.namespace import FOAF, SKOS, OWL
@@ -131,8 +132,11 @@ class YsoImporter(Importer):
             check_deprecated_keyword = lambda obj: obj.deprecated
             # manually add new keywords to deprecated ones
             for old_id, new_id in YSO_DEPRECATED_MAPS.items():
-                old_keyword = Keyword.objects.get(id=old_id)
-                new_keyword = Keyword.objects.get(id=new_id)
+                try:
+                    old_keyword = Keyword.objects.get(id=old_id)
+                    new_keyword = Keyword.objects.get(id=new_id)
+                except ObjectDoesNotExist:
+                    continue
                 print('Mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
                 new_keyword.events.add(*old_keyword.events.all())
                 new_keyword.audience_events.add(*old_keyword.audience_events.all())

--- a/events/management/commands/update_all_n_events.py
+++ b/events/management/commands/update_all_n_events.py
@@ -1,13 +1,13 @@
 from django.core.management import BaseCommand
 from django.db import transaction
 
-from events.models import Keyword, recache_n_events
+from events.models import Keyword
+from events.sql import count_events_for_keywords
 
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         with transaction.atomic():
-            keywords = Keyword.objects.all()
-            for kw in keywords:
-                recache_n_events(kw)
-            print(keywords.count())
+            Keyword.objects.update(n_events=0)
+            for keyword_id, n_events in count_events_for_keywords().items():
+                Keyword.objects.filter(id=keyword_id).update(n_events=n_events)

--- a/events/management/commands/update_all_n_events.py
+++ b/events/management/commands/update_all_n_events.py
@@ -10,4 +10,4 @@ class Command(BaseCommand):
         with transaction.atomic():
             Keyword.objects.update(n_events=0)
             for keyword_id, n_events in count_events_for_keywords().items():
-                Keyword.objects.filter(id=keyword_id).update(n_events=n_events)
+                Keyword.objects.filter(id=keyword_id).exclude(n_events=n_events).update(n_events=n_events)

--- a/events/management/commands/update_all_n_events.py
+++ b/events/management/commands/update_all_n_events.py
@@ -1,0 +1,13 @@
+from django.core.management import BaseCommand
+from django.db import transaction
+
+from events.models import Keyword, recache_n_events
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        with transaction.atomic():
+            keywords = Keyword.objects.all()
+            for kw in keywords:
+                recache_n_events(kw)
+            print(keywords.count())

--- a/events/sql.py
+++ b/events/sql.py
@@ -1,0 +1,37 @@
+from django.db import connection
+
+
+def count_events_for_keywords(keyword_ids=()):
+    """
+    Get the actual count of events using the given keywords.
+
+    :param keyword_ids: set of keyword ids; pass an empty set to get the data for all keywords
+    :type keyword_ids: Iterable[str]
+    :return: dict of keyword id to count
+    :rtype: dict[str, int]
+    """
+    # sorry for the non-DRY-ness; would be easier with an SQL generator like SQLAlchemy, but...
+
+    keyword_ids = tuple(set(keyword_ids))
+    with connection.cursor() as cursor:
+        if keyword_ids:
+            cursor.execute('''
+            SELECT t.keyword_id, COUNT(DISTINCT t.event_id)
+            FROM (
+              SELECT keyword_id, event_id FROM events_event_keywords WHERE keyword_id IN %s
+              UNION
+              SELECT keyword_id, event_id FROM events_event_audience WHERE keyword_id IN %s
+            ) t
+            GROUP BY t.keyword_id;
+            ''', [keyword_ids, keyword_ids])
+        else:
+            cursor.execute('''
+            SELECT t.keyword_id, COUNT(DISTINCT t.event_id)
+            FROM (
+              SELECT keyword_id, event_id FROM events_event_keywords
+              UNION
+              SELECT keyword_id, event_id FROM events_event_audience
+            ) t
+            GROUP BY t.keyword_id;
+            ''')
+        return dict(cursor.fetchall())


### PR DESCRIPTION
Instead of using the Django ORM, let's use SQL to figure out how many events each keyword has! ✨ 

Given a test database with 4431 events and 28054 keywords, `update_all_n_events` now finishes in about 5 seconds; with the code at `master`, it would have taken, extrapolating from the original 2.5 seconds per `recache_n_events`, about 70 000 seconds, so that's, uh, a 14 000× speed-up.

Single calls to `recache_n_events` become faster too, but not quite as dramatically (only a 1.94× speedup:)

```
(linkedevents) ~/b/linkedevents (n-event-up) $ time python update_50_times.py
        3.12 real         0.82 user         0.09 sys
(linkedevents) ~/b/linkedevents (master) $ time python update_50_times.py
        6.06 real         0.96 user         0.08 sys
```