### PR TITLE
LINK-1158 | Get SECRET_KEY from the environment variable by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:
+  SECRET_KEY: topsecret123
   POSTGRES_DB: test_linkedevents
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres

--- a/docker/django/.env.example
+++ b/docker/django/.env.example
@@ -5,4 +5,5 @@ DATABASE_URL=postgis://linkedevents:linkedevents@linkedevents-db/linkedevents
 DEBUG=true
 INSTALL_TEMPLATE=helevents
 MEMCACHED_URL=linkedevents-memcached:11211
+SECRET_KEY=mD0lDi30t3IJ83utHW8yFzV4p3J9SKv0VDSiZQ6wHhdbXPIeHNX2O0YRaPqC8utuDpZpcTAxnZ3n3e6q
 WAIT_FOR_IT_ADDRESS=linkedevents-db:5432

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -99,6 +99,7 @@ if os.path.exists(env_file_path):
 
 DEBUG = env("DEBUG")
 TEMPLATE_DEBUG = False
+SECRET_KEY = env("SECRET_KEY")
 
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 ADMINS = env("ADMINS")

--- a/linkedevents/test_settings.py
+++ b/linkedevents/test_settings.py
@@ -31,3 +31,5 @@ CACHES = {
 # Auth
 SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT = "https://test_issuer"
 OIDC_API_TOKEN_AUTH["ISSUER"] = "https://test_issuer"
+
+SECRET_KEY = "xxx"


### PR DESCRIPTION
Secret key from a generated file was used by default, which means it changes every time a new container is started. The `SECRET_KEY` environment variable was not actually read into the `SECRET_KEY` setting. 