### PR TITLE
Fix docker-compose volume path for postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         ports:
             - "127.0.0.1:5555:5432"
         volumes:
-            - postgres-data-volume:/var/lib/postgres/data
+            - postgres-data-volume:/var/lib/postgresql/data
 
     django:
         build:


### PR DESCRIPTION
/var/lib/postgresql/data is the correct path for docker volume to mange based on [postgres on docker hub](https://hub.docker.com/_/postgres/) at "Where to Store Data"