### PR TITLE
Cleanup importer logging

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -36,7 +36,6 @@ class Importer(object):
         super(Importer, self).__init__()
         self.options = options
         self.verbosity = options['verbosity']
-        self.logger = logging.getLogger(__name__)
 
         importer_langs = set(self.supported_languages)
         configured_langs = set(l[0] for l in settings.LANGUAGES)
@@ -204,7 +203,7 @@ class Importer(object):
 
     def _set_field(self, obj, field_name, val):
         if not hasattr(obj, field_name):
-            print(vars(obj))
+            logging.debug(vars(obj))
         obj_val = getattr(obj, field_name)
         # this prevents overwriting manually edited values with empty values
         if obj_val == val or (hasattr(obj, 'is_user_edited') and obj.is_user_edited() and not val):
@@ -313,7 +312,7 @@ class Importer(object):
             try:
                 obj.save()
             except ValidationError as error:
-                print('Event ' + str(obj) + ' could not be saved: ' + str(error))
+                logging.error('Event ' + str(obj) + ' could not be saved: ' + str(error))
                 raise
 
         # many-to-many fields
@@ -440,7 +439,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            print("%s %s" % (obj, verb))
+            logging.debug("%s %s" % (obj, verb))
 
         return obj
 
@@ -470,7 +469,7 @@ class Importer(object):
                     p.transform(self.gps_to_target_ct)
                 position = p
             else:
-                print("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
+                logging.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
 
         if position and obj.position:
             # If the distance is less than 10cm, assume the position
@@ -494,7 +493,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            print("%s %s" % (obj, verb))
+            logging.debug("%s %s" % (obj, verb))
             obj.save()
 
         return obj

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -19,6 +19,9 @@ from modeltranslation.translator import translator
 
 from events.models import Image, Language, Event, Offer, EventLink, Place
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 EXTENSION_COURSE_FIELDS = ('enrolment_start_time', 'enrolment_end_time', 'maximum_attendee_capacity',
                            'minimum_attendee_capacity', 'remaining_attendee_capacity')
 LOCAL_TZ = pytz.timezone(settings.TIME_ZONE)
@@ -203,7 +206,7 @@ class Importer(object):
 
     def _set_field(self, obj, field_name, val):
         if not hasattr(obj, field_name):
-            logging.debug(vars(obj))
+            logger.debug(vars(obj))
         obj_val = getattr(obj, field_name)
         # this prevents overwriting manually edited values with empty values
         if obj_val == val or (hasattr(obj, 'is_user_edited') and obj.is_user_edited() and not val):
@@ -312,7 +315,7 @@ class Importer(object):
             try:
                 obj.save()
             except ValidationError as error:
-                logging.error('Event ' + str(obj) + ' could not be saved: ' + str(error))
+                logger.error('Event {} could not be saved: {}'.format(obj, error))
                 raise
 
         # many-to-many fields
@@ -439,7 +442,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            logging.debug("%s %s" % (obj, verb))
+            logger.debug("{} {}".format(obj, verb))
 
         return obj
 
@@ -469,7 +472,7 @@ class Importer(object):
                     p.transform(self.gps_to_target_ct)
                 position = p
             else:
-                logging.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
+                logger.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
 
         if position and obj.position:
             # If the distance is less than 10cm, assume the position
@@ -493,7 +496,7 @@ class Importer(object):
                 verb = "created"
             else:
                 verb = "changed"
-            logging.debug("%s %s" % (obj, verb))
+            logger.debug("%s %s" % (obj, verb))
             obj.save()
 
         return obj

--- a/events/importer/espoo.py
+++ b/events/importer/espoo.py
@@ -182,14 +182,13 @@ def mark_deleted(obj):
 
 
 def clean_street_address(address):
-    logger = logging.getLogger(__name__)
     LATIN1_CHARSET = u'a-zàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ'
 
     address = address.strip()
     pattern = re.compile(r'([%s\ -]*[0-9-\ ]*\ ?[a-z]{0,2}),?\ *(0?2[0-9]{3})?\ *(espoo|esbo)?' % LATIN1_CHARSET, re.I)
     match = pattern.match(address)
     if not match:
-        logger.warning('Address not matching %s' % address)
+        logging.warning('Address not matching %s' % address)
         return {}
     groups = match.groups()
     street_address = groups[0]
@@ -335,7 +334,7 @@ class EspooImporter(Importer):
         places = Place.objects.filter(**filter_params).order_by('id')
         place = places.first()  # Choose one place arbitrarily if many.
         if len(places) > 1:
-            self.logger.warning('Several tprek_id match the address "%s".' % street_address)
+            logging.warning('Several tprek_id match the address "%s".' % street_address)
         if not place:
             origin_id = self._get_next_place_id("espoo")
             # address must be saved in the right language!
@@ -435,7 +434,7 @@ class EspooImporter(Importer):
             return event_keywords
         keywords = self._map_classification_keywords_from_db(classification_node_name, lang)
         if lang == 'fi' and not keywords:
-            self.logger.warning('Cannot find yso classification for keyword: %s' % classification_node_name)
+            logging.warning('Cannot find yso classification for keyword: %s' % classification_node_name)
             return set()
         self.keyword_by_id.update(dict({k.id: k for k in keywords}))
         return keywords
@@ -539,8 +538,8 @@ class EspooImporter(Importer):
 
         def set_attr(field_name, val):
             if event.get(field_name, val) != val:
-                self.logger.warning('Event %s: %s mismatch (%s vs. %s)' %
-                                    (eid, field_name, event[field_name], val))
+                logging.warning('Event %s: %s mismatch (%s vs. %s)' %
+                                (eid, field_name, event[field_name], val))
                 return
             event[field_name] = val
 
@@ -632,7 +631,7 @@ class EspooImporter(Importer):
                 if place_id:
                     event['location']['id'] = place_id
                 else:
-                    self.logger.warning('Cannot find %s' % ext_props['StreetAddress'])
+                    logging.warning('Cannot find %s' % ext_props['StreetAddress'])
             del ext_props['StreetAddress']
 
         if ext_props.get('EventLocation', ''):
@@ -640,8 +639,8 @@ class EspooImporter(Importer):
             del ext_props['EventLocation']
 
         if 'location' not in event:
-            self.logger.warning('Missing TPREK location map for event %s (%s)' %
-                                (event['name'][lang], str(eid)))
+            logging.warning('Missing TPREK location map for event %s (%s)' %
+                            (event['name'][lang], str(eid)))
             del events[event['origin_id']]
             return event
 
@@ -656,7 +655,7 @@ class EspooImporter(Importer):
         for _ in range(MAX_RETRY):
             response = requests.get(url)
             if response.status_code != 200:
-                self.logger.error("Espoo API reported HTTP %d" % response.status_code)
+                logging.error("Espoo API reported HTTP %d" % response.status_code)
                 time.sleep(5)
                 if self.cache:
                     self.cache.delete_url(url)
@@ -664,14 +663,14 @@ class EspooImporter(Importer):
             try:
                 root_doc = response.json()
             except ValueError:
-                self.logger.error("Espoo API returned invalid JSON for url: %s" % url)
+                logging.error("Espoo API returned invalid JSON for url: %s" % url)
                 if self.cache:
                     self.cache.delete_url(url)
                 time.sleep(5)
                 continue
             break
         else:
-            self.logger.error("Espoo API is broken, giving up")
+            logging.error("Espoo API is broken, giving up")
             raise APIBrokenError()
 
         documents = root_doc['value']
@@ -695,13 +694,13 @@ class EspooImporter(Importer):
                 ), lang, events)
 
     def import_events(self):
