### PR TITLE
make search terms ANDable

### DIFF
--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -975,3 +975,7 @@ def test_keyword_and_text(api_client, event, event2, keyword):
     event2.save()
     response = get_list(api_client, query_string='combined_text=lapset')
     assert_events_in_response([event, event2], response)
+    event.description_fi = 'lapset ja aikuiset'
+    event.save()
+    response = get_list(api_client, query_string='combined_text=lapset,aikuiset')
+    assert_events_in_response([event], response)


### PR DESCRIPTION
-comma separated search terms in `event/?combined_text` are now ANDed. i.e. `event/?combined_text=lapset,aikuiset` searches for the event that would contain both lapset and aikuiset in their translated fields or keywords.