### PR TITLE
 Allow fetching objects published by replaced/replacing organization

### DIFF
--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'events.apps.EventsConfig'

--- a/events/api.py
+++ b/events/api.py
@@ -134,10 +134,6 @@ def get_authenticated_data_source_and_publisher(request):
         publisher = data_source.owner
         if not publisher:
             raise PermissionDenied(_("Data source doesn't belong to any organization"))
-
-        if publisher.replaced_by:
-            # using new organization that replaces current organization
-            publisher = publisher.replaced_by
     else:
         # objects created by api are marked coming from the system data source unless api_key is provided
         # we must optionally create the system data source here, as the settings may have changed at any time

--- a/events/api.py
+++ b/events/api.py
@@ -134,6 +134,10 @@ def get_authenticated_data_source_and_publisher(request):
         publisher = data_source.owner
         if not publisher:
             raise PermissionDenied(_("Data source doesn't belong to any organization"))
+
+        if publisher.replaced_by:
+            # using new organization that replaces current organization
+            publisher = publisher.replaced_by
     else:
         # objects created by api are marked coming from the system data source unless api_key is provided
         # we must optionally create the system data source here, as the settings may have changed at any time

--- a/events/apps.py
+++ b/events/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+from django.db.models.signals import post_save
+
+from .signals import organization_post_save
+
+
+class EventsConfig(AppConfig):
+    name = 'events'
+
+    def ready(self):
+        post_save.connect(
+            organization_post_save,
+            sender="django_orghierarchy.Organization",
+            dispatch_uid='organization_post_save',
+        )

--- a/events/signals.py
+++ b/events/signals.py
@@ -1,0 +1,10 @@
+def organization_post_save(sender, instance, created, **kwargs):
+    if not created and instance.replaced_by:
+        new_org = instance.replaced_by
+
+        # copy old organization admin_users / regular_users to new organization
+        new_org.admin_users.add(*list(instance.admin_users.all()))
+        new_org.regular_users.add(*list(instance.regular_users.all()))
+
+        # update owned systems to new owner
+        instance.owned_systems.update(owner=new_org)

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -32,25 +32,18 @@ def test_api_page_size(api_client, event):
 
 @pytest.mark.django_db
 def test_get_authenticated_data_source_and_publisher(data_source):
