### PR TITLE
Fix SonarCloud warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v3
 
+      # Without this workaround Sonar reports a warning about an incorrect source path
+      - name: Override coverage report source path for Sonar
+        run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Required by Sonar
+          fetch-depth: 0
 
       - name: psycopg2 prerequisites
         run: sudo apt-get install libpq-dev

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,5 @@ sonar.projectKey=City-of-Helsinki_linkedevents
 sonar.organization=city-of-helsinki
 sonar.python.version=3.9
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.test.inclusions=**/tests/**/*
+sonar.exclusions=**/tests/**/*


### PR DESCRIPTION
SonarCloud was giving warnings after scanning, so two changes were needed:
* changed the GHA job to not use a shallow clone ([more info](https://community.sonarsource.com/t/sonarcloud-with-github-actions/22713/2))
* added a workaround that overrides source path in the generated coverage report file ([more info](https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057))

Also excluded tests from Sonar scans.
