### PR TITLE
LINK-1123 | Handle flake8 errors

### DIFF
--- a/events/custom_elasticsearch_search_backend.py
+++ b/events/custom_elasticsearch_search_backend.py
@@ -15,9 +15,7 @@ class CustomEsSearchBackend(es_backend.ElasticsearchSearchBackend):
     """
 
     def __init__(self, connection_alias, **connection_options):
-        super(CustomEsSearchBackend, self).__init__(
-            connection_alias, **connection_options
-        )
+        super().__init__(connection_alias, **connection_options)
         self.custom_mappings = connection_options.get("MAPPINGS")
         settings = connection_options.get("SETTINGS")
         if settings:
@@ -25,9 +23,7 @@ class CustomEsSearchBackend(es_backend.ElasticsearchSearchBackend):
             update(default_settings, settings)
 
     def build_schema(self, fields):
-        content_field_name, mappings = super(CustomEsSearchBackend, self).build_schema(
-            fields
-        )
+        content_field_name, mappings = super().build_schema(fields)
         if not self.custom_mappings:
             return (content_field_name, mappings)
 
@@ -41,9 +37,7 @@ class CustomEsSearchBackend(es_backend.ElasticsearchSearchBackend):
         return (content_field_name, mappings)
 
     def build_search_kwargs(self, query_string, decay_functions=None, **kwargs):
-        kwargs = super(CustomEsSearchBackend, self).build_search_kwargs(
-            query_string, **kwargs
-        )
+        kwargs = super().build_search_kwargs(query_string, **kwargs)
         if not decay_functions:
             return kwargs
 
@@ -61,11 +55,11 @@ class CustomEsSearchBackend(es_backend.ElasticsearchSearchBackend):
 
 class CustomEsSearchQuery(es_backend.ElasticsearchSearchQuery):
     def __init__(self, **kwargs):
-        super(CustomEsSearchQuery, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.decay_functions = []
 
     def build_params(self, *args, **kwargs):
-        search_kwargs = super(CustomEsSearchQuery, self).build_params(*args, **kwargs)
+        search_kwargs = super().build_params(*args, **kwargs)
         if self.decay_functions:
             search_kwargs["decay_functions"] = self.decay_functions
         return search_kwargs
@@ -74,7 +68,7 @@ class CustomEsSearchQuery(es_backend.ElasticsearchSearchQuery):
         self.decay_functions.append(function_dict)
 
     def _clone(self, **kwargs):
-        clone = super(CustomEsSearchQuery, self)._clone(**kwargs)
+        clone = super()._clone(**kwargs)
         clone.decay_functions = self.decay_functions[:]
         return clone
 

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -40,11 +40,11 @@ def recur_dict():
 
 class Importer(object):
     def __init__(self, options):
-        super(Importer, self).__init__()
+        super().__init__()
         self.options = options
 
         importer_langs = set(self.supported_languages)
-        configured_langs = set(l[0] for l in settings.LANGUAGES)
+        configured_langs = set(lang[0] for lang in settings.LANGUAGES)
         # Intersection is all the languages possible for the importer to use.
         self.languages = {}
         for lang_code in importer_langs & configured_langs:
@@ -55,7 +55,7 @@ class Importer(object):
         self.target_srid = settings.PROJECTION_SRID
         gps_srs = SpatialReference(4326)
         target_srs = SpatialReference(self.target_srid)
-        if getattr(settings, "BOUNDING_BOX"):
+        if settings.BOUNDING_BOX:
             self.bounding_box = Polygon.from_bbox(settings.BOUNDING_BOX)
             self.bounding_box.srid = self.target_srid
             target_to_gps_ct = CoordTransform(target_srs, gps_srs)
@@ -189,7 +189,7 @@ class Importer(object):
 
         return image
 
-    def link_recurring_events(self, events, instance_fields=[]):
+    def link_recurring_events(self, events):
         """Finds events that are instances of a common parent
         event by comparing the fields that do not differ between
         instances, for example different nights of the same play.
