### PR TITLE
Use logger in importers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You probably want to import some data for testing (these are events around Helsi
 cd $INSTALL_BASE/linkedevents
 # Import places from Helsinki service registry (used by events from following sources)
 python manage.py event_import tprek --places
+# Import YSO keywords for describing events (ditto)
+python manage.py event_import yso --keywords
 # Import events from Visit Helsinki
 python manage.py event_import matko --events
 # Import events from Helsinki metropolitan region libraries

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -28,7 +28,6 @@ class Importer(object):
         self._images = {obj.url: obj for obj in Image.objects.all()}
         self.options = options
         self.verbosity = options['verbosity']
-        self.logger = logging.getLogger(__name__)
 
         importer_langs = set(self.supported_languages)
         configured_langs = set(l[0] for l in settings.LANGUAGES)
@@ -106,7 +105,7 @@ class Importer(object):
 
     def _set_field(self, obj, field_name, val):
         if not hasattr(obj, field_name):
-            print(vars(obj))
+            logging.debug(vars(obj))
         obj_val = getattr(obj, field_name)
         # this prevents overwriting manually edited values with empty values
         if obj_val == val or (hasattr(obj, 'is_user_edited') and obj.is_user_edited() and not val):
@@ -209,7 +208,7 @@ class Importer(object):
                 try:
                     license_object = License.objects.get(id=license_id)
                 except License.DoesNotExist:
-                    print('Invalid license id "%s" image %s event %s' % (license_id, image_url, obj))
+                    logging.warning('Invalid license id "%s" image %s event %s' % (license_id, image_url, obj))
                     return
                 image_object.license = license_object
                 image_object.save(update_fields=('license',))
@@ -222,7 +221,7 @@ class Importer(object):
             try:
                 obj.save()
             except ValidationError as error:
-                print('Event ' + str(obj) + ' could not be saved: ' + str(error))
+                logging.error('Event ' + str(obj) + ' could not be saved: ' + str(error))
                 raise
 
         # many-to-many fields
@@ -303,7 +302,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            print("%s %s" % (obj, verb))
+            logging.debug("%s %s" % (obj, verb))
 
         return obj
 
@@ -333,7 +332,7 @@ class Importer(object):
                     p.transform(self.gps_to_target_ct)
                 position = p
             else:
-                print("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
+                logging.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
 
         if position and obj.position:
             # If the distance is less than 10cm, assume the position
@@ -357,7 +356,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            print("%s %s" % (obj, verb))
+            logging.debug("%s %s" % (obj, verb))
             obj.save()
 
         return obj

--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import requests
 import requests_cache
 import re
@@ -293,8 +294,8 @@ class HelmetImporter(Importer):
         def set_attr(field_name, val):
             if field_name in event:
                 if event[field_name] != val:
-                    self.logger.warning('Event %s: %s mismatch (%s vs. %s)' %
-                                        (eid, field_name, event[field_name], val))
+                    logging.warning('Event %s: %s mismatch (%s vs. %s)' %
+                                    (eid, field_name, event[field_name], val))
                     return
             event[field_name] = val
 
@@ -385,8 +386,8 @@ class HelmetImporter(Importer):
                 event['location']['extra_info'][lang] = extra_info
                 del ext_props['PlaceExtraInfo']
         else:
-            self.logger.warning('Missing TPREK location map for event %s (%s)' %
-                                (event['name'][lang], str(eid)))
+            logging.warning('Missing TPREK location map for event %s (%s)' %
+                            (event['name'][lang], str(eid)))
             del events[event['origin_id']]
             return event
 
@@ -403,7 +404,7 @@ class HelmetImporter(Importer):
         for _ in range(0, 5):
             response = requests.get(url)
             if response.status_code != 200:
-                self.logger.error("HelMet API reported HTTP %d" % response.status_code)
+                logging.error("HelMet API reported HTTP %d" % response.status_code)
                 time.sleep(2)
                 if self.cache:
                     self.cache.delete_url(url)
@@ -411,14 +412,14 @@ class HelmetImporter(Importer):
             try:
                 root_doc = response.json()
             except ValueError:
-                self.logger.error("HelMet API returned invalid JSON")
+                logging.error("HelMet API returned invalid JSON")
                 if self.cache:
                     self.cache.delete_url(url)
                 time.sleep(5)
                 continue
             break
         else:
-            self.logger.error("HelMet API broken again, giving up")
+            logging.error("HelMet API broken again, giving up")
             raise APIBrokenError()
 
         documents = root_doc['value']
@@ -442,13 +443,13 @@ class HelmetImporter(Importer):
                 ), lang, events)
 
     def import_events(self):
