### PR TITLE
LINK-1122 | Fix rest of the broken tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
       # With pytest-cov use: --cov=.
       # Some errors, skipping --doctest-modules for now
       - name: Run tests
-        continue-on-error: true # TODO remove once tests are sorted out
         uses: liskin/gh-problem-matcher-wrap@v2
         with:
           linters: pytest

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -90,7 +90,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
     def get_signups(self, obj):
         params = self.context["request"].query_params
-        if params.get("include", None) and params["include"] == "signups":
+        if params.get("include", None) == "signups":
             #  only the organization admins should be able to access the signup information
             user = self.context["user"]
             event = obj.event


### PR DESCRIPTION
This PR fixes all the remaining failing tests.

- Few tests were disabled due to their implementation not being quite there yet.
- Enable tests in GitHub actions i.e. don't ignore test failures.
- Fix minor bug in Registration.maximum_attendee_capacity handling logic