### PR TITLE
add gettext to Django's Dockerfile

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -20,7 +20,7 @@ ENTRYPOINT ["/tini", "--", "/app/docker/django/docker-entrypoint.sh"]
 
 COPY --chown=appuser:appuser requirements.txt /app/
 
-RUN apt-install.sh build-essential gdal-bin \
+RUN apt-install.sh build-essential gdal-bin gettext \
     && pip install --no-cache-dir -r /app/requirements.txt \
     && apt-cleanup.sh build-essential
 


### PR DESCRIPTION
This fixes the error thrown saying:

CommandError: Can't find msguniq. Make sure you have GNU gettext tools 0.15 or newer installed