### PR TITLE
LINK-533 Fix bulk event update for non general event type

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -336,7 +336,7 @@ class EnumChoiceField(serializers.Field):
         value = utils.get_value_from_tuple_list(self.choices,
                                                 self.prefix + str(data), 0)
         if value is None:
-            raise ParseError(_("Invalid value in event_status"))
+            raise ParseError(_(f'Invalid value "{data}"'))
         return value
 
 
@@ -2458,8 +2458,9 @@ class EventViewSet(JSONAPIViewMixin, BulkModelViewSet, viewsets.ReadOnlyModelVie
             # prevent changing events user does not have write permissions (for bulk operations)
             queryset = self.request.user.get_editable_events(original_queryset)
 
-        queryset = _filter_event_queryset(queryset, self.request.query_params,
-                                          srs=self.srs)
+        if self.request.method == 'GET':
+            queryset = _filter_event_queryset(queryset, self.request.query_params, srs=self.srs)
+
         return queryset.filter()
 
     def allow_bulk_destroy(self, qs, filtered):

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -594,6 +594,7 @@ def make_complex_event_dict(make_keyword_id):
             'data_source': data_source.id,
             'name': {'en': TEXT_EN, 'sv': TEXT_SV, 'fi': TEXT_FI},
             'event_status': 'EventScheduled',
+            'type_id': 'General',
             'location': {'@id': location_id},
             'keywords': [
                 {'@id': make_keyword_id(data_source, organization, 'simple')},


### PR DESCRIPTION
During update the events are passed through `EventViewset.filter_queryset()` for authorization check up, this method invokes  `_filter_queryset`. The latter is used to filter events by params in GET request and should not be used for other request methods.