-        print("Importing Espoo events")
+        logging.info("Importing Espoo events")
         events = recur_dict()
         for lang in self.supported_languages:
             espoo_lang_id = ESPOO_LANGUAGES[lang]
             url = ESPOO_API_URL.format(lang_code=espoo_lang_id)
-            print("Processing lang " + lang)
-            print("from URL " + url)
+            logging.info("Processing lang {}".format(lang))
+            logging.info("from URL {}".format(url))
             try:
                 self._recur_fetch_paginated_url(url, lang, events)
             except APIBrokenError:
@@ -718,4 +717,4 @@ class EspooImporter(Importer):
             self.syncher.mark(obj)
 
         self.syncher.finish()
-        print("%d events processed" % len(events.values()))
+        logging.info("{} events processed".format(len(events.values())))

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -65,7 +65,7 @@ class HarrastushakuImporter(Importer):
         self.tprek_data_source = DataSource.objects.get(id='tprek')
         self.ahjo_data_source, _ = DataSource.objects.get_or_create(id='ahjo', defaults={'name': 'Ahjo'})
         self.organization, _ = Organization.objects.get_or_create(origin_id='u48040030',
-                                                               data_source=self.ahjo_data_source)
+                                                                  data_source=self.ahjo_data_source)
         self.tprek_ids = {place.origin_id for place in Place.objects.filter(data_source=self.tprek_data_source)}
         self.keywords = {keyword.id: keyword for keyword in Keyword.objects.all()}
         self.keyword_matcher = KeywordMatcher()

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -20,6 +20,9 @@ from events.models import DataSource, Event, Keyword, Place
 
 from .base import Importer, register_importer
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 HARRASTUSHAKU_API_BASE_URL = 'http://nk.hel.fi/harrastushaku/api/'
 
 TIMEZONE = pytz.timezone('Europe/Helsinki')
@@ -45,8 +48,6 @@ AUDIENCE_BY_AGE_RANGE = (
 )
 
 SubEventTimeRange = namedtuple('SubEventTimeRange', ['start', 'end'])
-
-logger = logging.getLogger(__name__)
 
 
 class HarrastushakuException(Exception):

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -7,7 +7,6 @@ from functools import lru_cache, partial
 
 import pytz
 import requests
-from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.utils.dateparse import parse_time
 from django.utils.timezone import now
@@ -64,11 +63,9 @@ class HarrastushakuImporter(Importer):
         logger.debug('Running Harrastushaku importer setup...')
         self.data_source, _ = DataSource.objects.get_or_create(id=self.name, defaults={'name': 'Harrastushaku'})
         self.tprek_data_source = DataSource.objects.get(id='tprek')
