### PR TITLE
Corresponding changes in Organization REST API and permission check for Organization model

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -904,10 +904,15 @@ class OrganizationSerializer(LinkedEventsSerializer):
     )
     sub_organizations = serializers.HyperlinkedRelatedField(
         queryset=Organization.objects.all(),
-        source='children',
         view_name='organization-detail',
         many=True,
     )
+    affiliated_organizations = serializers.HyperlinkedRelatedField(
+        queryset=Organization.objects.all(),
+        view_name='organization-detail',
+        many=True,
+    )
+    is_affiliated = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
@@ -915,10 +920,13 @@ class OrganizationSerializer(LinkedEventsSerializer):
             'id', 'data_source', 'origin_id',
             'classification', 'name', 'founding_date',
             'dissolution_date', 'parent_organization',
-            'sub_organizations', 'responsible_organization',
+            'sub_organizations', 'affiliated_organizations',
             'created_time', 'last_modified_time', 'created_by',
-            'last_modified_by',
+            'last_modified_by', 'is_affiliated',
         )
+
+    def get_is_affiliated(self, obj):
+        return obj.internal_type == Organization.AFFILIATED
 
 
 class OrganizationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/events/tests/test_event_auth_api.py
+++ b/events/tests/test_event_auth_api.py
@@ -46,7 +46,8 @@ class TestEventAPI(APITestCase):
             name='org-4',
             origin_id='org-4',
             data_source=self.data_source,
-            responsible_organization=self.org_1
+            parent=self.org_1,
+            internal_type=Organization.AFFILIATED
         )
         self.event_1 = Event.objects.create(
             id='ds:event-1',

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -1,4 +1,3 @@
-from django_orghierarchy.models import Organization
 from helusers.models import AbstractUser
 
 from events.permissions import UserModelPermissionMixin
@@ -23,15 +22,11 @@ class User(AbstractUser, UserModelPermissionMixin):
         return admin_org or regular_org
 
     def is_admin(self, publisher):
-        # check if publisher exists in user's admin organizations and their descedants
+        # check if publisher exists in user's admin organizations or their descendants
         admin_orgs = self.admin_organizations.all()
         for org in admin_orgs:
             if org.get_descendants(include_self=True).filter(id=publisher.id).exists():
                 return True
-
-        # check if publisher exists in affiliated organizations of user's admin organizations
-        if Organization.objects.filter(responsible_organization__in=admin_orgs, id=publisher.id).exists():
-            return True
 
         return False
 

--- a/helevents/tests/test_models.py
+++ b/helevents/tests/test_models.py
@@ -35,7 +35,8 @@ class TestUser(TestCase):
             name='affiliated-org',
             origin_id='affiliated-org',
             data_source=data_source,
-            responsible_organization=self.org,
+            parent=self.org,
+            internal_type=Organization.AFFILIATED,
         )
 
     def test_get_default_organization(self):

--- a/requirements.in
+++ b/requirements.in
@@ -40,4 +40,4 @@ django-allauth
 django-leaflet
 djangorestframework-bulk
 python-docx
--e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.1#egg=django-orghierarchy
+-e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.2#egg=django-orghierarchy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/City-of-Helsinki/django-helusers@v0.1#egg=django-helusers
 -e git+https://github.com/City-of-Helsinki/munigeo@v0.2.1#egg=django-munigeo
--e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.1#egg=django-orghierarchy
+-e git+https://github.com/City-of-Helsinki/django-orghierarchy.git@v0.1.2#egg=django-orghierarchy
 astroid==1.5.3            # via pylint
 bleach==2.1
 certifi==2017.7.27.1      # via requests


### PR DESCRIPTION
The `responsible_organization` field is removed from Organization model, and the affiliated organizations are part of the organization hierarchical tree. We need to change the REST API and permission check accordingly.

Refs: https://github.com/City-of-Helsinki/linkedevents/issues/248