### PR TITLE
Make django-haystack manage elasticsearch package version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ django-cleanup
 django-cors-headers
 django-environ
 django-filter>=2.1.0
-django-haystack
+django-haystack[elasticsearch]
 django-helusers
 django-image-cropping
 django-jinja==2.10.2
@@ -24,7 +24,6 @@ djangorestframework-bulk
 djangorestframework-gis
 djangorestframework-jwt
 easy_thumbnails
-elasticsearch~=7.17
 httmock
 icalendar
 isodate

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ django-environ==0.9.0
     # via -r requirements.in
 django-filter==22.1
     # via -r requirements.in
-django-haystack==3.2.1
+django-haystack[elasticsearch]==3.2.1
     # via -r requirements.in
 django-helusers==0.7.1
     # via -r requirements.in
@@ -123,7 +123,7 @@ easy-thumbnails==2.8.3
 ecdsa==0.18.0
     # via python-jose
 elasticsearch==7.17.8
-    # via -r requirements.in
+    # via django-haystack
 exceptiongroup==1.0.0rc8
     # via cattrs
 httmock==1.4.0


### PR DESCRIPTION
`django-haystack` has an optional extra requirement, which currently will limit `elasticsearch` package to `elasticsearch>=5,<8`