### PR TITLE
Add pytest watch

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=linkedevents.test_settings
-
+addopts = --verbose --verbose
 
 [pytest-watch]
 nobeep = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=linkedevents.test_settings
-addopts = --verbose --verbose
+addopts = --verbose --verbose --reuse-db
 
 [pytest-watch]
 nobeep = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=linkedevents.test_settings
+
+
+[pytest-watch]
+nobeep = True
+clear = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=linkedevents.test_settings
-addopts = --verbose --verbose --reuse-db
+addopts = --verbose --verbose --reuse-db --capture=no
 
 [pytest-watch]
 nobeep = True

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pyflakes
 pylint
 pytest-django
 pytest
+pytest-watch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,28 +7,30 @@
 astroid==2.3.3            # via pylint
 attrs==19.3.0             # via pytest
 click==7.0                # via pip-tools
-django-extensions==2.2.6
+colorama==0.4.3           # via pytest-watch
+django-extensions==2.2.6  # via -r requirements-dev.in
+docopt==0.6.2             # via pytest-watch
 entrypoints==0.3          # via flake8
-flake8==3.7.9
-freezegun==0.3.15
-importlib-metadata==1.5.0  # via pluggy, pytest
+flake8==3.7.9             # via -r requirements-dev.in
+freezegun==0.3.15         # via -r requirements-dev.in
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 more-itertools==8.2.0     # via pytest
 packaging==20.1           # via pytest
-pip-tools==4.4.1
+pathtools==0.1.2          # via watchdog
+pip-tools==4.4.1          # via -r requirements-dev.in
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
-pyflakes==2.1.1
-pylint==2.4.4
-pyparsing==2.4.6          # via packaging
-pytest-django==3.8.0
-pytest==5.3.5
-python-dateutil==2.8.1    # via freezegun
-six==1.14.0               # via astroid, django-extensions, freezegun, packaging, pip-tools, python-dateutil
-typed-ast==1.4.1          # via astroid
+pyflakes==2.1.1           # via -r requirements-dev.in, flake8
+pylint==2.4.4             # via -r requirements-dev.in
+pyparsing==2.4.6          # via -c requirements.txt, packaging
+pytest-django==3.8.0      # via -r requirements-dev.in
+pytest-watch==4.2.0       # via -r requirements-dev.in
+pytest==5.3.5             # via -r requirements-dev.in, pytest-django, pytest-watch
+python-dateutil==2.8.1    # via -c requirements.txt, freezegun
+six==1.14.0               # via -c requirements.txt, astroid, django-extensions, freezegun, packaging, pip-tools, python-dateutil
+watchdog==0.10.2          # via pytest-watch
 wcwidth==0.1.8            # via pytest
 wrapt==1.11.2             # via astroid
-zipp==2.1.0               # via importlib-metadata


### PR DESCRIPTION
At the moment, running the tests locally even for a single module creates a database and applies the migrations before proceeding to the test itself. This, on my machine, takes 20 seconds each time, which makes local testing rather slow. 5231b43 fixes that.

On top of that, while writing the tests, it saves time for the tests to keep (re-)running after making changes to code, so one wouldn't have to run the test command again and again. `pytest-watch` fixes that too.  