### PR TITLE
Fix automatic creation of Internet location in helmet importer

### DIFF
--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -185,8 +185,8 @@ class HelmetImporter(Importer):
         self.tprek_data_source = DataSource.objects.get(id='tprek')
         self.ahjo_data_source = DataSource.objects.get(id='ahjo')
         system_data_source_defaults = {'user_editable': True}
-        self.system_data_source = DataSource.objects.get_or_create(id=settings.SYSTEM_DATA_SOURCE_ID,
-                                                                   defaults=system_data_source_defaults)
+        self.system_data_source, _ = DataSource.objects.get_or_create(id=settings.SYSTEM_DATA_SOURCE_ID,
+                                                                      defaults=system_data_source_defaults)
 
         org_args = dict(origin_id='u4804001010', data_source=self.ahjo_data_source)
         defaults = dict(name='Helsingin kaupunginkirjasto')


### PR DESCRIPTION
**Fixed**

- Currently, the `helmet` importer checks if an "Internet" location exists and creates one if it doesn't exist. This, however, currently fails since the `self.system_data_source` variable passed as an argument to the Place creation query contains a tuple and not a `DataSource` object:

  ```
  During handling of the above exception, another exception occurred:                                                                                                                                                                                                                       
                                                            
  Traceback (most recent call last):
    File "manage.py", line 9, in <module>                                    
      execute_from_command_line(sys.argv)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
      utility.execute()
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
      self.fetch_command(subcommand).run_from_argv(self.argv)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
      self.execute(*args, **cmd_options)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute                                                                                                                                                                       
      output = self.handle(*args, **options)
    File "/home/linkedevents/events/management/commands/event_import.py", line 51, in handle
      'force': options['force']})
    File "/home/linkedevents/events/importer/base.py", line 63, in __init__
      self.setup()                                                                                                                                                                                                                                                                          
    File "/home/linkedevents/events/importer/helmet.py", line 278, in setup
      self.internet_location, _ = Place.objects.get_or_create(id=INTERNET_LOCATION_ID, defaults=defaults)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/manager.py", line 82, in manager_method
      return getattr(self.get_queryset(), name)(*args, **kwargs)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/modeltranslation/manager.py", line 370, in get_or_create
      return super(MultilingualQuerySet, self).get_or_create(**kwargs)          
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/query.py", line 541, in get_or_create
      return self._create_object_from_params(kwargs, params)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/query.py", line 575, in _create_object_from_params
      obj = self.create(**params)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/modeltranslation/manager.py", line 362, in create
      return super(MultilingualQuerySet, self).create(**kwargs)              
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/query.py", line 420, in create
      obj = self.model(**kwargs)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/modeltranslation/translator.py", line 264, in new_init
      old_init(self, *args, **kwargs)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/mptt/models.py", line 410, in __init__
      super(MPTTModel, self).__init__(*args, **kwargs)                       
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/base.py", line 483, in __init__
      _setattr(self, field.name, rel_obj)
    File "/home/linkedevents/.local/lib/python3.7/site-packages/django/db/models/fields/related_descriptors.py", line 211, in __set__
      self.field.remote_field.model._meta.object_name,
  ValueError: Cannot assign "(<DataSource: espooevents>, True)": "Place.data_source" must be a "DataSource" instance.
  ```

  This change fixes the bug by correctly assigning the `DataSource` object to the `self.system_data_source` variable so that the "Internet" location can be successfully created if it doesn't already exist.