### PR TITLE
Fix overflow and DST handling in parse_time and add tests

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -1,4 +1,3 @@
-import datetime
 import itertools
 import logging
 import operator
@@ -16,6 +15,7 @@ from rest_framework.exceptions import ValidationError
 from events.importer.sync import ModelSyncher
 from events.models import Event, EventLink, Image, Language, Offer, Place
 
+from .. import utils
 from .util import clean_text, separate_scripts
 
 # Per module logger
@@ -354,8 +354,7 @@ class Importer(object):
             # Use midnight in event timezone, or, if given in utc, local timezone
             if info["end_time"].tzinfo == pytz.utc:
                 info["end_time"] = info["start_time"].astimezone(LOCAL_TZ)
-            info["end_time"] = info["end_time"].replace(hour=0, minute=0, second=0)
-            info["end_time"] += datetime.timedelta(days=1)
+            info["end_time"] = utils.start_of_next_day(info["end_time"])
 
         skip_fields = ["id", "location", "publisher", "offers", "keywords", "images"]
         self._update_fields(obj, info, skip_fields)

--- a/events/renderers/docx.py
+++ b/events/renderers/docx.py
@@ -9,7 +9,7 @@ from docx import Document
 from rest_framework import renderers
 from rest_framework.utils.serializer_helpers import ReturnDict
 
-from events.utils import parse_time
+from events import utils
 
 
 def get_any_language(dictionary, default="fi", language_codes=None):
@@ -209,12 +209,12 @@ class DOCXRenderer(renderers.BaseRenderer):
         if start is None:
             query_start_date = event_parser.earliest_date
         else:
-            query_start_date = parse_time(start, True)[0]
+            query_start_date = utils.parse_time(start)[0]
 
         if end is None:
             query_end_date = event_parser.latest_date
         else:
-            query_end_date = parse_time(end, False)[0]
+            query_end_date = utils.parse_end_time(end)[0]
 
         total_date_range = DateRange(query_start_date, query_end_date)
 

--- a/events/tests/test_utils.py
+++ b/events/tests/test_utils.py
@@ -1,43 +1,51 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 import pytz
-from django.conf import settings
+from django.conf import settings as django_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework.exceptions import ParseError
 
-from events.utils import parse_time
+from events.tests.test_event_get import get_list
+from events.tests.test_event_post import create_with_post
+from events.utils import (
+    parse_end_time,
+    parse_time,
+    start_of_day,
+    start_of_next_day,
+    start_of_previous_day,
+)
 
 
 @pytest.fixture
 def local_tz():
-    return pytz.timezone(settings.TIME_ZONE)
+    return pytz.timezone(django_settings.TIME_ZONE)
 
 
 @pytest.mark.django_db
 def test_parse_time_iso8601(local_tz):
