### PR TITLE
LINK-1233 | Make local Docker env to use media volume

### DIFF
--- a/docker/django/.env.example
+++ b/docker/django/.env.example
@@ -4,6 +4,7 @@ CREATE_SUPERUSER=true
 DATABASE_URL=postgis://linkedevents:linkedevents@linkedevents-db/linkedevents
 DEBUG=true
 INSTALL_TEMPLATE=helevents
+MEDIA_ROOT=/var/media/
 MEMCACHED_URL=linkedevents-memcached:11211
 SECRET_KEY=mD0lDi30t3IJ83utHW8yFzV4p3J9SKv0VDSiZQ6wHhdbXPIeHNX2O0YRaPqC8utuDpZpcTAxnZ3n3e6q
 WAIT_FOR_IT_ADDRESS=linkedevents-db:5432

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -9,6 +9,11 @@ RUN mkdir /entrypoint
 ENV PYTHONDONTWRITEBYTECODE=true
 ENV PYTHONUNBUFFERED=true
 
+## Setting the permissions beforehand makes the mounted volume inherit the permission
+## in docker compose. Useful for development with non-root user and named volume.
+## https://github.com/docker/compose/issues/3270#issuecomment-363478501
+RUN mkdir -p /var/media && chown -R appuser:appuser /var/media && chmod g=u -R /var/media
+
 COPY --chown=appuser:appuser requirements.txt /app/
 COPY --chown=appuser:appuser requirements-prod.txt /app/
 


### PR DESCRIPTION
This PR makes the local dev env to use the media volume created in `docker-compose.yml`

- Set MEDIA_ROOT for .env.example 
- Set permission for development env MEDIA_ROOT mount
