### PR TITLE
Split local_ongoing into AND and OR, fix urls.py

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1808,7 +1808,15 @@ def _filter_event_queryset(queryset, params, srs=None):
         queryset = queryset.filter(*qsets)
 
     #  This filtering param requires populate_local_event_cache management command
-    val = params.get('combined_local_ongoing', None)
+    val = params.get('local_ongoing_AND', None)
+    if val:
+        cache = caches['ongoing_local']
+        val = val.lower()
+        vals = val.split(',')
+        ids = {k for k, v in cache.get('ids').items() if all(val in v for val in vals)}
+        queryset = queryset.filter(id__in=ids)
+
+    val = params.get('local_ongoing_OR', None)
     if val:
         cache = caches['ongoing_local']
         val = val.lower()

--- a/events/management/commands/populate_local_event_cache.py
+++ b/events/management/commands/populate_local_event_cache.py
@@ -9,7 +9,9 @@ from linkedevents.settings import MUNIGEO_MUNI
 
 
 class Command(BaseCommand):
-    help = "Update local ongoing and upcoming events cache."
+    help = "Update local ongoing and upcoming events cache. Note that cache has to be set up and\
+           its memory limits will probably need adjustment. In case memcached is used, check -m and\
+           -I parameters."
 
     def handle(self, *args, **options):
         cache = caches['ongoing_local']

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -125,13 +125,13 @@ fields, use the query parameter <code>text</code>.</p>
 <pre><code>event/?text=shostakovich
 </code></pre>
 <p><a href="?text=shostakovich" title="json">See the result</a></p>
-<h3 id="combined-local-ongoing">Combined search for local events</h3>
-<p>Use to quickly access local events that are upcoming or have not ended yet. Combines the search on a number of 
-description, name, and keyword fields</p>
+<h3 id="local-ongoing">Local ongoing events</h3>
+<p>Use to quickly access local (municipality level) events that are upcoming or have not ended yet. Combines the search on a number of 
+description, name, and keyword fields. Locality is defined on the basis of MUNIGEO_MUNI value, which is set in the settings file. In the Helsinki case all the events would be retrieved that happen within Helsinki. Comes in two flavors: AND and OR. Use <code>event/?local_ongoing_AND=lapset,musiiki</code> to search for the events with both search terms in the description fields and <code>?local_ongoing_OR</code> to search for the events with at least one term mentioned.</p>
 <p>Example:</p>
-<pre><code>event/?combined_local_ongoing=rock
+<pre><code>event/?local_ongoing_AND=lapset,musiikki
 </code></pre>
-<p><a href="?combined_local_ongoing=rock" title="json">See the result</a></p>
+<p><a href="?local_ongoing_AND=lapset,musiikki" title="json">See the result</a></p>
 <h3 id="event-price">Event price</h3>
 <p>Events may or may not contain the <code>offers</code> field that lists event pricing. To return only
 free or non-free events, use the query parameter<code>is_free</code>. However, note that from some

--- a/linkedevents/urls.py
+++ b/linkedevents/urls.py
@@ -1,4 +1,3 @@
-import debug_toolbar
 import environ
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -26,4 +25,5 @@ urlpatterns = [
 ]
 
 if env('DEBUG'):
+    import debug_toolbar
     urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
This PR introduces `?local_ongoing_AND` and `?local_ongoing_OR` event filtering parameters. and fixes a misplaced import in the urls.py.