### PR TITLE
Switch to current Sentry Python SDK

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -3,11 +3,34 @@ Django settings module for linkedevents project.
 """
 import os
 import environ
-import raven
+import sentry_sdk
+import subprocess
+from sentry_sdk.integrations.django import DjangoIntegration
 from django.conf.global_settings import LANGUAGES as GLOBAL_LANGUAGES
 from django.core.exceptions import ImproperlyConfigured
 
-CONFIG_FILE_NAME="config_dev.toml"
+CONFIG_FILE_NAME = "config_dev.toml"
+
+
+def get_git_revision_hash():
+"""
+We need a way to retrieve git revision hash for sentry reports
+I assume that if we have a git repository available we will
+have git-the-comamand as well
+"""
+    try:
+        # We are not interested in gits complaints
+        git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.DEVNULL, encoding='utf8')
+    # ie. "git" was not found
+    # should we return a more generic meta hash here?
+    # like "undefined"?
+    except FileNotFoundError:
+        git_hash = "git_not_available"
+    except subprocess.CalledProcessError:
+    # Ditto
+        git_hash = "no_repository"
+    return git_hash.rstrip()
+
 
 root = environ.Path(__file__) - 2  # two levels back in hierarchy
 env = environ.Env(
@@ -36,9 +59,10 @@ env = environ.Env(
 BASE_DIR = root()
 
 # Django environ has a nasty habit of complanining at level
-# WARN env file not being preset. Here we pre-empt it.
+# WARN about env file not being preset. Here we pre-empt it.
 env_file_path = os.path.join(BASE_DIR, CONFIG_FILE_NAME)
 if os.path.exists(env_file_path):
+    # Logging configuration is not available at this point
     print(f'Reading config from {env_file_path}')
     environ.Env.read_env(env_file_path)
 
@@ -48,7 +72,7 @@ TEMPLATE_DEBUG = False
 ALLOWED_HOSTS = env('ALLOWED_HOSTS')
 ADMINS = env('ADMINS')
 INTERNAL_IPS = env('INTERNAL_IPS',
-                        default=(['127.0.0.1'] if DEBUG else []))
+                   default=(['127.0.0.1'] if DEBUG else []))
 DATABASES = {
     'default': env.db()
 }
@@ -109,7 +133,6 @@ INSTALLED_APPS = [
     'mptt',
     'reversion',
     'haystack',
-    'raven.contrib.django.raven_compat',
     'django_cleanup',
     'django_filters',
 
@@ -125,11 +148,12 @@ INSTALLED_APPS = [
 ]
 
 if env('SENTRY_DSN'):
-    RAVEN_CONFIG = {
-        'dsn': env('SENTRY_DSN'),
-        'environment': env('SENTRY_ENVIRONMENT'),
-        'release': raven.fetch_git_sha(BASE_DIR),
-    }
+    sentry_sdk.init(
+        dsn=env('SENTRY_DSN'),
+        environment=env('SENTRY_ENVIRONMENT'),
+        release=get_git_revision_hash(),
+        integrations=[DjangoIntegration()]
+    )
 
 MIDDLEWARE_CLASSES = [
     'corsheaders.middleware.CorsMiddleware',

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -12,12 +12,14 @@ from django.core.exceptions import ImproperlyConfigured
 CONFIG_FILE_NAME = "config_dev.toml"
 
 
-def get_git_revision_hash():
-"""
-We need a way to retrieve git revision hash for sentry reports
-I assume that if we have a git repository available we will
-have git-the-comamand as well
-"""
+def get_git_revision_hash() -> str:
+    """
+    Retrieve the git hash for the underlying git repository or die trying
+
+    We need a way to retrieve git revision hash for sentry reports
+    I assume that if we have a git repository available we will
+    have git-the-comamand as well
+    """
     try:
         # We are not interested in gits complaints
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.DEVNULL, encoding='utf8')
@@ -27,7 +29,7 @@ have git-the-comamand as well
     except FileNotFoundError:
         git_hash = "git_not_available"
     except subprocess.CalledProcessError:
-    # Ditto
+        # Ditto
         git_hash = "no_repository"
     return git_hash.rstrip()
 

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ httmock
 bleach
 django-haystack
 elasticsearch<5.0
-raven
+sentry-sdk
 django-helusers
 pytest-django
 pytest<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ astroid==2.2.5            # via pylint
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 bleach==3.1.0
-certifi==2019.3.9         # via requests
+certifi==2019.3.9         # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 defusedxml==0.5.0         # via python3-openid
@@ -73,15 +73,15 @@ python-jose==3.0.1        # via django-helusers
 python3-openid==3.1.0     # via django-allauth
 pytz==2018.9
 pyyaml==5.1
-raven==6.10.0
 rdflib==4.2.2
 requests-cache==0.4.13
 requests-oauthlib==1.2.0  # via django-allauth
 requests==2.21.0
 rsa==4.0                  # via python-jose
+sentry-sdk==0.7.14
 six==1.12.0
-swapper==1.1.0
+swapper==1.1.0            # via django-orghierarchy
 typed-ast==1.3.1          # via astroid
-urllib3==1.24.3           # via elasticsearch, requests
+urllib3==1.24.3           # via elasticsearch, requests, sentry-sdk
 webencodings==0.5.1       # via bleach
 wrapt==1.11.1             # via astroid


### PR DESCRIPTION
Old "raven" SDK does not work for some unfathomable raisin. Let's just upgrade the SDK and furgeddeaboutit.