### PR TITLE
Allow to filter by multiple publishers

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1360,8 +1360,10 @@ def _filter_event_queryset(queryset, params, srs=None):
         cond = 'end_time - start_time >= %s :: interval'
         queryset = queryset.extra(where=[cond], params=[str(dur)])
 
+    # Filter by publisher, multiple sources separated by comma
     val = params.get('publisher', None)
     if val:
+        val = val.split(',')
         queryset = queryset.filter(publisher__id=val)
 
     return queryset


### PR DESCRIPTION
Resolves https://github.com/City-of-Helsinki/linkedevents/issues/204

Allow to filter by multiple comma-separated `publisher` parameters, in the same way as `data_source`.

Note: untested, but CI passes.