-    org_1 = Organization.objects.create(
+    org = Organization.objects.create(
         data_source=data_source,
         origin_id='org-1',
         name='org-1',
     )
-    org_2 = Organization.objects.create(
-        data_source=data_source,
-        origin_id='org-2',
-        name='org-2',
-        replaced_by=org_1,
-    )
-    data_source.owner = org_2
+    data_source.owner = org
     data_source.save()
 
-    # test return new organization for replaced one
     request = MagicMock(auth=ApiKeyAuth(data_source))
     ds, publisher = get_authenticated_data_source_and_publisher(request)
     assert ds == data_source
-    assert publisher == org_1
+    assert publisher == org
 
 
 class TestImageAPI(APITestCase):

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -1,5 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
+from django_orghierarchy.models import Organization
+from rest_framework import status
+from rest_framework.test import APITestCase
+
 from .utils import versioned_reverse as reverse
+from ..models import DataSource, Event, Image, PublicationStatus
 
 
 @pytest.mark.django_db
@@ -19,3 +26,153 @@ def test_api_page_size(api_client, event):
     assert resp.status_code == 200
     meta = resp.data['meta']
     assert len(resp.data['data']) <= 100
+
+
+class TestImageAPI(APITestCase):
+
+    def setUp(self):
+        data_source = DataSource.objects.create(
+            id='ds',
+            name='data-source',
+        )
+        org_1 = Organization.objects.create(
+            name='org-1',
+            origin_id='org-1',
+            data_source=data_source,
+        )
+        org_2 = Organization.objects.create(
+            name='org-2',
+            origin_id='org-2',
+            data_source=data_source,
+            replaced_by=org_1,
+        )
+        org_3 = Organization.objects.create(
+            name='org-3',
+            origin_id='org-3',
+            data_source=data_source,
+        )
+        self.image_1 = Image.objects.create(
+            name='image-1',
+            data_source=data_source,
+            publisher=org_1,
+            url='http://fake.url/image-1/',
+        )
+        self.image_2 = Image.objects.create(
+            name='image-2',
+            data_source=data_source,
+            publisher=org_2,
+            url='http://fake.url/image-2/',
+        )
+        self.image_3 = Image.objects.create(
+            name='image-2',
+            data_source=data_source,
+            publisher=org_3,
+            url='http://fake.url/image-2/',
+        )
+
+    def test_get_image_list_with_publisher(self):
+        # test filtering with replaced organization
+        url = '{0}?publisher=ds:org-1'.format(reverse('image-list'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['data']), 2)
+
+        # test filtering with organization that replaces organization
+        url = '{0}?publisher=ds:org-2'.format(reverse('image-list'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['data']), 2)
+
+        # test filtering with normal organization
+        url = '{0}?publisher=ds:org-3'.format(reverse('image-list'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['data']), 1)
+
+
+class TestEventAPI(APITestCase):
+
+    def setUp(self):
+        self.data_source = DataSource.objects.create(
+            id='ds',
+            name='data-source',
+        )
+        self.org_1 = Organization.objects.create(
+            name='org-1',
+            origin_id='org-1',
+            data_source=self.data_source,
+        )
+        self.org_2 = Organization.objects.create(
+            name='org-2',
+            origin_id='org-2',
+            data_source=self.data_source,
+            replaced_by=self.org_1,
+        )
+        self.org_3 = Organization.objects.create(
+            name='org-3',
+            origin_id='org-3',
+            data_source=self.data_source,
+        )
+        self.event_1 = Event.objects.create(
+            id='event-1',
+            name='event-1',
+            data_source=self.data_source,
+            publisher=self.org_1,
+            publication_status=PublicationStatus.DRAFT,
+        )
+        self.event_2 = Event.objects.create(
+            id='event-2',
+            name='event-2',
+            data_source=self.data_source,
+            publisher=self.org_2,
+            publication_status=PublicationStatus.DRAFT,
+        )
+        self.event_3 = Event.objects.create(
+            id='event-3',
+            name='event-3',
+            data_source=self.data_source,
+            publisher=self.org_3,
+            publication_status=PublicationStatus.DRAFT,
+        )
+        self.event_4 = Event.objects.create(
+            id='event-4',
+            name='event-4',
+            data_source=self.data_source,
+            publisher=self.org_3,
+            publication_status=PublicationStatus.PUBLIC,
+        )
+
+    def test_event_list_with_auth_filters(self):
+        # test with public request
+        url = '{0}?show_all=1'.format(reverse('event-list'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['data']), 1)  # event-4
+
+        # test with authenticated data source and publisher
+        with patch(
+            'events.api.get_authenticated_data_source_and_publisher',
+            MagicMock(return_value=(self.data_source, self.org_2))
+        ):
+            url = '{0}?show_all=1'.format(reverse('event-list'))
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(response.data['data']), 3)  # event-1, event-2 and event-4
+
+    def test_event_list_with_publisher_filters(self):
+        # test with public request
+        url = '{0}?show_all=1&publisher=ds:org-3'.format(reverse('event-list'))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['data']), 1)  # event-4
+
+        # test with authenticated data source and publisher
+        with patch(
+            'events.api.get_authenticated_data_source_and_publisher',
+            MagicMock(return_value=(self.data_source, self.org_2))
+        ):
+            url = '{0}?show_all=1&publisher=ds:org-2'.format(reverse('event-list'))
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # note that org-2 is replaced by org-1
+            self.assertEqual(len(response.data['data']), 2)  # event-1 and event-2

