### PR TITLE
Fix template dir permission for production

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -56,6 +56,8 @@ FROM appbase AS production
 COPY --from=staticbuilder --chown=appuser:appuser /app/static /app/static
 COPY --chown=appuser:appuser . /app/
 
+RUN chgrp -R 0 /app/templates/rest_framework/ && chmod g+w -R /app/templates/rest_framework/
+
 USER appuser
 
 EXPOSE 8000/tcp


### PR DESCRIPTION
Platta needs more permissive permissions for the template directory.

Refs LINK-1138, LINK-1081