### PR TITLE
Allow multiple data_source for keyword API

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -590,16 +590,17 @@ class KeywordListViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         -the keyword is not deprecated
 
         Supported keyword filtering parameters:
-        data_source  (only keywords with the given data source are included)
+        data_source (only keywords with the given data sources are included)
         filter (only keywords containing the specified string are included)
         show_all_keywords (keywords without events are included)
         show_deprecated (deprecated keywords are included)
         """
         queryset = Keyword.objects.all()
         data_source = self.request.query_params.get('data_source')
+        # Filter by data source, multiple sources separated by comma
         if data_source:
-            data_source = data_source.lower()
-            queryset = queryset.filter(data_source=data_source)
+            data_source = data_source.lower().split(',')
+            queryset = queryset.filter(data_source__in=data_source)
         if not self.request.query_params.get('show_all_keywords'):
             queryset = queryset.filter(n_events__gt=0)
         if not self.request.query_params.get('show_deprecated'):


### PR DESCRIPTION
It would be useful to use multiple `data_source` values with the `keyword` API.

For example:
https://api.hel.fi/linkedevents/v1/keyword/?data_source=helmet 119 results
https://api.hel.fi/linkedevents/v1/keyword/?data_source=yso 326 results

But right now:
https://api.hel.fi/linkedevents/v1/keyword/?data_source=helmet,yso 0 results

Untested, but the CI passes.

Do the docs need updating for this somewhere? Same question for yesterday's https://github.com/City-of-Helsinki/linkedevents/pull/205.