@@ -205,7 +205,7 @@ class Importer(object):
 
         events.sort(key=event_name)
         parent_events = []
-        for name_fi, subevents in itertools.groupby(events, event_name):
+        for _name_fi, subevents in itertools.groupby(events, event_name):
             subevents = list(subevents)
             if len(subevents) < 2:
                 parent_events.extend(subevents)
@@ -306,7 +306,7 @@ class Importer(object):
                 continue
             self._set_field(obj, field_name, info[field_name])
 
-    def save_event(self, info):
+    def save_event(self, info):  # noqa: C901
         info = info.copy()
 
         args = dict(data_source=info["data_source"], origin_id=info["origin_id"])

--- a/events/importer/espoo.py
+++ b/events/importer/espoo.py
@@ -197,12 +197,12 @@ def mark_deleted(obj):
 
 
 def clean_street_address(address):
-    LATIN1_CHARSET = "a-zàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
+    latin1_charset = "a-zàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ"
 
     address = address.strip()
     pattern = re.compile(
         r"([%s\ -]*[0-9-\ ]*\ ?[a-z]{0,2}),?\ *(0?2[0-9]{3})?\ *(espoo|esbo)?"
-        % LATIN1_CHARSET,
+        % latin1_charset,
         re.I,
     )
     match = pattern.match(address)
@@ -247,7 +247,7 @@ class EspooImporter(Importer):
     location_cache = {}
 
     def _build_cache_places(self):
-        loc_id_list = [l[1] for l in LOCATIONS.values()]
+        loc_id_list = [location[1] for location in LOCATIONS.values()]
         place_list = Place.objects.filter(data_source=self.tprek_data_source).filter(
             origin_id__in=loc_id_list
         )
@@ -499,7 +499,7 @@ class EspooImporter(Importer):
         self.keyword_by_id.update(dict({k.id: k for k in keywords}))
         return keywords
 
