### PR TITLE
Filter events also based on place fields

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -64,7 +64,7 @@ from events.models import (
     Place, Event, Keyword, KeywordSet, Language, OpeningHoursSpecification, EventLink,
     Offer, DataSource, Image, PublicationStatus, PUBLICATION_STATUSES, License, Video
 )
-from events.translation import EventTranslationOptions
+from events.translation import EventTranslationOptions, PlaceTranslationOptions
 from helevents.models import User
 from events.renderers import DOCXRenderer
 
@@ -1582,12 +1582,21 @@ def _filter_event_queryset(queryset, params, srs=None):
     val = params.get('text', None)
     if val:
         val = val.lower()
-        # Free string search from all translated fields
-        fields = EventTranslationOptions.fields
         qset = Q()
-        for field in fields:
+
+        # Free string search from all translated event fields
+        event_fields = EventTranslationOptions.fields
+        for field in event_fields:
             # check all languages for each field
             qset |= _text_qset_by_translated_field(field, val)
+
+        # Free string search from all translated place fields
+        place_fields = PlaceTranslationOptions.fields
+        for field in place_fields:
+            location_field = 'location__' + field
+            # check all languages for each field
+            qset |= _text_qset_by_translated_field(location_field, val)
+
         queryset = queryset.filter(qset)
 
     val = params.get('last_modified_since', None)

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -116,9 +116,14 @@ def test_get_unknown_event_detail_check_404(api_client):
 
 @pytest.mark.django_db
 def test_get_event_list_verify_text_filter(api_client, event, event2):
+    # Search with event name
     response = get_list(api_client, data={'text': 'event'})
     assert event.id not in [entry['id'] for entry in response.data['data']]
     assert event2.id in [entry['id'] for entry in response.data['data']]
+    # Search with place name
+    response = get_list(api_client, data={'text': 'paikka'})
+    assert event.id in [entry['id'] for entry in response.data['data']]
+    assert event2.id not in [entry['id'] for entry in response.data['data']]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Currently, the event API text search filters events only based on Event fields. Thus, searching with a place name doesn't bring any results unless the place name is included, e.g., in the location_extra_info
field of an event.

To be able to search with place names, this change supplements the text search filters with the following place fields: name, description, info_url, street_address, address_locality, telephone.

As a result, the text query in the API searches for the given string both in event and place fields thus broadening the search.