### PR TITLE
Tiny optimizations

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -972,8 +972,8 @@ class EventSerializer(LinkedEventsSerializer, GeoModelAPIView):
 
         # clean the html
         for k, v in data.items():
-            if type(v) == str:
-                if k in ["description"]:
+            if k in ["description"]:
+                if isinstance(v, str) and any(c in v for c in '<>&'):
                     data[k] = bleach.clean(v, settings.BLEACH_ALLOWED_TAGS)
         data = super().validate(data)
 

--- a/events/api.py
+++ b/events/api.py
@@ -1391,7 +1391,7 @@ class EventViewSet(BulkModelViewSet, JSONAPIViewSet):
     # Use select_ and prefetch_related() to reduce the amount of queries
     queryset = queryset.select_related('location')
     queryset = queryset.prefetch_related(
-        'offers', 'keywords', 'external_links', 'sub_events')
+        'offers', 'keywords', 'audience', 'external_links', 'sub_events', 'in_language')
     serializer_class = EventSerializer
     filter_backends = (EventOrderingFilter, filters.DjangoFilterBackend)
     filter_class = EventFilter

--- a/events/models.py
+++ b/events/models.py
@@ -349,10 +349,11 @@ def recache_n_events_in_location(place):
     Django apps cannot serialize unbound instance functions when saving model history during migration.
     :type place: place
     """
-    n_events = place.events.all().count()
+    n_events = place.events.count()
     if n_events != place.n_events:
         place.n_events = n_events
-        place.save(update_fields=("n_events",))
+        # Use the queryset update API to skip the position/divisions save
+        Place.objects.filter(id=place.id).update(n_events=n_events)
 
 
 class OpeningHoursSpecification(models.Model):


### PR DESCRIPTION
* Speed up recache_n_events_in_location: Use the queryset update API to skip the position/divisions save when we certifiably won't need it.
* If the description doesn't contain any tag-like things (<>&), no need to try and parse it as HTML, right?
* Audience and in_language were missing prefetches, causing extraneous queries for them