### PR TITLE
Update EMAIL_BACKEND in local dev env

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.core.mail import send_mail
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -22,7 +23,7 @@ def organization_post_save(sender, instance, created, **kwargs):
 
 
 def user_post_save(sender, instance, created, **kwargs):
-    if created:
+    if created and settings.DEBUG is False:
         User = get_user_model()
         recipient_list = [item[0] for item in User.objects.filter(is_superuser=True).values_list('email')]
         notification_type = NotificationType.USER_CREATED

--- a/events/signals.py
+++ b/events/signals.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.core.mail import send_mail
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -23,7 +22,7 @@ def organization_post_save(sender, instance, created, **kwargs):
 
 
 def user_post_save(sender, instance, created, **kwargs):
-    if created and settings.DEBUG is False:
+    if created:
         User = get_user_model()
         recipient_list = [item[0] for item in User.objects.filter(is_superuser=True).values_list('email')]
         notification_type = NotificationType.USER_CREATED

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -469,3 +469,5 @@ if env('MAIL_MAILGUN_KEY'):
         'MAILGUN_API_URL': env('MAIL_MAILGUN_API'),
     }
     EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+elif not env('MAIL_MAILGUN_KEY') and DEBUG is True:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
When using Docker in local dev env, an admin user is created so that we can immediately login to django admin views after the server is run.

At the moment, `docker-compose up` crashes on the first run because it tries to send an email when the admin user is created. This PR fixes this, by checking if DEBUG is False to send the email after a user is created.