### PR TITLE
LINK-952: Add distance filter (aka "circle filter")

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3645,12 +3645,18 @@ class EventFilter(django_filters.rest_framework.FilterSet):
             # Need both values for filtering
             return queryset
 
-        origin_x, origin_y = origin
-        metres = float(metres)
+        try:
+            origin_x, origin_y = [float(i) for i in origin]
+        except ValueError:
+            raise ParseError("Origin must be a tuple of two numbers")
+        try:
+            metres = float(metres)
+        except ValueError:
+            raise ParseError("Metres must be a number")
 
-        places = Place.geo_objects.filter(
-            position__distance_lte=(
-                Point(float(origin_x), float(origin_y)),
+        places = Place.objects.filter(
+            position__dwithin=(
+                Point(origin_x, origin_y),
                 D(m=metres),
             )
         )

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -216,6 +216,30 @@ def test_get_event_list_verify_dwithin_filter(event, event2):
     )
 
 
+@pytest.mark.parametrize(
+    "query_string,expected_message",
+    [
+        ("dwithin_origin=0,0&dwithin_metres=foo", "Metres must be a number"),
+        ("dwithin_origin=0&dwithin_metres=35", "Origin must be a tuple of two numbers"),
+        (
+            "dwithin_origin=0,0,0&dwithin_metres=35",
+            "Origin must be a tuple of two numbers",
+        ),
+        (
+            "dwithin_origin=0,foo&dwithin_metres=35",
+            "Origin must be a tuple of two numbers",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_get_event_list_verify_dwithin_filter_error(
+    query_string, expected_message, api_client, event, event2
+):
+    response = get_list_no_code_assert(api_client, query_string=query_string)
+    assert response.status_code == 400
+    assert response.data["detail"] == expected_message
+
+
 @pytest.mark.django_db
 def test_get_event_list_verify_audience_max_age_lt_filter(api_client, keyword, event):
     event.audience_max_age = 16

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -64,6 +64,7 @@ end before 21:00.
 </code></pre>
 <p><a href="?starts_after=16:30&amp;ends_before=21" title="json">See the result</a></p>
 <h3 id="event-location">Event location</h3>
+
 <h4 id="bounding-box">Bounding box</h4>
 <p>To restrict the retrieved events to a geographical region, use
 the query parameter <code>bbox</code> in the format</p>
@@ -76,6 +77,7 @@ and so on. The coordinate system is the trusty old EPSG:4326 known from all onli
 <pre><code>event/?bbox=24.9348,60.1762,24.9681,60.1889
 </code></pre>
 <p><a href="?bbox=24.9348,60.1762,24.9681,60.1889" title="json">See the result</a></p>
+
 <h4 id="specific-location">Specific location</h4>
 <p>To restrict the retrieved events to a known location(s), use
 the query parameter <code>location</code>, separating values by commas
@@ -106,6 +108,20 @@ regardless of division type.</p>
 <pre><code>event/?division=malmi
 </code></pre>
 <p><a href="?division=malmi" title="json">See the result</a></p>
+
+<h4 id="distance-filter">Within a distance (or "circle filter")</h4>
+<p>To restrict the retrieved events to a certain distance from a point,
+use the query parameters <code>dwithin_origin</code> and <code>dwithin_metres</code> in the format</p>
+<pre><code>dwithin_origin=lon,lat&dwithin_metres=distance
+</code></pre>
+<p>Where <code>lon</code> is the longitude of the origin point,
+<code>lat</code> is the latitude of the origin point,
+and <code>distance</code> is the radius in metres.
+Both parameters are required. The coordinate system is EPSG:4326.</p>
+<p>Example:</p>
+<pre><code>event/?dwithin_origin=24.9348,60.1762&dwithin_metres=1000
+</code></pre>
+<p><a href="?dwithin_origin=24.9348,60.1762&dwithin_metres=1000" title="json">See the result</a></p>
 
 <h3 id="event-category">Event category</h3>
 <p>To restrict the retrieved events by category, use the query


### PR DESCRIPTION
Adds two new event filters, `dwithin_origin` and `dwithin_metres`, which filters all events within the given distance (in metres) from the origin point (x, y).

E.g.
`/v1/event/?dwithin_origin=24.941430575828296,60.17186028180228&dwithin_metres=1000`
Get all events within 1 km radius of Helsinki Central Station.

Refs LINK-952