-    assert parse_time("2022-07-17T17:17:17+03:00", True) == (
+    assert parse_time("2022-07-17T17:17:17+03:00") == (
         local_tz.localize(datetime(2022, 7, 17, 17, 17, 17)),
-        True,
+        False,
     )
 
 
 @pytest.mark.django_db
 def test_parse_time_iso8601_invalid_offset(local_tz):
     with pytest.raises(ParseError) as ex:
-        parse_time("2022-07-17T17:17:17+25:00", True)
+        parse_time("2022-07-17T17:17:17+25:00")
     assert "time in invalid format" in str(ex.value)
 
     with pytest.raises(ParseError) as ex:
-        parse_time("2022-07-17T17:17:17+23:00", True)
+        parse_time("2022-07-17T17:17:17+23:00")
     assert "out of bounds" in str(ex.value)
 
 
 @pytest.mark.django_db
 def test_parse_time_invalid_format(local_tz):
     with pytest.raises(ParseError) as ex:
-        parse_time("asdfdsaasdf", True)
+        parse_time("asdfdsaasdf")
     assert "time in invalid format" in str(ex.value)
 
 
@@ -46,33 +54,118 @@ def test_parse_time_overflow_error(local_tz):
     # Underlying overflow error that needs to be separately
     # handled by parse_time
     with pytest.raises(ParseError) as ex:
-        parse_time("999999999999999999", False)
+        parse_time("999999999999999999")
     assert "time in invalid format" in str(ex.value)
 
 
 @pytest.mark.django_db
 def test_parse_time_dst_handling(local_tz):
-    assert parse_time("2022-3-27", False) == (
+    assert parse_end_time("2022-3-27") == (
         local_tz.localize(datetime(2022, 3, 28)),
-        False,
+        True,
     )
-    assert parse_time("2022-10-30", False) == (
+    assert parse_end_time("2022-10-30") == (
         local_tz.localize(datetime(2022, 10, 31)),
-        False,
+        True,
     )
 
     # This is right in the middle of a DST change from DST (+3) to normal
     # time (+2) where a local time without timezone information would
     # be ambiguous
     with freeze_time("2022-10-30 03:30:00+02:00"):
-        assert parse_time("today", True) == (
+        assert parse_time("today") == (
             local_tz.localize(datetime(2022, 10, 30)),
-            False,
+            True,
         )
-        assert parse_time("today", False) == (
+        assert parse_end_time("today") == (
             local_tz.localize(datetime(2022, 10, 31)),
-            False,
+            True,
         )
 
-        assert parse_time("now", True) == (timezone.now(), True)
-        assert parse_time("now", False) == (timezone.now(), True)
+        assert parse_time("now") == (timezone.now(), False)
+        assert parse_end_time("now") == (timezone.now(), False)
+
+
+@pytest.mark.django_db
+def test_start_of_day(local_tz):
+    naive_dt = datetime(2022, 3, 27)
+    aware_dt = local_tz.localize(naive_dt)
+    utc_dt = aware_dt.astimezone(pytz.utc)
+
+    assert start_of_day(aware_dt) == aware_dt
+    assert start_of_day(utc_dt) == aware_dt
+
+
+@pytest.mark.django_db
+def test_start_of_next_day(local_tz):
+    naive_dt = datetime(2022, 3, 27)
+    aware_dt = local_tz.localize(naive_dt)
+    utc_dt = aware_dt.astimezone(pytz.utc)
+
+    naive_tomorrow_dt = datetime(2022, 3, 28)
+    aware_tomorrow_dt = local_tz.localize(naive_tomorrow_dt)
+
+    assert start_of_next_day(aware_dt) == aware_tomorrow_dt
+    assert start_of_next_day(utc_dt) == aware_tomorrow_dt
+
+
+@pytest.mark.django_db
+def test_start_of_previous_day(local_tz):
+    naive_dt = datetime(2022, 3, 27)
+    aware_dt = local_tz.localize(naive_dt)
+    utc_dt = aware_dt.astimezone(pytz.utc)
+
+    naive_previous_dt = datetime(2022, 3, 26)
+    aware_previous_dt = local_tz.localize(naive_previous_dt)
+
+    assert start_of_previous_day(aware_dt) == aware_previous_dt
+    assert start_of_previous_day(utc_dt) == aware_previous_dt
+
+
+@pytest.mark.django_db
+def test_inconsistent_tz_default(api_client, minimal_event_dict, user, settings):
+    """
+    Sadly the behaviour naive datetimes of GET and POST in events API is
+    inconsistent. POST assumes naive datetimes are in UTC, while GET assumes
+    naive datetimes are in local time. Fixing this breaks other tests and
+    backwards compatibility, so this test is here to ensure that
+    linkedevents remains inconsistent.
+
+    At least these tests rely on this incorrect behaviour:
+    * test_event_get.test_start_end_iso_date_time
+    * test_event_get.test_start_end_events_without_endtime
+    """
+    api_client.force_authenticate(user=user)
+
+    # Ensure test runs on a time zone that is different from UTC
+    settings.TIME_ZONE = "Europe/Helsinki"
+
+    # pick some DST irrelevant date in the future
+    # January 1st next year at 15:00:00
+    # This is the naive time we use to create the event
+    future_naive_dt = datetime(timezone.now().year + 1, 1, 1, 15)
+    future_naive_dt_str = future_naive_dt.isoformat()
+
+    # Bump by two hours... this is the naive time that will actually find the event
+    offset_naive_dt = future_naive_dt + timedelta(hours=2)
+    offset_naive_dt_str = offset_naive_dt.isoformat()
+
+    minimal_event_dict["start_time"] = future_naive_dt_str
+    minimal_event_dict["end_time"] = future_naive_dt_str
+    create_response = create_with_post(api_client, minimal_event_dict)
+
+    list_with_original_create_dt = get_list(
+        api_client,
+        query_string=f"start={future_naive_dt_str}&end={future_naive_dt_str}",
+    )
+    assert (
+        list_with_original_create_dt.json()["meta"]["count"] == 0
+    ), list_with_original_create_dt.json()
+
+    list_with_offset_create_dt = get_list(
+        api_client,
+        query_string=f"start={offset_naive_dt_str}&end={offset_naive_dt_str}",
+    )
+    assert (
+        list_with_offset_create_dt.json()["meta"]["count"] == 1
+    ), list_with_offset_create_dt.json()

--- a/events/tests/test_utils.py
+++ b/events/tests/test_utils.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+import pytest
+import pytz
+from django.conf import settings
+from django.utils import timezone
+from freezegun import freeze_time
+from rest_framework.exceptions import ParseError
+
+from events.utils import parse_time
+
+
+@pytest.fixture
+def local_tz():
+    return pytz.timezone(settings.TIME_ZONE)
+
+
+@pytest.mark.django_db
+def test_parse_time_iso8601(local_tz):
+    assert parse_time("2022-07-17T17:17:17+03:00", True) == (
+        local_tz.localize(datetime(2022, 7, 17, 17, 17, 17)),
+        True,
+    )
+
+
+@pytest.mark.django_db
+def test_parse_time_iso8601_invalid_offset(local_tz):
+    with pytest.raises(ParseError) as ex:
+        parse_time("2022-07-17T17:17:17+25:00", True)
+    assert "time in invalid format" in str(ex.value)
+
+    with pytest.raises(ParseError) as ex:
+        parse_time("2022-07-17T17:17:17+23:00", True)
+    assert "out of bounds" in str(ex.value)
+
+
+@pytest.mark.django_db
+def test_parse_time_invalid_format(local_tz):
+    with pytest.raises(ParseError) as ex:
+        parse_time("asdfdsaasdf", True)
+    assert "time in invalid format" in str(ex.value)
+
+
+@pytest.mark.django_db
+def test_parse_time_overflow_error(local_tz):
+    # Underlying overflow error that needs to be separately
+    # handled by parse_time
+    with pytest.raises(ParseError) as ex:
+        parse_time("999999999999999999", False)
+    assert "time in invalid format" in str(ex.value)
+
+
+@pytest.mark.django_db
+def test_parse_time_dst_handling(local_tz):
+    assert parse_time("2022-3-27", False) == (
+        local_tz.localize(datetime(2022, 3, 28)),
+        False,
+    )
+    assert parse_time("2022-10-30", False) == (
+        local_tz.localize(datetime(2022, 10, 31)),
+        False,
+    )
+
+    # This is right in the middle of a DST change from DST (+3) to normal
+    # time (+2) where a local time without timezone information would
+    # be ambiguous
+    with freeze_time("2022-10-30 03:30:00+02:00"):
+        assert parse_time("today", True) == (
+            local_tz.localize(datetime(2022, 10, 30)),
+            False,
+        )
+        assert parse_time("today", False) == (
+            local_tz.localize(datetime(2022, 10, 31)),
+            False,
+        )
+
+        assert parse_time("now", True) == (timezone.now(), True)
+        assert parse_time("now", False) == (timezone.now(), True)


### PR DESCRIPTION
Warning: Don't hurt yourself trying to read this.

Backstory: So.. in the Events API, the fields `start_time`, `end_time` and `date_published` are DateTimeFields, but utilizing a surprise `to_internal_value` method  some preprocessing is done to allow them also be date strings or special nouns like `now` or `today`. Additionally for dates (and `today`)  there's a concept of `is_start`, which if `False`, means the date is actually not the given date but the next day at 00:00:00. Because there are two different virtual types living the same field, there's a concept of `is_exact`. If the object is not exact, it means it's a date (disguised as a datetime). This information is stored in a helper field `has_start_time` which is `False` if the object is not `is_exact`.  This allows us to use a condition like follows to check if the object is a date disguised as a datetime:

`if obj.start_time and not obj.has_start_time:`

Food for thought: I'm not sure if the real world actually ever POSTs anything other than valid DateTimeField values. However there are 60 test cases that fail if the support for posting dates is dropped. 

The OG feature was made in https://github.com/City-of-Helsinki/linkedevents/issues/267 to support old frontend https://github.com/City-of-Helsinki/linkedevents-ui/issues/54 but I don't think linkedcomponents has this kind of "whole day" concept. 