-        print("Importing HelMet events")
+        logging.info("Importing HelMet events")
         events = recur_dict()
         for lang in self.supported_languages:
             helmet_lang_id = HELMET_LANGUAGES[lang]
             url = HELMET_API_URL.format(lang_code=helmet_lang_id, start_date='2016-01-01')
-            print("Processing lang " + lang)
-            print("from URL " + url)
+            logging.info("Processing lang {}".format(lang))
+            logging.info("from URL {}".format(url))
             try:
                 self._recur_fetch_paginated_url(url, lang, events)
             except APIBrokenError:
@@ -465,4 +466,4 @@ class HelmetImporter(Importer):
             self.syncher.mark(obj)
 
         self.syncher.finish()
-        print("%d events processed" % len(events.values()))
+        logging.info("%d events processed" % len(events.values()))

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -4,6 +4,7 @@ import os
 import re
 import functools
 from lxml import etree
+import logging
 import dateutil
 from pytz import timezone
 from django.conf import settings
@@ -188,7 +189,7 @@ class KulkeImporter(Importer):
         place_list = Place.objects.filter(data_source=self.tprek_data_source).filter(origin_id__in=id_list)
         self.tprek_by_id = {p.origin_id: p.id for p in place_list}
 
-        print('Preprocessing categories')
+        logging.info('Preprocessing categories')
         categories = self.parse_kulke_categories()
 
         keyword_matcher = KeywordMatcher()
@@ -237,7 +238,7 @@ class KulkeImporter(Importer):
         tprek_id = None
         location = event['location']
         if location['name'] is None:
-            print("Missing place for event %s (%s)" % (
+            logging.warning("Missing place for event %s (%s)" % (
                 get_event_name(event), event['origin_id']))
             return None
 
@@ -276,7 +277,7 @@ class KulkeImporter(Importer):
         if tprek_id:
             event['location']['id'] = self.tprek_by_id[tprek_id]
         else:
-            print("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
+            logging.warning("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
 
     @staticmethod
     def _html_format(text):
@@ -371,7 +372,7 @@ class KulkeImporter(Importer):
             except ValidationError:
                 continue
             except ValueError:
-                print('value error with event %s and url %s ' % (eid, link))
+                logging.error('value error with event %s and url %s ' % (eid, link))
             external_links.append({'link': link})
         event['external_links'][lang] = external_links
 
@@ -458,7 +459,7 @@ class KulkeImporter(Importer):
                     kulke_keyword = Keyword.objects.get(pk=kulke_id)
                     event_keywords.add(kulke_keyword)
                 except Keyword.DoesNotExist:
-                    print('Could not find {}'.format(kulke_id))
+                    logging.error('Could not find {}'.format(kulke_id))
 
             event['keywords'] = event_keywords
             event['audience'] = event_audience
@@ -495,10 +496,10 @@ class KulkeImporter(Importer):
             for inner_key in group:
                 inner_group = recurring_groups.get(inner_key)
                 if inner_group and inner_group != group:
-                    print('Differing groups:', key, inner_key)
-                    print('Differing groups:', group, inner_group)
+                    logging.warning('Differing groups:', key, inner_key)
+                    logging.warning('Differing groups:', group, inner_group)
                     if len(inner_group) == 0:
-                        print(
+                        logging.warning(
                             'Event self-identifies to no group, removing.',
                             inner_key
                         )
@@ -561,8 +562,8 @@ class KulkeImporter(Importer):
                     for headline in [event.name for event in events]
                     ):
                 name += words.pop(0) + ' '
-                print(words)
-                print(name)
+                logging.warning(words)
+                logging.warning(name)
             setattr(super_event, 'name', name)
 
         for lang in self.languages.keys():
@@ -606,8 +607,8 @@ class KulkeImporter(Importer):
             cnt = superevent_aggregates.count()
 
             if cnt > 1:
-                print('Error: the superevent has an ambiguous aggregate group.')
-                print('Aggregate ids: {}, group: {}'.format(
+                logging.error('Error: the superevent has an ambiguous aggregate group.')
+                logging.error('Aggregate ids: {}, group: {}'.format(
                     superevent_aggregates.values_list('id', flat=True), group))
                 continue
 
@@ -659,7 +660,7 @@ class KulkeImporter(Importer):
         return aggregates
 
     def import_events(self):
-        print("Importing Kulke events")
+        logging.info("Importing Kulke events")
         self.url_validator = URLValidator()
         events = recur_dict()
         recurring_groups = dict()
@@ -694,7 +695,7 @@ class KulkeImporter(Importer):
             self._update_super_event(agg.super_event)
 
     def import_keywords(self):
-        print("Importing Kulke categories as keywords")
+        logging.info("Importing Kulke categories as keywords")
         categories = self.parse_kulke_categories()
         for kid, value in categories.items():
             try:

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class ModelSyncher(object):
     def __init__(self, queryset, generate_obj_id,
                  delete_func=None, check_deleted_func=None, allow_deleting_func=None):
@@ -48,4 +51,4 @@ class ModelSyncher(object):
                 obj.delete()
                 deleted = True
             if deleted:
-                print("Deleting object %s" % obj)
+                logging.info("Deleting object %s" % obj)

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import logging
 from django.utils.translation.trans_real import activate, deactivate
 
 from events.models import Place
@@ -84,8 +85,8 @@ def replace_location(replace=None,
         replace.deleted = True
         replace.replaced_by = by
         replace.save(update_fields=['deleted', 'replaced_by'])
-        print("Location %s (%s) was deleted. Discovered replacement location %s" %
-              (replace.id, str(replace), by.id))
+        logging.info("Location %s (%s) was deleted. Discovered replacement location %s" %
+                     (replace.id, str(replace), by.id))
     return True
 
 

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
+import logging
 
 import rdflib
 from django.core.exceptions import ObjectDoesNotExist
@@ -73,11 +74,11 @@ def deprecate_and_replace(graph, keyword):
         except Keyword.DoesNotExist:
             pass
     if new_keyword:
-        print('Keyword %s replaced by %s' % (keyword, new_keyword))
+        logging.info('Keyword %s replaced by %s' % (keyword, new_keyword))
         new_keyword.events.add(*keyword.events.all())
         new_keyword.audience_events.add(*keyword.audience_events.all())
     else:
-        print('Keyword %s deprecated without replacement!' % keyword)
+        logging.info('Keyword %s deprecated without replacement!' % keyword)
         if keyword.events.all().exists() or keyword.audience_events.all().exists():
             raise Exception("Deprecating YSO keyword %s that is referenced in events %s. "
                             "No replacement keyword was found in YSO. Please manually map the "
@@ -104,25 +105,25 @@ class YsoImporter(Importer):
         self.organization, _ = Organization.objects.get_or_create(defaults=defaults, **org_args)
 
     def import_keywords(self):
-        print("Importing YSO keywords")
+        logging.info("Importing YSO keywords")
         graph = self.load_graph_into_memory(URL)
         self.save_keywords(graph)
 
     def load_graph_into_memory(self, url):
         if self.verbosity >= 2:
-            print("Fetching %s" % url)
+            logging.debug("Fetching %s" % url)
         resp = requests.get(url)
         assert resp.status_code == 200
         resp.encoding = 'UTF-8'
         graph = rdflib.Graph()
         if self.verbosity >= 2:
-            print("Parsing RDF")
+            logging.debug("Parsing RDF")
         graph.parse(data=resp.text, format='turtle')
         return graph
 
     def save_keywords(self, graph):
         if self.verbosity >= 2:
-            print("Saving data")
+            logging.debug("Saving data")
 
         bulk_mode = False
         if bulk_mode:
@@ -171,7 +172,7 @@ class YsoImporter(Importer):
                     new_keyword = Keyword.objects.get(id=new_id)
                 except ObjectDoesNotExist:
                     continue
-                print('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
+                logging.info('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
                 new_keyword.events.add(*old_keyword.events.all())
                 new_keyword.audience_events.add(*old_keyword.audience_events.all())
 
@@ -222,7 +223,7 @@ class YsoImporter(Importer):
         for _, literal in graph.preferredLabel(subject):
             with active_language(literal.language):
                 if keyword.name != str(literal):
-                    print('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
+                    logging.info('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
                     keyword.name = str(literal)
                     keyword._changed = True
                     keyword.last_modified_time = BaseModel.now()
@@ -238,7 +239,7 @@ class YsoImporter(Importer):
     def save_alt_label(self, syncher, graph, label):
         label_text = str(label)
         if label.language is None:
-            print('Error:', str(label), 'has no language')
+            logging.error('Error:', str(label), 'has no language')
             return None
         label_object = syncher.get((label_text, str(label.language)))
         if label_object is None:

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -29,7 +29,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'timestamped': {
-            'format': '%(asctime)s: %(message)s',
+            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
         },
     },
     'handlers': {


### PR DESCRIPTION
All importers are changed to use logging.* functions for
logging instead of prints. Also removed the superfluous
logger created in base.py. Django has already created a
logger for us, therefore we can just use `logging`.

Default log format has been changed to include severity
and module name.

Also sneak in instructions on importing YSO keywords.