-        self.ahjo_data_source, _ = DataSource.objects.get_or_create(id='ahjo', name='Ahjo')
-        try:
-            self.organization = Organization.objects.get(origin_id='u48040030', data_source=self.ahjo_data_source)
-        except Organization.DoesNotExist:
-            raise ImproperlyConfigured("orgid u48040030 missing from DB, harrastushaku importer cannot continue")
+        self.ahjo_data_source, _ = DataSource.objects.get_or_create(id='ahjo', defaults={'name': 'Ahjo'})
+        self.organization, _ = Organization.objects.get_or_create(origin_id='u48040030',
+                                                               data_source=self.ahjo_data_source)
         self.tprek_ids = {place.origin_id for place in Place.objects.filter(data_source=self.tprek_data_source)}
         self.keywords = {keyword.id: keyword for keyword in Keyword.objects.all()}
         self.keyword_matcher = KeywordMatcher()

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -9,7 +9,7 @@ import dateutil
 from pytz import timezone
 from django.conf import settings
 from django.core.validators import URLValidator
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.core.exceptions import ValidationError, ObjectDoesNotExist, ImproperlyConfigured
 from django.db import IntegrityError
 from django_orghierarchy.models import Organization
 
@@ -239,11 +239,14 @@ class KulkeImporter(Importer):
         course_keyword_ids = ['yso:{}'.format(kw) for kw in COURSE_KEYWORDS]
         self.course_keywords = set(Keyword.objects.filter(id__in=course_keyword_ids))
 
+<<<<<<< HEAD
         try:
             self.event_only_license = License.objects.get(id='event_only')
         except License.DoesNotExist:
             self.event_only_license = None
 
