### PR TITLE
Improve docker postgis initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The best way to contribute is to open a new PR for discussion. We strive to be a
 ## How to setup your local development environment
 If all you want is a barebone application to work with for your own city:
 
-* Change ./docker/django/.env.example to ./docker/django/.env and change the variable values to your liking.
+* Copy ./docker/django/.env.example to ./docker/django/.env and change the variable values to your liking.
 * Start django application and database server:
   ```
   docker-compose up
@@ -154,6 +154,7 @@ ALTER USER "$DATABASE_USER" CREATEDB;
 \c template1
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 EOF
 
 ```

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -4,5 +4,5 @@ ARG IMAGE_VARIANT=alpine
 
 FROM helsinkitest/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION}-${IMAGE_VARIANT}
 
-# over-writing the parent /docker-entrypoint-initdb.d/postgis.sh
-COPY ./docker/postgres/docker-entrypoint.sh /docker-entrypoint-initdb.d/postgis.sh
+# over-writing the parent /docker-entrypoint-initdb.d/10_postgis.sh
+COPY ./docker/postgres/docker-entrypoint.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/docker/postgres/docker-entrypoint.sh
+++ b/docker/postgres/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 #################################################
 # This file is taken directly from:
 # https://github.com/City-of-Helsinki/docker-images/blob/master/templates/postgis/9.6-2.5/initdb-postgis.sh
-# Only "hstore" extension has been added
+# Only "hstore" and "pg_trgm" extensions have been added.
 #################################################
 
 set -e
@@ -13,17 +13,20 @@ export PGUSER="$POSTGRES_USER"
 
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
-CREATE DATABASE template_postgis;
-UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
+CREATE DATABASE template_postgis IS_TEMPLATE true;
 EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
-for DB in template_postgis "$POSTGRES_DB"; do
+for DB in template1 template_postgis "$POSTGRES_DB"; do
 	echo "Loading PostGIS extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS hstore;
+		CREATE EXTENSION IF NOT EXISTS pg_trgm;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
+		-- Reconnect to update pg_setting.resetval
+		-- See https://github.com/postgis/docker-postgis/issues/288
+		\c
 		CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 EOSQL

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -98,6 +98,7 @@ DATABASES = {
 }
 
 DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 SYSTEM_DATA_SOURCE_ID = env('SYSTEM_DATA_SOURCE_ID')
 


### PR DESCRIPTION
This PR makes some changes to dev env setup.
- [Fix issue where base image initialization script has been renamed](https://github.com/City-of-Helsinki/docker-images/pull/18).
- Add `hstore` and `pg_trgm` extensions to docker postgres default DB template (`template1`). **Note** Initialization script is only run for a fresh DB container, so existing DBs need to run this manually or recreate the DB container and data.
- Add note about Postgres pg_trgm extension to README.md

For silencing a warning
- Add [`DEFAULT_AUTO_FIELD`](https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DEFAULT_AUTO_FIELD) setting with the current default value.