### PR TITLE
Fix issue in helmet import

### DIFF
--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -193,7 +193,7 @@ class HelmetImporter(Importer):
         self.tprek_data_source = DataSource.objects.get(id="tprek")
         self.ahjo_data_source = DataSource.objects.get(id="ahjo")
         system_data_source_defaults = {"user_editable": True}
-        self.system_data_source = DataSource.objects.get_or_create(
+        self.system_data_source, _ = DataSource.objects.get_or_create(
             id=settings.SYSTEM_DATA_SOURCE_ID, defaults=system_data_source_defaults
         )
 


### PR DESCRIPTION
self.system_data_source was set to a tuple and if a new place was created 
with defaults the foreign key relation would be set to the tuple instead of 
data source instance leading to an error.