+=======
+>>>>>>> Add Kulke course importer
     def parse_kulke_categories(self):
         categories = {}
         categories_file = os.path.join(
@@ -446,11 +449,15 @@ class KulkeImporter(Importer):
                 end_time = end_time.astimezone(LOCAL_TZ)
                 event['has_end_time'] = True
 
+<<<<<<< HEAD
             # sometimes, the data has errors. then we set end time to start time
             if end_time > start_time:
                 event['end_time'] = end_time
             else:
                 event['end_time'] = event['start_time']
+=======
+            event['end_time'] = end_time
+>>>>>>> Add Kulke course importer
 
         if is_course:
             event['extension_course'] = {

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -20,6 +20,9 @@ from events.models import DataSource, Event, EventAggregate, EventAggregateMembe
 from events.keywords import KeywordMatcher
 from events.translation_utils import expand_model_fields
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 LOCATION_TPREK_MAP = {
     'malmitalo': '8740',
     'malms kulturhus': '8740',
@@ -203,7 +206,7 @@ class KulkeImporter(Importer):
         place_list = Place.objects.filter(data_source=self.tprek_data_source).filter(origin_id__in=id_list)
         self.tprek_by_id = {p.origin_id: p.id for p in place_list}
 
-        logging.info('Preprocessing categories')
+        logger.info('Preprocessing categories')
         categories = self.parse_kulke_categories()
 
         keyword_matcher = KeywordMatcher()
@@ -260,7 +263,7 @@ class KulkeImporter(Importer):
         tprek_id = None
         location = event['location']
         if location['name'] is None:
-            logging.warning("Missing place for event %s (%s)" % (
+            logger.warning("Missing place for event %s (%s)" % (
                 get_event_name(event), event['origin_id']))
             return None
 
@@ -299,7 +302,7 @@ class KulkeImporter(Importer):
         if tprek_id:
             event['location']['id'] = self.tprek_by_id[tprek_id]
         else:
-            logging.warning("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
+            logger.warning("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
 
     @staticmethod
     def _html_format(text):
@@ -400,7 +403,7 @@ class KulkeImporter(Importer):
             except ValidationError:
                 continue
             except ValueError:
-                logging.error('value error with event %s and url %s ' % (eid, link))
+                logger.error('value error with event %s and url %s ' % (eid, link))
             external_links.append({'link': link})
         event['external_links'][lang] = external_links
 
@@ -500,7 +503,7 @@ class KulkeImporter(Importer):
                     kulke_keyword = Keyword.objects.get(pk=kulke_id)
                     event_keywords.add(kulke_keyword)
                 except Keyword.DoesNotExist:
-                    logging.error('Could not find {}'.format(kulke_id))
+                    logger.error('Could not find {}'.format(kulke_id))
 
             if is_course:
                 event_keywords.update(self.course_keywords)
@@ -541,10 +544,10 @@ class KulkeImporter(Importer):
             for inner_key in group:
                 inner_group = recurring_groups.get(inner_key)
                 if inner_group and inner_group != group:
-                    logging.warning('Differing groups:', key, inner_key)
-                    logging.warning('Differing groups:', group, inner_group)
+                    logger.warning('Differing groups:', key, inner_key)
+                    logger.warning('Differing groups:', group, inner_group)
                     if len(inner_group) == 0:
-                        logging.warning(
+                        logger.warning(
                             'Event self-identifies to no group, removing.',
                             inner_key
                         )
@@ -607,8 +610,8 @@ class KulkeImporter(Importer):
                     for headline in [event.name for event in events]
                     ):
                 name += words.pop(0) + ' '
-                logging.warning(words)
-                logging.warning(name)
+                logger.warning(words)
+                logger.warning(name)
             setattr(super_event, 'name', name)
 
         for lang in self.languages.keys():
@@ -652,8 +655,8 @@ class KulkeImporter(Importer):
             cnt = superevent_aggregates.count()
 
             if cnt > 1:
-                logging.error('Error: the superevent has an ambiguous aggregate group.')
-                logging.error('Aggregate ids: {}, group: {}'.format(
+                logger.error('Error: the superevent has an ambiguous aggregate group.')
+                logger.error('Aggregate ids: {}, group: {}'.format(
                     superevent_aggregates.values_list('id', flat=True), group))
                 continue
 
@@ -705,11 +708,11 @@ class KulkeImporter(Importer):
         return aggregates
 
     def import_events(self):
-        logging.info("Importing Kulke events")
+        logger.info("Importing Kulke events")
         self._import_events()
 
     def import_courses(self):
-        logging.info("Importing Kulke courses")
+        logger.info("Importing Kulke courses")
         self._import_events(importing_courses=True)
 
     def _import_events(self, importing_courses=False):
@@ -742,7 +745,7 @@ class KulkeImporter(Importer):
             self._update_super_event(agg.super_event)
 
     def import_keywords(self):
-        logging.info("Importing Kulke categories as keywords")
+        logger.info("Importing Kulke categories as keywords")
         categories = self.parse_kulke_categories()
         for kid, value in categories.items():
             try:

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -9,7 +9,7 @@ import dateutil
 from pytz import timezone
 from django.conf import settings
 from django.core.validators import URLValidator
-from django.core.exceptions import ValidationError, ObjectDoesNotExist, ImproperlyConfigured
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import IntegrityError
 from django_orghierarchy.models import Organization
 
@@ -239,14 +239,11 @@ class KulkeImporter(Importer):
         course_keyword_ids = ['yso:{}'.format(kw) for kw in COURSE_KEYWORDS]
         self.course_keywords = set(Keyword.objects.filter(id__in=course_keyword_ids))
 
-<<<<<<< HEAD
         try:
             self.event_only_license = License.objects.get(id='event_only')
         except License.DoesNotExist:
             self.event_only_license = None
 
-=======
->>>>>>> Add Kulke course importer
     def parse_kulke_categories(self):
         categories = {}
         categories_file = os.path.join(
@@ -449,15 +446,11 @@ class KulkeImporter(Importer):
                 end_time = end_time.astimezone(LOCAL_TZ)
                 event['has_end_time'] = True
 
-<<<<<<< HEAD
             # sometimes, the data has errors. then we set end time to start time
             if end_time > start_time:
                 event['end_time'] = end_time
             else:
                 event['end_time'] = event['start_time']
-=======
-            event['end_time'] = end_time
->>>>>>> Add Kulke course importer
 
         if is_course:
             event['extension_course'] = {

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -4,6 +4,7 @@ import os
 import re
 import functools
 from lxml import etree
+import logging
 import dateutil
 from pytz import timezone
 from django.conf import settings
@@ -202,7 +203,7 @@ class KulkeImporter(Importer):
         place_list = Place.objects.filter(data_source=self.tprek_data_source).filter(origin_id__in=id_list)
         self.tprek_by_id = {p.origin_id: p.id for p in place_list}
 
-        print('Preprocessing categories')
+        logging.info('Preprocessing categories')
         categories = self.parse_kulke_categories()
 
         keyword_matcher = KeywordMatcher()
@@ -259,7 +260,7 @@ class KulkeImporter(Importer):
         tprek_id = None
         location = event['location']
         if location['name'] is None:
-            print("Missing place for event %s (%s)" % (
+            logging.warning("Missing place for event %s (%s)" % (
                 get_event_name(event), event['origin_id']))
             return None
 
@@ -298,7 +299,7 @@ class KulkeImporter(Importer):
         if tprek_id:
             event['location']['id'] = self.tprek_by_id[tprek_id]
         else:
-            print("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
+            logging.warning("No match found for place '%s' (event %s)" % (loc_name, get_event_name(event)))
 
     @staticmethod
     def _html_format(text):
@@ -399,7 +400,7 @@ class KulkeImporter(Importer):
             except ValidationError:
                 continue
             except ValueError:
-                print('value error with event %s and url %s ' % (eid, link))
+                logging.error('value error with event %s and url %s ' % (eid, link))
             external_links.append({'link': link})
         event['external_links'][lang] = external_links
 
@@ -499,7 +500,7 @@ class KulkeImporter(Importer):
                     kulke_keyword = Keyword.objects.get(pk=kulke_id)
                     event_keywords.add(kulke_keyword)
                 except Keyword.DoesNotExist:
-                    print('Could not find {}'.format(kulke_id))
+                    logging.error('Could not find {}'.format(kulke_id))
 
             if is_course:
                 event_keywords.update(self.course_keywords)
@@ -540,10 +541,10 @@ class KulkeImporter(Importer):
             for inner_key in group:
                 inner_group = recurring_groups.get(inner_key)
                 if inner_group and inner_group != group:
-                    print('Differing groups:', key, inner_key)
-                    print('Differing groups:', group, inner_group)
+                    logging.warning('Differing groups:', key, inner_key)
+                    logging.warning('Differing groups:', group, inner_group)
                     if len(inner_group) == 0:
-                        print(
+                        logging.warning(
                             'Event self-identifies to no group, removing.',
                             inner_key
                         )
@@ -606,8 +607,8 @@ class KulkeImporter(Importer):
                     for headline in [event.name for event in events]
                     ):
                 name += words.pop(0) + ' '
-                print(words)
-                print(name)
+                logging.warning(words)
+                logging.warning(name)
             setattr(super_event, 'name', name)
 
         for lang in self.languages.keys():
@@ -651,8 +652,8 @@ class KulkeImporter(Importer):
             cnt = superevent_aggregates.count()
 
             if cnt > 1:
-                print('Error: the superevent has an ambiguous aggregate group.')
-                print('Aggregate ids: {}, group: {}'.format(
+                logging.error('Error: the superevent has an ambiguous aggregate group.')
+                logging.error('Aggregate ids: {}, group: {}'.format(
                     superevent_aggregates.values_list('id', flat=True), group))
                 continue
 
@@ -704,11 +705,11 @@ class KulkeImporter(Importer):
         return aggregates
 
     def import_events(self):
-        print("Importing Kulke events")
+        logging.info("Importing Kulke events")
         self._import_events()
 
     def import_courses(self):
-        print("Importing Kulke courses")
+        logging.info("Importing Kulke courses")
         self._import_events(importing_courses=True)
 
     def _import_events(self, importing_courses=False):
@@ -741,7 +742,7 @@ class KulkeImporter(Importer):
             self._update_super_event(agg.super_event)
 
     def import_keywords(self):
-        print("Importing Kulke categories as keywords")
+        logging.info("Importing Kulke categories as keywords")
         categories = self.parse_kulke_categories()
         for kid, value in categories.items():
             try:

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -1,5 +1,8 @@
 import logging
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 
 class ModelSyncher(object):
     def __init__(self, queryset, generate_obj_id,
@@ -58,4 +61,4 @@ class ModelSyncher(object):
                 obj.delete()
                 deleted = True
             if deleted:
-                logging.info("Deleting object %s" % obj)
+                logger.info("Deleting object %s" % obj)

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class ModelSyncher(object):
     def __init__(self, queryset, generate_obj_id,
                  delete_func=None, check_deleted_func=None, allow_deleting_func=None):
@@ -55,4 +58,4 @@ class ModelSyncher(object):
                 obj.delete()
                 deleted = True
             if deleted:
-                print("Deleting object %s" % obj)
+                logging.info("Deleting object %s" % obj)

--- a/events/importer/tprek.py
+++ b/events/importer/tprek.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import re
 import requests
 import requests_cache
@@ -54,7 +55,7 @@ class TprekImporter(Importer):
         url = "%s%s/" % (URL_BASE, resource_name)
         if res_id is not None:
             url = "%s%s/" % (url, res_id)
-        print("Fetching URL %s" % url)
+        logging.info("Fetching URL %s" % url)
         resp = requests.get(url)
         assert resp.status_code == 200
         return resp.json()
@@ -74,11 +75,11 @@ class TprekImporter(Importer):
                 call_command('event_import', 'matko', places=True, single=obj.name)
                 replaced = replace_location(replace=obj, by_source='matko')
             if not replaced:
-                self.logger.warning("Tprek deleted location %s (%s) with events."
-                                    "No unambiguous replacement was found. "
-                                    "Please look for a replacement location and save it in the replaced_by field. "
-                                    "Until then, events will stay mapped to the deleted location." %
-                                    (obj.id, str(obj)))
+                logging.warning("Tprek deleted location %s (%s) with events."
+                                "No unambiguous replacement was found. "
+                                "Please look for a replacement location and save it in the replaced_by field. "
+                                "Until then, events will stay mapped to the deleted location." %
+                                (obj.id, str(obj)))
         return True
 
     def mark_deleted(self, obj):
@@ -99,7 +100,7 @@ class TprekImporter(Importer):
                 val = None
 
             if max_length and val and len(val) > max_length:
-                self.logger.warning("%s: field %s too long" % (obj, info_field_name))
+                logging.warning("%s: field %s too long" % (obj, info_field_name))
                 val = None
 
             obj_key = '%s_%s' % (obj_field_name, lang)
@@ -179,7 +180,7 @@ class TprekImporter(Importer):
                     p.transform(self.gps_to_target_ct)
                 position = p
             else:
-                print("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
+                logging.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
 
         picture_url = info.get('picture_url', '').strip()
         if picture_url:
@@ -213,7 +214,7 @@ class TprekImporter(Importer):
                 verb = "created"
             else:
                 verb = "changed (fields: %s)" % ', '.join(obj._changed_fields)
-            print("%s %s" % (obj, verb))
+            logging.info("%s %s" % (obj, verb))
             obj.save()
 
         syncher.mark(obj)
@@ -228,14 +229,14 @@ class TprekImporter(Importer):
             obj_list = [self.pk_get('unit', obj_id)]
             queryset = queryset.filter(id=obj_id)
         else:
-            print("Loading units...")
+            logging.info("Loading units...")
             obj_list = self.pk_get('unit')
-            print("%s units loaded" % len(obj_list))
+            logging.info("%s units loaded" % len(obj_list))
         syncher = ModelSyncher(queryset, lambda obj: obj.origin_id, delete_func=self.mark_deleted,
                                check_deleted_func=self.check_deleted)
         for idx, info in enumerate(obj_list):
             if idx and (idx % 1000) == 0:
-                print("%s units processed" % idx)
+                logging.info("%s units processed" % idx)
             self._import_unit(syncher, info)
 
         syncher.finish(self.options.get('remap', False))

--- a/events/importer/tprek.py
+++ b/events/importer/tprek.py
@@ -15,6 +15,9 @@ from events.models import DataSource, Place
 from .sync import ModelSyncher
 from .base import Importer, register_importer
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 URL_BASE = 'http://www.hel.fi/palvelukarttaws/rest/v4/'
 GK25_SRID = 3879
 
@@ -55,7 +58,7 @@ class TprekImporter(Importer):
         url = "%s%s/" % (URL_BASE, resource_name)
         if res_id is not None:
             url = "%s%s/" % (url, res_id)
-        logging.info("Fetching URL %s" % url)
+        logger.info("Fetching URL %s" % url)
         resp = requests.get(url)
         assert resp.status_code == 200
         return resp.json()
@@ -75,11 +78,11 @@ class TprekImporter(Importer):
                 call_command('event_import', 'matko', places=True, single=obj.name)
                 replaced = replace_location(replace=obj, by_source='matko')
             if not replaced:
-                logging.warning("Tprek deleted location %s (%s) with events."
-                                "No unambiguous replacement was found. "
-                                "Please look for a replacement location and save it in the replaced_by field. "
-                                "Until then, events will stay mapped to the deleted location." %
-                                (obj.id, str(obj)))
+                logger.warning("Tprek deleted location %s (%s) with events."
+                               "No unambiguous replacement was found. "
+                               "Please look for a replacement location and save it in the replaced_by field. "
+                               "Until then, events will stay mapped to the deleted location." %
+                               (obj.id, str(obj)))
         return True
 
     def mark_deleted(self, obj):
@@ -100,7 +103,7 @@ class TprekImporter(Importer):
                 val = None
 
             if max_length and val and len(val) > max_length:
-                logging.warning("%s: field %s too long" % (obj, info_field_name))
+                logger.warning("%s: field %s too long" % (obj, info_field_name))
                 val = None
 
             obj_key = '%s_%s' % (obj_field_name, lang)
@@ -180,7 +183,7 @@ class TprekImporter(Importer):
                     p.transform(self.gps_to_target_ct)
                 position = p
             else:
-                logging.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
+                logger.warning("Invalid coordinates (%f, %f) for %s" % (n, e, obj))
 
         picture_url = info.get('picture_url', '').strip()
         if picture_url:
@@ -214,7 +217,7 @@ class TprekImporter(Importer):
                 verb = "created"
             else:
                 verb = "changed (fields: %s)" % ', '.join(obj._changed_fields)
-            logging.info("%s %s" % (obj, verb))
+            logger.info("%s %s" % (obj, verb))
             obj.save()
 
         syncher.mark(obj)
@@ -229,14 +232,14 @@ class TprekImporter(Importer):
             obj_list = [self.pk_get('unit', obj_id)]
             queryset = queryset.filter(id=obj_id)
         else:
-            logging.info("Loading units...")
+            logger.info("Loading units...")
             obj_list = self.pk_get('unit')
-            logging.info("%s units loaded" % len(obj_list))
+            logger.info("%s units loaded" % len(obj_list))
         syncher = ModelSyncher(queryset, lambda obj: obj.origin_id, delete_func=self.mark_deleted,
                                check_deleted_func=self.check_deleted)
         for idx, info in enumerate(obj_list):
             if idx and (idx % 1000) == 0:
-                logging.info("%s units processed" % idx)
+                logger.info("%s units processed" % idx)
             self._import_unit(syncher, info)
 
         syncher.finish(self.options.get('remap', False))

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import logging
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
 from django.utils.translation.trans_real import activate, deactivate
@@ -142,8 +143,8 @@ def replace_location(replace=None,
         replace.deleted = True
         replace.replaced_by = by
         replace.save(update_fields=['deleted', 'replaced_by'])
-        print("Location %s (%s) was deleted. Discovered replacement location %s" %
-              (replace.id, str(replace), by.id))
+        logging.info("Location %s (%s) was deleted. Discovered replacement location %s" %
+                     (replace.id, str(replace), by.id))
     return True
 
 

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -55,7 +55,7 @@ def separate_scripts(text, scripts):
             language = last_language
         if language != last_language:
             # fix html paragraph breaks after language change
-            print('supported language detected: ' + language)
+            logging.debug('supported language detected: ' + language)
             if last_paragraph in (r'</p><p>', r'</p>', r'<p>'):
                 separated[last_language] = re.sub(r'<p>$', '', separated[last_language])
                 separated[language] += r'<p>'

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -8,6 +8,9 @@ from django.utils.translation.trans_real import activate, deactivate
 
 from events.models import Place
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 
 def clean_text(text, strip_newlines=False):
     text = text.replace('\xa0', ' ').replace('\x1f', '')
@@ -55,7 +58,7 @@ def separate_scripts(text, scripts):
             language = last_language
         if language != last_language:
             # fix html paragraph breaks after language change
-            logging.debug('supported language detected: ' + language)
+            logger.debug('supported language detected: ' + language)
             if last_paragraph in (r'</p><p>', r'</p>', r'<p>'):
                 separated[last_language] = re.sub(r'<p>$', '', separated[last_language])
                 separated[language] += r'<p>'
@@ -143,8 +146,8 @@ def replace_location(replace=None,
         replace.deleted = True
         replace.replaced_by = by
         replace.save(update_fields=['deleted', 'replaced_by'])
-        logging.info("Location %s (%s) was deleted. Discovered replacement location %s" %
-                     (replace.id, str(replace), by.id))
+        logger.info("Location %s (%s) was deleted. Discovered replacement location %s" %
+                    (replace.id, str(replace), by.id))
     return True
 
 

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
+import logging
 
 import rdflib
 from django.core.exceptions import ObjectDoesNotExist
@@ -73,11 +74,11 @@ def deprecate_and_replace(graph, keyword):
         except Keyword.DoesNotExist:
             pass
     if new_keyword:
-        print('Keyword %s replaced by %s' % (keyword, new_keyword))
+        logging.info('Keyword %s replaced by %s' % (keyword, new_keyword))
         new_keyword.events.add(*keyword.events.all())
         new_keyword.audience_events.add(*keyword.audience_events.all())
     else:
-        print('Keyword %s deprecated without replacement!' % keyword)
+        logging.info('Keyword %s deprecated without replacement!' % keyword)
         if keyword.events.all().exists() or keyword.audience_events.all().exists():
             raise Exception("Deprecating YSO keyword %s that is referenced in events %s. "
                             "No replacement keyword was found in YSO. Please manually map the "
@@ -104,25 +105,25 @@ class YsoImporter(Importer):
         self.organization, _ = Organization.objects.get_or_create(defaults=defaults, **org_args)
 
     def import_keywords(self):
-        print("Importing YSO keywords")
+        logging.info("Importing YSO keywords")
         graph = self.load_graph_into_memory(URL)
         self.save_keywords(graph)
 
     def load_graph_into_memory(self, url):
         if self.verbosity >= 2:
-            print("Fetching %s" % url)
+            logging.debug("Fetching %s" % url)
         resp = requests.get(url)
         assert resp.status_code == 200
         resp.encoding = 'UTF-8'
         graph = rdflib.Graph()
         if self.verbosity >= 2:
-            print("Parsing RDF")
+            logging.debug("Parsing RDF")
         graph.parse(data=resp.text, format='turtle')
         return graph
 
     def save_keywords(self, graph):
         if self.verbosity >= 2:
-            print("Saving data")
+            logging.debug("Saving data")
 
         bulk_mode = False
         if bulk_mode:
@@ -171,7 +172,7 @@ class YsoImporter(Importer):
                     new_keyword = Keyword.objects.get(id=new_id)
                 except ObjectDoesNotExist:
                     continue
-                print('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
+                logging.info('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
                 new_keyword.events.add(*old_keyword.events.all())
                 new_keyword.audience_events.add(*old_keyword.audience_events.all())
 
@@ -222,7 +223,7 @@ class YsoImporter(Importer):
         for _, literal in graph.preferredLabel(subject):
             with active_language(literal.language):
                 if keyword.name != str(literal):
-                    print('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
+                    logging.info('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
                     keyword.name = str(literal)
                     keyword._changed = True
                     keyword.last_modified_time = BaseModel.now()
@@ -238,7 +239,7 @@ class YsoImporter(Importer):
     def save_alt_label(self, syncher, graph, label):
         label_text = str(label)
         if label.language is None:
-            print('Error:', str(label), 'has no language')
+            logging.error('Error:', str(label), 'has no language')
             return None
         label_object = syncher.get((label_text, str(label.language)))
         if label_object is None:

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -14,6 +14,9 @@ from .util import active_language
 from .sync import ModelSyncher
 from .base import Importer, register_importer
 
+# Per module logger
+logger = logging.getLogger(__name__)
+
 yso = rdflib.Namespace('http://www.yso.fi/onto/yso/')
 URL = 'http://finto.fi/rest/v1/yso/data'
 
@@ -74,11 +77,11 @@ def deprecate_and_replace(graph, keyword):
         except Keyword.DoesNotExist:
             pass
     if new_keyword:
-        logging.info('Keyword %s replaced by %s' % (keyword, new_keyword))
+        logger.info('Keyword %s replaced by %s' % (keyword, new_keyword))
         new_keyword.events.add(*keyword.events.all())
         new_keyword.audience_events.add(*keyword.audience_events.all())
     else:
-        logging.info('Keyword %s deprecated without replacement!' % keyword)
+        logger.info('Keyword %s deprecated without replacement!' % keyword)
         if keyword.events.all().exists() or keyword.audience_events.all().exists():
             raise Exception("Deprecating YSO keyword %s that is referenced in events %s. "
                             "No replacement keyword was found in YSO. Please manually map the "
@@ -105,25 +108,23 @@ class YsoImporter(Importer):
         self.organization, _ = Organization.objects.get_or_create(defaults=defaults, **org_args)
 
     def import_keywords(self):
-        logging.info("Importing YSO keywords")
+        logger.info("Importing YSO keywords")
         graph = self.load_graph_into_memory(URL)
         self.save_keywords(graph)
 
     def load_graph_into_memory(self, url):
-        if self.verbosity >= 2:
-            logging.debug("Fetching %s" % url)
+        logger.debug("Fetching %s" % url)
         resp = requests.get(url)
         assert resp.status_code == 200
         resp.encoding = 'UTF-8'
         graph = rdflib.Graph()
-        if self.verbosity >= 2:
-            logging.debug("Parsing RDF")
+        logger.debug("Parsing RDF")
         graph.parse(data=resp.text, format='turtle')
         return graph
 
     def save_keywords(self, graph):
         if self.verbosity >= 2:
-            logging.debug("Saving data")
+            logger.debug("Saving data")
 
         bulk_mode = False
         if bulk_mode:
@@ -172,7 +173,7 @@ class YsoImporter(Importer):
                     new_keyword = Keyword.objects.get(id=new_id)
                 except ObjectDoesNotExist:
                     continue
-                logging.info('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
+                logger.info('Manually mapping events with %s to %s' % (str(old_keyword), str(new_keyword)))
                 new_keyword.events.add(*old_keyword.events.all())
                 new_keyword.audience_events.add(*old_keyword.audience_events.all())
 
@@ -223,7 +224,7 @@ class YsoImporter(Importer):
         for _, literal in graph.preferredLabel(subject):
             with active_language(literal.language):
                 if keyword.name != str(literal):
-                    logging.info('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
+                    logger.info('(re)naming keyword ' + keyword.name + ' to ' + str(literal))
                     keyword.name = str(literal)
                     keyword._changed = True
                     keyword.last_modified_time = BaseModel.now()
@@ -239,7 +240,7 @@ class YsoImporter(Importer):
     def save_alt_label(self, syncher, graph, label):
         label_text = str(label)
         if label.language is None:
-            logging.error('Error:', str(label), 'has no language')
+            logger.error('Error: {} has no language'.format(label))
             return None
         label_object = syncher.get((label_text, str(label.language)))
         if label_object is None:

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -123,8 +123,7 @@ class YsoImporter(Importer):
         return graph
 
     def save_keywords(self, graph):
-        if self.verbosity >= 2:
-            logger.debug("Saving data")
+        logger.debug("Saving data")
 
         bulk_mode = False
         if bulk_mode:

--- a/events/management/commands/event_import.py
+++ b/events/management/commands/event_import.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
             method = getattr(importer, name, None)
             if options[imp_type]:
                 if not method:
-                    raise CommandError("Importer %s does not support importing %s" % (name, imp_type))
+                    raise CommandError("Importer {} does not support importing {}".format(importer.name, imp_type))
                 if imp_type == 'courses' and 'extension_course' not in settings.INSTALLED_APPS:
                     raise CommandError("Course extension must be installed when importing courses.")
             else:

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -29,7 +29,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'timestamped': {
-            'format': '%(asctime)s: %(message)s',
+            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
         },
     },
     'handlers': {

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -1,19 +1,12 @@
 """
 Django base settings for linkedevents project.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/1.6/topics/settings/
-
-For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+import logging
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 DEBUG = False
 
@@ -23,20 +16,22 @@ ALLOWED_HOSTS = []
 
 SITE_ID = 1
 
-# log to stderr, at level INFO and add timestamps
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'timestamped': {
-            'format': '%(asctime)s %(levelname)s %(module)s: %(message)s',
+        'timestamped_named': {
+            'format': '%(asctime)s %(name)s %(levelname)s: %(message)s',
         },
     },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'formatter': 'timestamped',
-            'level': 'DEBUG',
+            'formatter': 'timestamped_named',
+        },
+        # Just for reference, not used
+        'blackhole' : {
+            'class': 'logging.NullHandler',
         },
     },
     'loggers': {
@@ -44,11 +39,15 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         },
+# Special configuration for elasticsearch, as INFO level prints
+# out every single call to elasticsearch
+        'elasticsearch': {
+            'level': 'WARNING',
+        },
     }
 }
 
 # Application definition
-
 INSTALLED_APPS = [
     'helusers',
     'django.contrib.sites',

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -4,7 +4,6 @@ Django base settings for linkedevents project.
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import logging
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -30,7 +29,7 @@ LOGGING = {
             'formatter': 'timestamped_named',
         },
         # Just for reference, not used
-        'blackhole' : {
+        'blackhole': {
             'class': 'logging.NullHandler',
         },
     },
@@ -39,8 +38,8 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         },
-# Special configuration for elasticsearch, as INFO level prints
-# out every single call to elasticsearch
+        # Special configuration for elasticsearch, as INFO level prints
+        # out every single call to elasticsearch
         'elasticsearch': {
             'level': 'WARNING',
         },
@@ -116,7 +115,7 @@ LANGUAGES = (
     ('sv', 'Swedish'),
     ('en', 'English'),
     ('zh-hans', 'Simplified Chinese'),
-    ('ru' ,'Russian'),
+    ('ru', 'Russian'),
     ('ar', 'Arabic'),
 )
 


### PR DESCRIPTION
All importers are changed to use logging.* functions for
logging instead of prints. Also removed the superfluous
logger created in base.py. Django has already created a
logger for us, therefore we can just use `logging`.

Default log format has been changed to include severity
and module name.

the little-used verbosity flag usage has been removed
from importers. Instead messages are tagged with log
level. If verbosity flag is desired, it can be used to
control logging level.