### PR TITLE
Prevent stopped docker-compose containers restarting on boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         container_name: linkedevents-memcached
 
     django:
-        restart: always
+        restart: unless-stopped
         build:
             context: ./
             dockerfile: ./docker/django/Dockerfile


### PR DESCRIPTION
`unless-stopped` is similar to `always` flag, but it doesn't restart any stopped containers when the Docker daemon restarts (e.g. on boot).

https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy