### PR TITLE
TH-161 Kulke course name regex parsing improvements

### DIFF
--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -184,7 +184,7 @@ def parse_age_range(secondary_headline):
     if not isinstance(secondary_headline, str):
         return (None, None)
 
-    pattern = r'^\D*(\d{1,2}).(\d{1,2}).[v.|år].+$'
+    pattern = r'^\D*(\d{1,2}).(\d{1,2}).(v|år).+$'
     match = re.match(pattern, secondary_headline)
 
     if match:

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -184,7 +184,7 @@ def parse_age_range(secondary_headline):
     if not isinstance(secondary_headline, str):
         return (None, None)
 
-    pattern = r'^\D*(\d{1,2}).(\d{1,2}).(v|år).+$'
+    pattern = r'^\D*(\d{1,2}).(\d{1,2}).(v|år).*$'
     match = re.match(pattern, secondary_headline)
 
     if match:

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -199,7 +199,7 @@ def parse_course_time(secondary_headline):
     if not isinstance(secondary_headline, str):
         return (None, None)
 
-    pattern = r'^.*klo?\s(\d{1,2})\.?(\d{1,2})?.(\d{1,2})\.?(\d{1,2})?.*$'
+    pattern = r'^.*klo?\s(\d{1,2})([.:](\d{1,2}))?.(\d{1,2})([.:](\d{1,2}))?.*$'
     match = re.match(pattern, secondary_headline)
 
     if match:

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -204,9 +204,9 @@ def parse_course_time(secondary_headline):
 
     if match:
         course_time_beginning_hour = int(match.groups()[0])
-        course_time_beginning_minute = int(match.groups()[1]) if match.groups()[1] else 0
-        course_time_end_hour = int(match.groups()[2])
-        course_time_end_minute = int(match.groups()[3]) if match.groups()[3] else 0
+        course_time_beginning_minute = int(match.groups()[2]) if match.groups()[2] else 0
+        course_time_end_hour = int(match.groups()[3])
+        course_time_end_minute = int(match.groups()[5]) if match.groups()[5] else 0
         course_time_beginning = time(hour=course_time_beginning_hour, minute=course_time_beginning_minute)
         course_time_end = time(hour=course_time_end_hour, minute=course_time_end_minute)
         return (course_time_beginning, course_time_end)


### PR DESCRIPTION
About:

> This regexp does not probably do what you would like it to do.
> 
> ```
> >>> my_re = re.compile(r'^\D*(\d{1,2}).(\d{1,2}).[v.|år].+$')
> >>> my_re.match('Yes 45678-åå').groups()
> ('45', '78')
> >>> my_re.match('"Introduction 101"|by me').groups()
> ('1', '1')
> ```
> 
> The regular expression you're aiming at is probably:
> `^\D*(\d\d?)-(\d\d?)[- ](v|år).*$`

The things that are different between the regexes:

* To capture a two-digit number, like “something something 11 something something” for 11, I’m using `\d{1,2}` and you’re using` \d\d?` . I think both of them achieve the same goal and I can use both of them. I think first version is just a tad more readable because I read it as `a digit, occurring 1 or 2 times` and I read second version like `a digit. and then a digit, that is optional`. 

* To refer to the dash character, `-`, which would be in between the age range numbers, like “something 11-22 something” for (11, 22), you’re using `-` with character code 45. If you’d run the tests with only this character changed, a couple of tests fail because there’s another dash character they’re using with character code 8211.  `'5–6 v klo 15.45–17.15'`  as an example. When writing the regex, I thought it’d be quite unreadable to have two dash characters next to each other, and I intentionally wrote it like that. We can fix this by saying **either** char code 45 OR char code 8211, but I thought _what if there are other char codes for dash, then I have to keep updating the regular expression_?

* Same reasoning with `[- ]` in your suggested regex, which has dash character and space. 
* `(v|år)` is neater 👍 I updated it in 710b23dd7d4228da969176aafc9297db23317a66
* Having a `*` char at the is more reasonable 👍 done in ee5c2d78a8a556d979457e1dc5d1f06707c04ccc  

About your suggestion of adding negative test cases, while it's possible, I wonder if it'd make sense considering the objective of the parsing the course titles:

* This is a problem that should ideally be solved at the root. Their API should send us age range and course times in appropriate formats.
* Now that the situation is not ideal, we can try to write a simple logic to parse *most* cases, not all. It'd take substantially bigger amount of time to try to cover all cases that'd break the current regex by using `Yes 45678-åå`, and more time to maintain and update the regex as we go down the road.
* So I think it's best at this point to keep it simple to cover most realistic (my test cases are from the imported objects in database) cases. 

About:

> Here, I would suggest
> `^.*klo?\s(\d{1,2})([.:](\d{1,2}))?.(\d{1,2})([.:](\d{1,2}))?.*$`
> (and corresponding changes in group indices).

I think `([.:](\d{1,2}))?` reads much better than `\.?(\d{1,2})?` (done in b1e95d0f5aaf8a7f167ad181e8061fe7efb98333 ).

* `([.:](\d{1,2}))?` => an optional group of a dot or colon, followed by a two digit number.
*  `\.?(\d{1,2})?` => an optional dot, followed by an optional two digit number group. This also lacks if the people would write the time with colon (`17:30` for example), which your suggested regex supports 👍 

Wonderful suggestion, done in 2e638683cad1a1752a9fd8f23f15a457fac08467.