### PR TITLE
Fix elasticsearch dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ Linkedevents uses Elasticsearch for generating results on the /search-endpoint. 
 
 1. Install elasticsearch
 
-    We've only tested using the rather ancient 1.7 version. Version 5.x will certainly not work as the `django-haystack`-library does not support it. If you are using Ubuntu 16.04, 1.7 will be available in the official repository.
+    We've only tested using the rather ancient 1.7 version. If you are using Ubuntu 16.04, 1.7 will be available in the official repository.
+    This limitation was originally due to django-haystack not supporting versions above 1. 
+    As of writing this the django-haystack version in use does support versions 1, 2, 5 and 7.
 
 2. (For Finnish support) Install elasticsearch-analyzer-voikko, libvoikko and needed dictionaries
 

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ djangorestframework-bulk
 djangorestframework-gis
 djangorestframework-jwt
 easy_thumbnails
-elasticsearch
+elasticsearch~=7.17
 httmock
 icalendar
 isodate

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ cattrs==22.1.0
     # via requests-cache
 certifi==2022.6.15
     # via
-    #   elastic-transport
+    #   elasticsearch
     #   requests
     #   sentry-sdk
 cffi==1.15.1
@@ -122,9 +122,7 @@ easy-thumbnails==2.8.3
     # via -r requirements.in
 ecdsa==0.18.0
     # via python-jose
-elastic-transport==8.1.2
-    # via elasticsearch
-elasticsearch==8.3.3
+elasticsearch==7.17.8
     # via -r requirements.in
 exceptiongroup==1.0.0rc8
     # via cattrs
@@ -248,7 +246,7 @@ url-normalize==1.4.3
     # via requests-cache
 urllib3==1.26.11
     # via
-    #   elastic-transport
+    #   elasticsearch
     #   requests
     #   requests-cache
     #   sentry-sdk


### PR DESCRIPTION
django-haystack==3.2.1 supports ES 1, 2, 5 ja 7 versions. Currently the unconstrainted elasticsearch dependency picks v8 package.

Without restricting to v7, `python manage.py event_import tprek --places` breaks with `TypeError: bulk() got an unexpected keyword argument 'doc_type'`