-    def _import_event(self, lang, event_el, events):
+    def _import_event(self, lang, event_el, events):  # noqa: C901
         # Times are in Helsinki timezone
         def to_utc(dt):
             return LOCAL_TZ.localize(dt, is_dst=None).astimezone(pytz.utc)

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -358,7 +358,7 @@ class HarrastushakuImporter(Importer):
         ) | self.get_event_audiences_from_keywords(keywords)
         keywords |= audience
         event_data = {
-            "type_id": Event.Type_Id.COURSE,
+            "type_id": Event.TypeId.COURSE,
             "name": get_string("name", localized=True),
             "description": get_string("description", localized=True),
             "audience_max_age": get_int("agemax"),
@@ -627,7 +627,7 @@ class HarrastushakuImporter(Importer):
     def get_event_audiences_from_keywords(self, keywords):
         return {kw for kw in keywords if kw.id in KEYWORDS_TO_ADD_TO_AUDIENCE}
 
-    @lru_cache()
+    @lru_cache()  # noqa: B019
     def match_keyword(self, text):
         return self.keyword_matcher.match(text, language="fi")
 

--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -207,7 +207,7 @@ class HelmetImporter(Importer):
         self.city, _ = Organization.objects.get_or_create(defaults=defaults, **org_args)
 
         # Build a cached list of Places
-        loc_id_list = [l[1] for l in LOCATIONS.values()]
+        loc_id_list = [location[1] for location in LOCATIONS.values()]
         place_list = Place.objects.filter(data_source=self.tprek_data_source).filter(
             origin_id__in=loc_id_list
         )
@@ -262,7 +262,7 @@ class HelmetImporter(Importer):
                     continue
         return ext_props
 
-    def _import_event(self, lang, event_el, events):
+    def _import_event(self, lang, event_el, events):  # noqa: C901
         def dt_parse(dt_str):
             """Convert a string to UTC datetime"""
             # Times are in UTC+02:00 timezone
@@ -419,7 +419,7 @@ class HelmetImporter(Importer):
                         # The event is only online, do not consider other locations
                         event["location"]["id"] = INTERNET_LOCATION_ID
                     else:
-                        for k, v in LOCATIONS.items():
+                        for _k, v in LOCATIONS.items():
                             if classification["NodeId"] in v[0]:
                                 event["location"]["id"] = self.tprek_by_id[str(v[1])]
                                 break

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -466,7 +466,7 @@ class KulkeImporter(Importer):
             formatted_paragraphs.append(formatted_paragraph)
         return "".join(formatted_paragraphs)
 
-    def _import_event(self, lang, event_el, events, is_course=False):
+    def _import_event(self, lang, event_el, events, is_course=False):  # noqa: C901
         def text(t):
             return unicodetext(event_el.find("event" + t))
 
@@ -811,7 +811,7 @@ class KulkeImporter(Importer):
 
         # The name may vary within a recurring event; hence, take the common part
         if expand_model_fields(super_event, ["headline"])[0] not in common_fields:
-            words = getattr(events.first(), "headline").split(" ")
+            words = events.first().headline.split(" ")
             name = ""
             while words and all(
                 headline.startswith(name + words[0])
@@ -820,7 +820,7 @@ class KulkeImporter(Importer):
                 name += words.pop(0) + " "
                 logger.warning(words)
                 logger.warning(name)
-            setattr(super_event, "name", name)
+            super_event.name = name
 
         for lang in self.languages.keys():
             headline = getattr(super_event, "headline_{}".format(lang))

--- a/events/importer/lippupiste.py
+++ b/events/importer/lippupiste.py
@@ -386,12 +386,12 @@ class LippupisteImporter(Importer):
                 "address match, pick the name with most common words and least different words, if any:"
             )
             if len(matches_by_address) > 1:
-                for common_words, match_list in sorted(
+                for _common_words, match_list in sorted(
                     matches_by_partial_name.items(),
                     key=(lambda x: int(x[0])),
                     reverse=True,
                 ):
-                    for different_words, sublist in sorted(
+                    for _different_words, sublist in sorted(
                         match_list.items(), key=(lambda x: int(x[0]))
                     ):
                         address_and_word_matches = set(matches_by_address) & set(

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -116,7 +116,7 @@ class MatkoImporter(Importer):
     supported_languages = ["fi", "sv", "en"]
 
     def __init__(self, *args, **kwargs):
-        super(MatkoImporter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.timezone = pytz.timezone("Europe/Helsinki")
 
     def put(self, rdict, key, val):

--- a/events/importer/mikkelinyt.py
+++ b/events/importer/mikkelinyt.py
@@ -37,7 +37,7 @@ class MikkeliNytImporter(Importer):
     supported_languages = ["fi"]
 
     def __init__(self, *args, **kwargs):
-        super(MikkeliNytImporter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.timezone = pytz.timezone("Europe/Helsinki")
 
     def items_from_url(self, url):
@@ -121,8 +121,8 @@ class MikkeliNytImporter(Importer):
         address = self.strip_html(item["address"])
         city = self.strip_html(item["city"])
         place = self.strip_html(item["place"])
-        zipCode = self.strip_html(item["zip"])
-        location = self.upsert_place(location_origin_id, address, city, place, zipCode)
+        zip_code = self.strip_html(item["zip"])
+        location = self.upsert_place(location_origin_id, address, city, place, zip_code)
 
         categories = item["category"]
         keywords = self.upsert_keywords(categories)
@@ -193,7 +193,7 @@ class MikkeliNytImporter(Importer):
         keywords = Keyword.objects.filter(id__exact="%s" % _id).order_by("id")
         return keywords.first()
 
-    def upsert_place(self, origin_id, address, city, place, zipCode):
+    def upsert_place(self, origin_id, address, city, place, zip_code):
         result = recur_dict()
         _id = "mikkelinyt:{}".format(origin_id)
 
@@ -201,7 +201,7 @@ class MikkeliNytImporter(Importer):
         result["origin_id"] = origin_id
         result["name"]["fi"] = place
         result["street_address"]["fi"] = address
-        result["postal_code"] = zipCode
+        result["postal_code"] = zip_code
         result["address_locality"]["fi"] = city
         result["publisher"] = self.organization
         result["data_source"] = self.data_source

--- a/events/importer/osoite.py
+++ b/events/importer/osoite.py
@@ -65,10 +65,10 @@ class OsoiteImporter(Importer):
 
     def pk_get(self, resource_name, res_id=None):
         # support all munigeo resources, not just addresses
-        Klass = import_string("munigeo.models." + resource_name)
+        klass = import_string("munigeo.models." + resource_name)
         if res_id is not None:
-            return Klass.objects.get(origin_id=res_id)
-        return Klass.objects.all()
+            return klass.objects.get(origin_id=res_id)
+        return klass.objects.all()
 
     def delete_and_replace(self, obj):
         obj.deleted = True

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -43,7 +43,7 @@ class ModelSyncher(object):
 
     def finish(self, force=False):
         delete_list = []
-        for obj_id, obj in self.obj_dict.items():
+        for _obj_id, obj in self.obj_dict.items():
             if obj._found:
                 # We have to reset _found so we don't mark or match the same object across several synchers.
                 # Only relevant if consecutive synchers get different querysets;

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -5,7 +5,6 @@ import re
 
 from bs4 import BeautifulSoup
 from django.core.validators import URLValidator, ValidationError
-from django.utils.translation.trans_real import activate, deactivate
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
 
@@ -128,8 +127,12 @@ def address_eq(a, b):
         return False
     for key in ["locality", "street_address"]:
         languages = a[key].viewkeys() | b[key].viewkeys()
-        for l in languages:
-            if l in a[key] and l in b[key] and not text_match(a[key][l], b[key][l]):
+        for lang in languages:
+            if (
+                lang in a[key]
+                and lang in b[key]
+                and not text_match(a[key][lang], b[key][lang])
+            ):
                 return False
     return True
 
@@ -186,15 +189,3 @@ def replace_location(
             % (replace.id, str(replace), by.id)
         )
     return True
-
-
-class active_language:
-    def __init__(self, language):
-        self.language = language
-
-    def __enter__(self):
-        activate(self.language)
-        return self.language
-
-    def __exit__(self, type, value, traceback):
-        deactivate()

--- a/events/management/commands/add_helfi_topics.py
+++ b/events/management/commands/add_helfi_topics.py
@@ -63,7 +63,7 @@ NEW_HELFI_KEYWORDS_DATA = [
 class Command(BaseCommand):
     help = "Creates www.hel.fi topic keywords and keyword set used by the UI."
 
-    @lru_cache()
+    @lru_cache()  # noqa: B019
     def get_keyword_obj(self, keyword_id):
         try:
             keyword = Keyword.objects.get(id=keyword_id)

--- a/events/management/commands/add_helsinki_audience.py
+++ b/events/management/commands/add_helsinki_audience.py
@@ -50,7 +50,7 @@ NEW_SOTE_KEYWORDS_DATA = [
 class Command(BaseCommand):
     help = "Creates SOTE keywords and Helsinki audience keyword set and adds YSO audience keywords to events."
 
-    @lru_cache()
+    @lru_cache()  # noqa: B019
     def get_keyword_obj(self, keyword_id):
         try:
             keyword = Keyword.objects.get(id=keyword_id)

--- a/events/management/commands/add_helsinki_topics.py
+++ b/events/management/commands/add_helsinki_topics.py
@@ -41,7 +41,7 @@ HELSINKI_KEYWORD_IDS = [
 class Command(BaseCommand):
     help = "Creates Helsinki topics keyword set."
 
-    @lru_cache()
+    @lru_cache()  # noqa: B019
     def get_keyword_obj(self, keyword_id):
         try:
             keyword = Keyword.objects.get(id=keyword_id)

--- a/events/models.py
+++ b/events/models.py
@@ -249,7 +249,7 @@ class Image(models.Model):
         if self.url and self.image:
             raise ValidationError(_("You can only provide image or url, not both."))
         self.last_modified_time = BaseModel.now()
-        super(Image, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def is_user_editable(self):
         return bool(self.data_source and self.data_source.user_editable)
@@ -743,15 +743,15 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         (SuperEventType.UMBRELLA, _("Umbrella event")),
     )
 
-    class Type_Id:
+    class TypeId:
         GENERAL = 1
         COURSE = 2
         VOLUNTEERING = 3
 
     TYPE_IDS = (
-        (Type_Id.GENERAL, _("General")),
-        (Type_Id.COURSE, _("Course")),
-        (Type_Id.VOLUNTEERING, _("Volunteering")),
+        (TypeId.GENERAL, _("General")),
+        (TypeId.COURSE, _("Course")),
+        (TypeId.VOLUNTEERING, _("Volunteering")),
     )
 
     # Properties from schema.org/Thing
@@ -851,7 +851,7 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         blank=False,
         null=False,
         db_index=False,
-        default=Type_Id.GENERAL,
+        default=TypeId.GENERAL,
         choices=TYPE_IDS,
     )
 
@@ -973,7 +973,7 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         # if self.location__divisions__ocd_id__endswith == MUNIGEO_MUNI:
         #     self.local = True
 
-        super(Event, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
         # needed to cache location event numbers
         if not old_location and self.location:
@@ -1180,7 +1180,7 @@ class ExportInfo(models.Model):
 
     def save(self, *args, **kwargs):
         self.last_exported_time = BaseModel.now()
-        super(ExportInfo, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class EventAggregate(models.Model):
@@ -1214,4 +1214,4 @@ class Feedback(models.Model):
             )
         except SMTPException as e:
             logger.error(e, exc_info=True)
-        super(Feedback, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)

--- a/events/parsers.py
+++ b/events/parsers.py
@@ -31,7 +31,7 @@ class CamelCaseJSONParser(JSONParser):
     def parse(self, stream, media_type=None, parser_context=None):
         parser_context = parser_context or {}
         if "disable_camelcase" in parser_context["request"].query_params:
-            return super(CamelCaseJSONParser, self).parse(media_type, parser_context)
+            return super().parse(media_type, parser_context)
         else:
             encoding = parser_context.get("encoding", settings.DEFAULT_CHARSET)
             try:

--- a/events/renderers/json.py
+++ b/events/renderers/json.py
@@ -6,7 +6,7 @@ class JSONRenderer(renderers.JSONRenderer):
     charset = "utf-8"
 
     def render(self, data, media_type=None, renderer_context=None):
-        return super(JSONRenderer, self).render(data, media_type, renderer_context)
+        return super().render(data, media_type, renderer_context)
 
 
 class JSONLDRenderer(JSONRenderer):

--- a/events/signals.py
+++ b/events/signals.py
@@ -28,10 +28,12 @@ def organization_post_save(sender, instance, created, **kwargs):
 
 def user_post_save(sender, instance, created, **kwargs):
     if created:
-        User = get_user_model()
+        user_model = get_user_model()
         recipient_list = [
             item[0]
-            for item in User.objects.filter(is_superuser=True).values_list("email")
+            for item in user_model.objects.filter(is_superuser=True).values_list(
+                "email"
+            )
         ]
         notification_type = NotificationType.USER_CREATED
         context = {"user": instance}

--- a/events/tests/common.py
+++ b/events/tests/common.py
@@ -8,12 +8,12 @@ class TestDataMixin:
     def set_up_test_data(self):
 
         # dummy inputs
-        TEXT = "testing"
+        text = "testing"
 
         # data source
-        self.test_ds, _ = DataSource.objects.get_or_create(id=TEXT)
+        self.test_ds, _ = DataSource.objects.get_or_create(id=text)
 
         #  organization
         self.test_org, _ = Organization.objects.get_or_create(
-            id=TEXT, data_source=self.test_ds
+            id=text, data_source=self.test_ds
         )

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -951,7 +951,7 @@ def test_keywordset_search(
 
 
 @pytest.mark.django_db
-def test_keyword_OR_set_search(
+def test_keyword_or_set_search(
     api_client,
     event,
     event2,
@@ -975,9 +975,9 @@ def test_keyword_OR_set_search(
 @pytest.mark.django_db
 def test_event_get_by_type(api_client, event, event2, event3):
     #  default type is General, only general events should be present in the default search
-    event2.type_id = Event.Type_Id.COURSE
+    event2.type_id = Event.TypeId.COURSE
     event2.save()
-    event3.type_id = Event.Type_Id.VOLUNTEERING
+    event3.type_id = Event.TypeId.VOLUNTEERING
     event3.save()
     get_list_and_assert_events("", [event])
     get_list_and_assert_events("event_type=general", [event])

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -220,8 +220,8 @@ def test__update_an_event_complex_dict(api_client, complex_event_dict, user):
     response = create_with_post(api_client, complex_event_dict)
 
     # dummy inputs
-    TEXT = "text updated"
-    URL = "http://localhost"
+    text = "text updated"
+    url = "http://localhost"
 
     # set up updates
     data2 = response.data
@@ -235,9 +235,9 @@ def test__update_an_event_complex_dict(api_client, complex_event_dict, user):
     data2["offers"] = [
         {
             "is_free": False,
-            "price": {"en": TEXT, "sv": TEXT, "fi": TEXT},
-            "description": {"en": TEXT, "fi": TEXT},
-            "info_url": {"en": URL, "sv": URL, "fi": URL},
+            "price": {"en": text, "sv": text, "fi": text},
+            "description": {"en": text, "fi": text},
+            "info_url": {"en": url, "sv": url, "fi": url},
         }
     ]
     data2["keywords"] = data2["keywords"][:1]

--- a/events/tests/test_events_search.py
+++ b/events/tests/test_events_search.py
@@ -15,7 +15,7 @@ from ..models import Event
 from .common import TestDataMixin
 
 # Make sure we don't overwrite our main indices
-for key, val in settings.HAYSTACK_CONNECTIONS.items():
+for _key, val in settings.HAYSTACK_CONNECTIONS.items():
     if "INDEX_NAME" in val:
         val["INDEX_NAME"] = "test_%s" % val["INDEX_NAME"]
 
@@ -45,7 +45,7 @@ class EventSearchTests(TestCase, TestDataMixin):
         # simple backend doesn't have an index, so we cannot test indexing
         # rebuild_index.Command().handle(interactive=False)
 
-        super(EventSearchTests, self).setUp()
+        super().setUp()
 
     def _get_response(self, query):
         return self.client.get("/v1/search/", {"q": query}, format="json")

--- a/events/tests/utils.py
+++ b/events/tests/utils.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIRequestFactory
 def assert_event_data_is_equal(d1, d2, version="v1"):
     # TODO: start using version parameter
     # make sure the saved data is equal to the one we posted before
-    FIELDS = (
+    fields = (
         "data_source",
         "publisher",
         "location",
@@ -33,19 +33,19 @@ def assert_event_data_is_equal(d1, d2, version="v1"):
         "end_time",
     )
     if version == "v1":
-        FIELDS += ("images",)
+        fields += ("images",)
     elif version == "v0.1":
-        FIELDS += (
+        fields += (
             "image",
             "headline",
             "secondary_headline",
             "origin_id",
         )
-    assert_data_is_equal(d1, d2, FIELDS)
+    assert_data_is_equal(d1, d2, fields)
 
 
 def assert_place_data_is_equal(d1, d2, version="v1"):
-    FIELDS = (
+    fields = (
         "data_source",
         "publisher",
         "email",
@@ -55,12 +55,12 @@ def assert_place_data_is_equal(d1, d2, version="v1"):
         "street_address",
         "address_locality",
     )
-    assert_data_is_equal(d1, d2, FIELDS)
+    assert_data_is_equal(d1, d2, fields)
 
 
 def assert_keyword_data_is_equal(d1, d2, version="v1"):
-    FIELDS = ("data_source", "publisher", "name")
-    assert_data_is_equal(d1, d2, FIELDS)
+    fields = ("data_source", "publisher", "name")
+    assert_data_is_equal(d1, d2, fields)
 
 
 def assert_data_is_equal(d1, d2, fields):

--- a/events/utils.py
+++ b/events/utils.py
@@ -33,7 +33,7 @@ def get_value_from_tuple_list(list_of_tuples, search_key, value_index):
     :return: Value from either side of tuple
     """
 
-    for i, v in enumerate(list_of_tuples):
+    for _i, v in enumerate(list_of_tuples):
         if str(v[value_index ^ 1]) == str(search_key):
             return v[value_index]
 

--- a/helevents/api.py
+++ b/helevents/api.py
@@ -15,7 +15,7 @@ class UserSerializer(serializers.ModelSerializer):
     display_name = serializers.ReadOnlyField(source="get_display_name")
 
     def to_representation(self, obj):
-        rep = super(UserSerializer, self).to_representation(obj)
+        rep = super().to_representation(obj)
         default_org = obj.get_default_organization()
         if default_org:
             rep["organization"] = default_org.id

--- a/linkedevents/api.py
+++ b/linkedevents/api.py
@@ -17,7 +17,7 @@ class LinkedEventsAPIRouter(DefaultRouter):
     )
 
     def __init__(self):
-        super(LinkedEventsAPIRouter, self).__init__()
+        super().__init__()
         self.registered_api_views = set()
         self._register_all_views()
 

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -10,7 +10,7 @@ import sentry_sdk
 from django.conf.global_settings import LANGUAGES as GLOBAL_LANGUAGES
 from django.core.exceptions import ImproperlyConfigured
 from django_jinja.builtins import DEFAULT_EXTENSIONS
-from easy_thumbnails.conf import Settings as thumbnail_settings
+from easy_thumbnails.conf import Settings as thumbnail_settings  # noqa: N813
 from sentry_sdk.integrations.django import DjangoIntegration
 
 CONFIG_FILE_NAME = "config_dev.toml"
@@ -214,7 +214,7 @@ WSGI_APPLICATION = "linkedevents.wsgi.application"
 # thus some gyrations
 language_map = {x: y for x, y in GLOBAL_LANGUAGES}
 try:
-    LANGUAGES = tuple((l, language_map[l]) for l in env("LANGUAGES"))
+    LANGUAGES = tuple((lang, language_map[lang]) for lang in env("LANGUAGES"))
 except KeyError as e:
     raise ImproperlyConfigured(f'unknown language code "{e.args[0]}"')
 LANGUAGE_CODE = env("LANGUAGES")[0]
@@ -414,7 +414,7 @@ HAYSTACK_CONNECTIONS = {
     }
 }
 
-for language in [l[0] for l in LANGUAGES]:
+for language in [lang[0] for lang in LANGUAGES]:
     if env("ELASTICSEARCH_URL"):
         connection = haystack_connection_for_lang(language)
     else:

--- a/linkedevents/test_settings.py
+++ b/linkedevents/test_settings.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 Django settings module for pytest
 """
@@ -13,6 +14,6 @@ def dummy_haystack_connection_without_warnings_for_lang(language_code):
     }
 
 
-for language in [l[0] for l in LANGUAGES]:
+for language in [lang[0] for lang in LANGUAGES]:
     connection = dummy_haystack_connection_without_warnings_for_lang(language)
     HAYSTACK_CONNECTIONS.update(connection)

--- a/multilingual_haystack/backends.py
+++ b/multilingual_haystack/backends.py
@@ -82,7 +82,7 @@ class LanguageSearchEngine(BaseEngine):
 
         self.query = base_engine.query
 
-        super(LanguageSearchEngine, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class SimpleSearchBackendWithoutWarnings(SimpleSearchBackend):

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.db import models
-from django.utils import timezone, translation
+from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.html import strip_tags
 from django.utils.translation import activate

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -14,7 +14,7 @@ from notifications.models import (
 
 @pytest.fixture(scope="function")
 def notification_type():
-    setattr(NotificationType, "TEST", "test")
+    NotificationType.TEST = "test"
     yield NotificationType.TEST
     delattr(NotificationType, "TEST")
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -1,8 +1,6 @@
-from datetime import datetime
 from smtplib import SMTPException
 from uuid import uuid4
 
-import pytz
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail
@@ -187,9 +185,9 @@ class SignUp(models.Model):
             email_variables["instructions"] = self.registration.instructions
 
         event_type_name = {
-            str(Event.Type_Id.GENERAL): "tapahtumaan",
-            str(Event.Type_Id.COURSE): "kurssille",
-            str(Event.Type_Id.VOLUNTEERING): "vapaaehtoistehtävään",
+            str(Event.TypeId.GENERAL): "tapahtumaan",
+            str(Event.TypeId.COURSE): "kurssille",
+            str(Event.TypeId.VOLUNTEERING): "vapaaehtoistehtävään",
         }
 
         email_variables["event_type"] = event_type_name[self.registration.event.type_id]

--- a/registrations/tests/test_registration_admin_side.py
+++ b/registrations/tests/test_registration_admin_side.py
@@ -1,14 +1,14 @@
 import uuid
 from copy import deepcopy
+from datetime import datetime, timedelta
 
 import environ
 import pytest
 from dateutil.parser import parse
-from django.conf import settings
 from django.core import mail
 
-from events.models import Language
-from events.tests.conftest import *
+from events.models import Event, Language
+from events.tests.conftest import *  # noqa
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import Registration, SignUp
 
@@ -107,10 +107,10 @@ def test_list_all_registrations(api_client, user, user2, event, event2, event3):
 @pytest.mark.django_db
 def test_successful_sign_up(api_client, user, event):
     url = reverse("registration-list")
-    l = Language()
-    l.id = "fi"
-    l.name = "finnish"
-    l.save()
+    lang = Language()
+    lang.id = "fi"
+    lang.name = "finnish"
+    lang.save()
 
     api_client.force_authenticate(user)
     registration_data = {"event": event.id}
@@ -528,35 +528,6 @@ def test_get_signup_info_with_cancel_code_no_auth(api_client, user, event):
     signup_url = reverse("signup-list")
     response = api_client.post(signup_url, sign_up_payload, format="json")
 
-    delete_payload = {"cancellation_code": response.data["cancellation_code"]}
-
-    response = api_client.get(
-        f'{signup_url}?cancellation_code={response.data["cancellation_code"]}'
-    )
-    assert response.data["name"] == "Michael Jackson"
-
-
-@pytest.mark.django_db
-def test_get_signup_info_with_cancel_code_no_auth(api_client, user, event):
-    registration_url = reverse("registration-list")
-
-    api_client.force_authenticate(user)
-    registration_data = {"event": event.id}
-
-    response = api_client.post(registration_url, registration_data, format="json")
-    registration_id = response.data["id"]
-
-    api_client.force_authenticate(user=None)
-    sign_up_payload = {
-        "registration": registration_id,
-        "name": "Michael Jackson",
-        "email": "test@test.com",
-    }
-    signup_url = reverse("signup-list")
-    response = api_client.post(signup_url, sign_up_payload, format="json")
-
-    delete_payload = {"cancellation_code": response.data["cancellation_code"]}
-
     response = api_client.get(
         f'{signup_url}?cancellation_code={response.data["cancellation_code"]}'
     )
@@ -692,7 +663,7 @@ def test_filter_registrations(api_client, user, user2, event, event2):
     response = api_client.post(registration_url, registration_data, format="json")
     registration_id2 = response.data["id"]
 
-    event2.type_id = Event.Type_Id.COURSE
+    event2.type_id = Event.TypeId.COURSE
     event2.save()
 
     response = api_client.get(registration_url)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = migrations,tests
 max-line-length = 120
-max-complexity = 10
+max-complexity = 20
 extend-ignore = E203
 
 [tool:pytest]


### PR DESCRIPTION
- Fix simple errors
- Ignore too complex functions from QA
- Raise allowed level of complexity
- Remove duplicated test code
- Replace custom `active_language` function with `override` from Django

Refactoring `super` calls to have no arguments wasn't part of `flake8` errors. It however highlights the `super` calls where the immediate superclass is not called.

Refs LINK-1123