### PR TITLE
LINK-485. Fix failing PUT requests

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -928,7 +928,7 @@ class Feedback(models.Model):
     name = models.CharField(verbose_name=_('Name'), max_length=255, blank=True)
     email = models.EmailField(verbose_name=_('E-mail'))
     subject = models.CharField(verbose_name=_('Subject'), max_length=255, blank=True)
-    body = models.TextField(verbose_name=_('Body'), blank=True)
+    body = models.TextField(verbose_name=_('Body'), max_length=10000, blank=True)
 
     def save(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Querying *.objects.all() for related fields results in huge requests whenever an Event is updated. Internal DRF mechanics for related fields as specified in relations.py uses get() for every updated related field and presumes an existing queryset. The goal of this bug fix is to provide querysets for the related fields that would contain only the related objects mentioned in the request