### PR TITLE
create_initial_licenses improvement

### DIFF
--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -617,7 +617,7 @@ def all_api_get_list(request, event, api_client):
 # These initial licenses are created by a migration, but because of a feature
 # related to Django testing, objects created in datamigrations aren't available
 # in all testcases, so we need to create those here too to be sure they exist.
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def create_initial_licenses():
     License.objects.get_or_create(
         id='event_only',

--- a/events/tests/importers/test_kulke.py
+++ b/events/tests/importers/test_kulke.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from events.importer.kulke import KulkeImporter, parse_age_range, parse_course_time
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize("test_input,expected", [
     ('Pölyt pois taidehistoriasta! Rooman ylväät pylväät', (None, None)),
     ('(3 kk–4 v) klo 9.30–10.15 kevään mittainen lyhytkurssi', (None, None)),
@@ -23,7 +22,6 @@ def test_parse_age_range_returns_correct_result(test_input, expected):
     assert parse_age_range(test_input) == expected
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize("test_input,expected", [
     ('Pölyt pois taidehistoriasta! Rooman ylväät pylväät', (None, None)),
     ('Työpaja ja esitys 9-12-vuotiaille', (None, None)),

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -13,6 +13,11 @@ from ..auth import ApiKeyAuth
 from ..models import DataSource, Image
 
 
+@pytest.fixture(scope='function', autouse=True)
+def run_for_every_test_function(create_initial_licenses):
+    pass
+
+
 @pytest.mark.django_db
 def test_api_page_size(api_client, event):
     event_count = 200

--- a/events/tests/test_event_images_v1.py
+++ b/events/tests/test_event_images_v1.py
@@ -22,6 +22,11 @@ from events.auth import ApiKeyUser
 temp_dir = tempfile.mkdtemp()
 
 
+@pytest.fixture(scope='function', autouse=True)
+def run_for_every_test_function(create_initial_licenses):
+    pass
+
+
 @pytest.yield_fixture(autouse=True)
 def tear_down():
     yield

--- a/events/tests/test_models.py
+++ b/events/tests/test_models.py
@@ -1,8 +1,14 @@
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django_orghierarchy.models import Organization
 
 from ..models import DataSource, Event, Image, PublicationStatus
+
+
+@pytest.fixture(scope='function', autouse=True)
+def run_for_every_test_function(create_initial_licenses):
+    pass
 
 
 class TestImage(TestCase):


### PR DESCRIPTION
At the moment, if you create a test module like below and run it:

```python
# events/tests/hello_world.py

def test_simple_proof():
    assert True
```

pytest would complain that `test_simple_proof` needs database access! and that you should mark it with `@pytest.mark.django_db`:

```
RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```

This is because we're using *autouse* on `create_initial_licenses` fixture which has `function` scope (default scope of pytest fixtures), and therefore every test function that has access to `events/test/conftest.py` would execute  `create_initial_licenses`. Therefore, `test_simple_proof` need to execute `create_initial_licenses` and because `create_initial_licenses` needs database access, so does `test_simple_proof`.

I fixed this issue by first removing *autouse* on `create_initial_licenses` (e3647ed87d750166f7af826977174434655b7e1e), then adding it to test modules that actually need it (181c9f5c569b039463a57d929c6bdd9432a171fe) and removed the `django_db` marker from the tests I had written previously that actually didn't need it (c759cb35e2318980a54d394a1f3f468f00d907f9) but I had no other choice because I wanted to keep my PR focused on Kulke importer at the time and had this PR in my mind for a long time 😄 