### PR TITLE
LINK-490 Set "General" as default type for event list

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1951,7 +1951,7 @@ def _filter_event_queryset(queryset, params, srs=None):
 
         queryset = queryset.filter(type_id__in=search_vals)
     else:
-        queryset = queryset.filter(type_id=1)
+        queryset = queryset.filter(type_id=Event.Type_Id.GENERAL)
 
     val = params.get('last_modified_since', None)
     # This should be in format which dateutil.parser recognizes, e.g.

--- a/events/api.py
+++ b/events/api.py
@@ -1950,6 +1950,8 @@ def _filter_event_queryset(queryset, params, srs=None):
             search_vals.append(event_types[v])
 
         queryset = queryset.filter(type_id__in=search_vals)
+    else:
+        queryset = queryset.filter(type_id=1)
 
     val = params.get('last_modified_since', None)
     # This should be in format which dateutil.parser recognizes, e.g.

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -182,6 +182,7 @@ def offer(event2):
 def make_minimal_event_dict(make_keyword_id):
     def _make_minimal_event_dict(data_source, organization, location_id):
         return {
+            'type_id': 'General',
             'name': {'fi': TEXT_FI},
             'start_time': datetime.strftime(timezone.now() + timedelta(days=1), '%Y-%m-%d'),
             'location': {'@id': location_id},


### PR DESCRIPTION
When event_type query parameter is not specified only events of type "General" are returned.