--- a/events/tests/test_signals.py
+++ b/events/tests/test_signals.py
@@ -1,0 +1,52 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django_orghierarchy.models import Organization
+
+from ..models import DataSource
+
+
+class TestOrganizationPostSave(TestCase):
+
+    def setUp(self):
+        user_model = get_user_model()
+        self.user_1 = user_model.objects.create(username='user-1')
+        self.user_2 = user_model.objects.create(username='user-2')
+
+        self.data_source_1 = DataSource.objects.create(
+            id='ds-1',
+            name='data-source-1',
+        )
+        self.data_source_2 = DataSource.objects.create(
+            id='ds-2',
+            name='data-source-2'
+        )
+        self.org_1 = Organization.objects.create(
+            data_source=self.data_source_1,
+            name='org-1',
+            origin_id='org-1',
+        )
+        self.org_2 = Organization.objects.create(
+            data_source=self.data_source_2,
+            name='org-2',
+            origin_id='org-2',
+        )
+        self.data_source_1.owner = self.org_1
+        self.data_source_1.save()
+        self.data_source_2.owner = self.org_2
+        self.data_source_2.save()
+
+        self.org_1.admin_users.set([self.user_1, self.user_2])
+        self.org_1.regular_users.set([self.user_1, self.user_2])
+
+    def test_organization_post_save(self):
+        self.org_1.replaced_by = self.org_2
+        self.org_1.save()
+
+        qs = self.org_2.admin_users.all()
+        self.assertQuerysetEqual(qs, [repr(self.user_1), repr(self.user_2)], ordered=False)
+
+        qs = self.org_2.regular_users.all()
+        self.assertQuerysetEqual(qs, [repr(self.user_1), repr(self.user_2)], ordered=False)
+
+        self.data_source_1.refresh_from_db()
+        self.assertEqual(self.data_source_1.owner, self.org_2)

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -9,4 +9,6 @@ class User(AbstractUser):
         return '{0} {1}'.format(self.first_name, self.last_name).strip()
 
     def get_default_organization(self):
-        return self.admin_organizations.order_by('created_time').first()
+        return self.admin_organizations.filter(
+            replaced_by__isnull=True,
+        ).order_by('created_time').first()

--- a/helevents/tests/test_models.py
+++ b/helevents/tests/test_models.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from django_orghierarchy.models import Organization
+
+from events.models import DataSource
+from ..models import User
+
+
+class TestUser(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create(username='testuser')
+        data_source = DataSource.objects.create(id='ds', name='data-source')
+
+        self.org_1 = Organization.objects.create(data_source=data_source, origin_id='org-1')
+        self.org_2 = Organization.objects.create(data_source=data_source, origin_id='org-2', replaced_by=self.org_1)
+
+    def test_get_default_organization(self):
+        self.org_1.admin_users.add(self.user)
+        org = self.user.get_default_organization()
+        self.assertEqual(org, self.org_1)
+
+    def test_get_default_organization_org_replaced(self):
+        self.org_2.admin_users.add(self.user)
+        org = self.user.get_default_organization()
+        self.assertIsNone(org)

--- a/requirements.in
+++ b/requirements.in
@@ -40,4 +40,4 @@ django-allauth
 django-leaflet
 djangorestframework-bulk
 python-docx
--e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1#egg=django-orghierarchy
+-e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.1#egg=django-orghierarchy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/City-of-Helsinki/django-helusers@v0.1#egg=django-helusers
 -e git+https://github.com/City-of-Helsinki/munigeo@v0.2.1#egg=django-munigeo
--e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1#egg=django-orghierarchy
+-e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.1#egg=django-orghierarchy
 astroid==1.5.3            # via pylint
 bleach==2.1
 certifi==2017.7.27.1      # via requests


### PR DESCRIPTION
When filtering the objects with publishers, the REST API will also return objects that are published by a replaced organization when a replacing organization is provided. Also it will return objects for replacing organization if a replaced organization is provided.