### PR TITLE
Feature/automatic place remap

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -357,6 +357,11 @@ class Importer(object):
             obj._changed = True
             obj.position = position
 
+        # we may end up reinstating deleted locations whenever they are imported back and forth
+        if obj.deleted:
+            obj.deleted = False
+            obj._changed = True
+
         self._set_field(obj, 'publisher_id', info['publisher'].id)
 
         if obj._changed or obj._created:

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -34,9 +34,13 @@ LOCATION_TPREK_MAP = {
     'helsingin kaupunginteatteri / lilla teatern': '9353',
     'helsingin kaupunginteatteri / teatteristudio pasila': '9340',
     'finlandia-talo': '9294',
-    'hietaniemen uimaranta': '7766',
     'helsingin kaupunginmuseo': '8663',
     'helsingin kaupunginmuseo/ hakasalmen huvila': '8645',
+    'tuomiokirkko': '43181',
+    'sotamuseo': '25782',
+    'mäkelänrinteen uintikeskus': '41783',
+    'uimastadion': '41047',
+    'eläintarhan yleisurheilukenttä': '40498'
 }
 
 EXTRA_LOCATIONS = {

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -177,7 +177,8 @@ class MatkoImporter(Importer):
         # found places are kept mapped to tprek even if literal matko match exists
         try:
             matko_place = Place.objects.get(data_source=self.data_source, origin_id=location['origin_id'])
-            replace_location(replace=matko_place, by=place)
+            if not (matko_place.deleted and matko_place.replaced_by == place):
+                replace_location(replace=matko_place, by=place)
         except Place.DoesNotExist:
             pass
 

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -15,7 +15,7 @@ from events.keywords import KeywordMatcher
 
 from .sync import ModelSyncher
 from .base import Importer, register_importer, recur_dict
-from .util import clean_text, unicodetext
+from .util import clean_text, unicodetext, replace_location
 
 MATKO_URLS = {
     'places': OrderedDict([
@@ -122,10 +122,15 @@ class MatkoImporter(Importer):
         self.organization, _ = Organization.objects.get_or_create(
             defaults=defaults, **org_args)
 
-        place_list = Place.objects.filter(data_source=self.tprek_data_source)
+        place_list = Place.objects.filter(data_source=self.tprek_data_source, deleted=False)
+        deleted_place_list = Place.objects.filter(data_source=self.tprek_data_source,
+                                                  deleted=True)
         # Get only places that have unique names
         place_list = place_list.annotate(count=Count('name_fi')).filter(count=1).values('id', 'origin_id', 'name_fi')
+        deleted_place_list = deleted_place_list.annotate(count=Count('name_fi')).\
+            filter(count=1).values('id', 'origin_id', 'name_fi', 'replaced_by_id')
         self.tprek_by_name = {p['name_fi'].lower(): (p['id'], p['origin_id']) for p in place_list}
+        self.deleted_tprek_by_name = {p['name_fi'].lower(): (p['id'], p['origin_id'], p['replaced_by_id']) for p in deleted_place_list}
 
         if self.options['cached']:
             requests_cache.install_cache('matko')
@@ -138,7 +143,7 @@ class MatkoImporter(Importer):
         if link is not None:
             result['info_url'][lang_code] = unicodetext(link)
 
-    def _find_place_from_tprek(self, location):
+    def _find_place_from_tprek(self, location, include_deleted=False):
         if 'fi' in location['name']:
             place_name = location['name']['fi']
         else:
@@ -152,10 +157,25 @@ class MatkoImporter(Importer):
         elif place_name in LOCATION_TPREK_MAP:
             tprek_id = LOCATION_TPREK_MAP[place_name]
         else:
-            return None
+            # fallback to deleted if requested
+            if include_deleted and place_name in self.deleted_tprek_by_name:
+                place_id, tprek_id, replaced_by_id = self.deleted_tprek_by_name[place_name]
+                if replaced_by_id:
+                    self.logger.info('Place ' + place_id + ' replaced by ' + replaced_by_id)
+                    place_id = replaced_by_id
+            else:
+                return None
 
         if tprek_id and not place_id:
             place_id = Place.objects.get(data_source=self.tprek_data_source, origin_id=tprek_id).id
+
+        place = Place.objects.get(data_source=self.tprek_data_source, origin_id=tprek_id)
+        # found places are kept mapped to tprek even if literal matko match exists
+        try:
+            matko_place = Place.objects.get(data_source=self.data_source, origin_id=location['origin_id'])
+            replace_location(replace=matko_place, by=place)
+        except Place.DoesNotExist:
+            pass
 
         return place_id
 
@@ -170,15 +190,26 @@ class MatkoImporter(Importer):
             place = Place.objects.get(data_source=self.data_source, origin_id=matko_id)
         except Place.DoesNotExist:
             place = None
+        if place and place.deleted:
+            # The matko location has been superseded by tprek, but the tprek location no longer exists!
+            replace_location(from_source='tprek', by=place)
 
         # No existing entry, load it from Matko.
         if not place:
             places = self._fetch_places()
             from pprint import pprint
             if matko_id not in places:
-                print("Matko location %s (%s) not found!" % (
+                # The final fallback is to use deleted tprek locations.
+                self.logger.info("Matko location %s (%s) not found in feed!" % (
                     location['name']['fi'], location['origin_id']))
+                self.logger.info("Reverting back to deleted tprek locations.")
+                place_id = self._find_place_from_tprek(location, include_deleted=True)
+                if place_id:
+                    self.logger.warning(location['name']['fi'] + " found deleted in tprek!")
+                    return place_id
+                self.logger.warning(location['name']['fi'] + " not found in tprek history!")
                 return None
+            self.logger.info("Place %s found in matko feed, importing." % location['name']['fi'])
             pprint(places[matko_id])
             place = self.save_place(places[matko_id])
 
@@ -307,7 +338,7 @@ class MatkoImporter(Importer):
         if len(keywords) > 0:
             event['keywords'] = keywords
         else:
-            print('Warning: no keyword matches for', event['name'], keywords)
+            self.logger.warning('Warning: no keyword matches for', event['name'], keywords)
 
         if 'id' not in event['location']:
             place_id = self._find_place(event['location'])
@@ -383,7 +414,7 @@ class MatkoImporter(Importer):
         return root.xpath('channel/item')
 
     def import_events(self):
-        print("Importing Matko events")
+        self.logger.info("Importing Matko events")
         events = recur_dict()
         keyword_matcher = KeywordMatcher()
         for lang, url in MATKO_URLS['events'].items():
@@ -394,7 +425,7 @@ class MatkoImporter(Importer):
 
         for event in events.values():
             self.save_event(event)
-        print("%d events processed" % len(events.values()))
+        self.logger.info("%d events processed" % len(events.values()))
 
     def _fetch_places(self):
         if hasattr(self, 'places'):
@@ -419,11 +450,22 @@ class MatkoImporter(Importer):
 
     def import_places(self):
         self._fetch_places()
+        if self.options['single']:
+            self.logger.info("Trying to find single matko location %s" % self.options['single'])
+            for matko_id, location in self.places.items():
+                if location['name']['fi'].lower() == self.options['single'].lower():
+                    self.logger.info("Location %s (%s) found in matko feed"
+                          % (self.options['single'], matko_id))
+                    self.save_place(location)
+                    return
+            self.logger.warning("Location %s not found in matko feed" % self.options['single'])
+            return
+        self.logger.info("Updating existing matko places")
         place_list = Place.objects.filter(data_source=self.data_source)
         for place in place_list:
             origin_id = int(place.origin_id)
             if origin_id not in self.places:
-                self.logger.warning("%s not found in Matko places" % place)
+                self.logger.warning("%s not found in Matko feed anymore" % place)
                 continue
             place = self.places[origin_id]
             self.save_place(place)

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -28,7 +28,7 @@ class ModelSyncher(object):
     def get(self, obj_id):
         return self.obj_dict.get(obj_id, None)
 
-    def finish(self):
+    def finish(self, force=False):
         delete_list = []
         for obj_id, obj in self.obj_dict.items():
             if obj._found:
@@ -36,7 +36,7 @@ class ModelSyncher(object):
             if self.check_deleted_func is not None and self.check_deleted_func(obj):
                 continue
             delete_list.append(obj)
-        if len(delete_list) > 5 and len(delete_list) > len(self.obj_dict) * 0.2:
+        if len(delete_list) > 5 and len(delete_list) > len(self.obj_dict) * 0.2 and not force:
             raise Exception("Attempting to delete more than 20% of total items")
         for obj in delete_list:
             if self.allow_deleting_func:

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -4,6 +4,9 @@ import re
 from lxml import etree
 from django.utils.translation.trans_real import activate, deactivate
 
+from events.models import Place
+
+
 def clean_text(text):
     text = text.replace('\n', ' ')
     # remove consecutive whitespaces
@@ -30,6 +33,54 @@ def address_eq(a, b):
             if (l in a[key] and l in b[key] and not
                text_match(a[key][l], b[key][l])):
                 return False
+    return True
+
+
+def replace_location(replace=None,
+                     from_source='tprek',
+                     by=None,
+                     by_source='matko',
+                     include_deleted=False):
+    """
+    Takes two locations from different data sources and replaces one by the other. If one or the other is
+    not provided, the other is found by the name of the other and the specified data source.
+
+    :param replace: The location to be replaced
+    :param from_datasource: The data source to look for the location to be replaced
+    :param by: The location to replace by
+    :param by_datasource: The data source to look for the location to replace by
+    :param include_deleted: Include deleted locations when looking for replacements
+    :return: Boolean that determines whether a new location was found for the hapless events
+    """
+    if not by:
+        replacements = Place.objects.filter(name__iexact=replace.name, data_source=by_source, deleted=False)
+        if replacements.count() == 1:
+            by = replacements[0]
+        else:
+            # the backup is to look for deleted locations and reinstate them
+            if include_deleted:
+                replacements = Place.objects.filter(name__iexact=replace.name, data_source=by_source)
+                if replacements.count() == 1:
+                    by = replacements[0]
+                else:
+                    # no replacement whatsoever was found, this may result in an exception
+                    return False
+            else:
+                return False
+    if not replace:
+        to_be_replaced = Place.objects.filter(name__iexact=by.name, data_source=from_source)
+        if to_be_replaced.count() == 1:
+            replace = to_be_replaced[0]
+        # if no place to be replaced was found, it's alright, we might have a brand new location here!
+    by.deleted = False
+    by.replaced_by = None
+    by.save(update_fields=['deleted', 'replaced_by'])
+    if replace:
+        replace.deleted = True
+        replace.replaced_by = by
+        replace.save(update_fields=['deleted', 'replaced_by'])
+        print("Location %s (%s) was deleted. Discovered replacement location %s" %
+              (replace.id, str(replace), by.id))
     return True
 
 

--- a/events/management/commands/event_import.py
+++ b/events/management/commands/event_import.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
         parser.add_argument('--all', action='store_true', dest='all', help='Import all entities')
         parser.add_argument('--cached', action='store_true', dest='cached', help='Cache requests (if possible)')
         parser.add_argument('--single', action='store', dest='single', help='Import only single entity')
+        parser.add_argument('--remap', action='store_true', dest='remap', help='Remap all deleted entities to new ones')
 
         for imp in self.importer_types:
             parser.add_argument('--%s' % imp, dest=imp, action='store_true', help='import %s' % imp)
@@ -40,7 +41,8 @@ class Command(BaseCommand):
         importer = imp_class({'data_path': os.path.join(root_dir, 'data'),
                               'verbosity': int(options['verbosity']),
                               'cached': options['cached'],
-                              'single': options['single']})
+                              'single': options['single'],
+                              'remap': options['remap']})
 
         # Activate the default language for the duration of the import
         # to make sure translated fields are populated correctly.

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -185,7 +185,8 @@ def place(data_source, organization, administrative_division):
         id=data_source.id + ':test_location',
         data_source=data_source,
         publisher=organization,
-        position=Point(50, 50)
+        position=Point(50, 50),
+        name='Place 1'
     )
 
 
@@ -210,7 +211,8 @@ def place2(other_data_source, organization2):
     return Place.objects.create(
         id=other_data_source.id + ':test_location_2',
         data_source=other_data_source,
-        publisher=organization2
+        publisher=organization2,
+        name='Place 2'
     )
 
 

--- a/events/tests/test_importer_util.py
+++ b/events/tests/test_importer_util.py
@@ -1,0 +1,14 @@
+import pytest
+
+from events.importer.util import replace_location
+from events.models import Event
+
+
+@pytest.mark.django_db
+def test_replace_location_by_different_source(place, place2, other_data_source, event):
+    assert event.location == place
+    place2.name = place.name
+    place2.save()
+    replace_location(replace=place, by_source=other_data_source.id)
+    updated_event = Event.objects.get(id=event.id)
+    assert updated_event.location == place2

--- a/events/tests/test_place_get.py
+++ b/events/tests/test_place_get.py
@@ -43,6 +43,9 @@ def test_get_place_detail_check_redirect_and_event_remap(api_client, event, plac
     assert response2.data['n_events'] == 1
     event_response2 = get_event_detail(api_client, event.pk)
     assert event_response2.data['location']['@id'] == reverse('place-detail', kwargs={'pk': place2.id})
+    with pytest.raises(Exception):
+        place2.replaced_by = place
+        place.save()
 
 
 @pytest.mark.django_db

--- a/events/tests/test_place_get.py
+++ b/events/tests/test_place_get.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+from django.core.management import call_command
+
 from .utils import versioned_reverse as reverse
 import pytest
 from .utils import get
+from .test_event_get import get_detail as get_event_detail
 
 
 def get_list(api_client, version='v1', data=None):
@@ -21,15 +24,25 @@ def test_get_place_detail(api_client, place):
 
 
 @pytest.mark.django_db
-def test_get_place_detail_check_redirect(api_client, place, place2):
+def test_get_place_detail_check_redirect_and_event_remap(api_client, event, place, place2):
+    call_command('update_n_events')
+    response = get_detail(api_client, place.pk)
+    assert response.data['id'] == place.id
+    assert response.data['n_events'] == 1
+    event_response = get_event_detail(api_client, event.pk)
+    assert event_response.data['location']['@id'] == reverse('place-detail', kwargs={'pk': place.id})
     place.replaced_by = place2
     place.deleted = True
     place.save()
+    call_command('update_n_events')
     url = reverse('place-detail', version='v1', kwargs={'pk': place.pk})
     response = api_client.get(url, data=None, format='json')
     assert response.status_code == 301
     response2 = api_client.get(response.url, data=None, format='json')
     assert response2.data['id'] == place2.id
+    assert response2.data['n_events'] == 1
+    event_response2 = get_event_detail(api_client, event.pk)
+    assert event_response2.data['location']['@id'] == reverse('place-detail', kwargs={'pk': place2.id})
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The idea is to automatically map missing tprek locations to matko locations, and back again if and when they become available again in tprek. The order of preference is
1) existing tprek locations
2) existing matko locations
3) deleted tprek locations, if the location is not present in tprek or matko any longer.

This way, there are no longer any duplicate locations, and all events are mapped to the most recent data whenever locations appear in tprek or events appear in matko.

Also, updated some matko tprek mapping codes to reflect current tprek ids.