### PR TITLE
TH-609 start/end time filter

### DIFF
--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -21,6 +21,19 @@ Any events that intersect with the given date range will be returned.</p>
 <pre><code>event/?start=now&amp;end=today
 </code></pre>
 <p><a href="?start=now&amp;end=today" title="json">See the result</a></p>
+<h3 id="event-hours">Event start/end time</h3>
+<p>Use <code>starts_after</code>, <code>starts_before</code>, <code>ends_after</code>, and <code>ends_before</code> 
+to filter for the events that start and end within certain hours, for example for the ones that start after 17:00 and 
+end before 21:00.
+<p>The parameters can be given as:</p>
+<ul>
+<li>Hours only</li>
+<li>Hours and minutes separated by a colon</li>
+</ul>
+<p>Example:</p>
+<pre><code>event/?starts_after=16:30&amp;ends_before=21
+</code></pre>
+<p><a href="?starts_after=16:30&amp;ends_before=21" title="json">See the result</a></p>
 <h3 id="event-location">Event location</h3>
 <h4 id="bounding-box">Bounding box</h4>
 <p>To restrict the retrieved events to a geographical region, use

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ pyflakes
 pylint
 pytest-django
 pytest
+Werkzeug

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,4 +31,5 @@ six==1.14.0               # via astroid, django-extensions, freezegun, packaging
 typed-ast==1.4.1          # via astroid
 wcwidth==0.1.8            # via pytest
 wrapt==1.11.2             # via astroid
+Werkzeug==0.16.1
 zipp==2.1.0               # via importlib-metadata


### PR DESCRIPTION
This PR adds start and end time filtering for the events, so that it becomes possible to filter for the events that, for example, start before 16 or end after 17:30

The added parameters are `starts_after`, `starts_before`,`ends_after`, and `ends_before`.

Sample usage:
https://api.hel.fi/linkedevents/v1/event/?starts_after=16:40
