### PR TITLE
LINK-348 | Support filtering images by text

### DIFF
--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -18,6 +18,7 @@ from events.api import KeywordSerializer, LanguageSerializer, PlaceSerializer
 # events
 from events.models import (
     Event,
+    Image,
     Keyword,
     KeywordLabel,
     KeywordSet,
@@ -42,6 +43,36 @@ DATETIME = (timezone.now() + timedelta(days=1)).isoformat().replace("+00:00", "Z
 @pytest.fixture(autouse=True)
 def setup_env(settings):
     settings.SUPPORT_EMAIL = "test@test.com"
+
+
+@pytest.fixture
+def image_name():
+    return "tunnettu_kuva"
+
+
+@pytest.fixture
+def image_name_2():
+    return "known_image"
+
+
+@pytest.fixture
+def image_name_3():
+    return "känd_bild"
+
+
+@pytest.fixture
+def image_url():
+    return "http://fake.url/image-1/"
+
+
+@pytest.fixture
+def image_url_2():
+    return "http://fake.url/image-2/"
+
+
+@pytest.fixture
+def image_url_3():
+    return "http://fake.url/image-3/"
 
 
 @pytest.fixture
@@ -380,6 +411,20 @@ def keyword_dict(data_source, organization):
 
 @pytest.mark.django_db
 @pytest.fixture(scope="class")
+def make_image():
+    def _make_image(data_source, organization, image_name, image_url):
+        return Image.objects.create(
+            data_source=data_source,
+            name=image_name,
+            publisher=organization,
+            url=image_url,
+        )
+
+    return _make_image
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope="class")
 def make_keyword():
     def _make_keyword(data_source, organization, kw_name):
         lang_objs = [
@@ -404,6 +449,24 @@ def make_keyword():
         return obj
 
     return _make_keyword
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def image(data_source, organization, image_name, image_url, make_image):
+    return make_image(data_source, organization, image_name, image_url)
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def image2(data_source, organization, image_name_2, image_url_2, make_image):
+    return make_image(data_source, organization, image_name_2, image_url_2)
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def image3(data_source, organization, image_name_3, image_url_3, make_image):
+    return make_image(data_source, organization, image_name_3, image_url_3)
 
 
 @pytest.mark.django_db

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -228,7 +228,7 @@ class TestImageAPI(APITestCase):
             url="http://fake.url/image-2/",
         )
         self.image_3 = Image.objects.create(
-            name="image-2",
+            name="image-3",
             data_source=self.data_source,
             publisher=self.org_3,
             url="http://fake.url/image-2/",

--- a/events/tests/test_event_images_v1.py
+++ b/events/tests/test_event_images_v1.py
@@ -110,6 +110,14 @@ def test__get_image_list_check_fields_exist_for_url(api_client):
 
 
 @pytest.mark.django_db
+def test_get_image_list_verify_text_filter(api_client, image, image2, image3):
+    response = api_client.get(reverse("image-list"), data={"text": "kuva"})
+    assert image.id in [entry["id"] for entry in response.data["data"]]
+    assert image2.id not in [entry["id"] for entry in response.data["data"]]
+    assert image3.id not in [entry["id"] for entry in response.data["data"]]
+
+
+@pytest.mark.django_db
 def test__get_detail_check_fields_exist(api_client):
     image_file = create_in_memory_image_file(name="existing_test_image")
     uploaded_image = SimpleUploadedFile(

--- a/helcourses/templates/rest_framework/api.html
+++ b/helcourses/templates/rest_framework/api.html
@@ -20,6 +20,8 @@
     {{ block.super }}
 {% elif name == "Event List" %}
     {% include "rest_framework/event_list.html" %}
+{% elif name == "Image List" %}
+    {% include "rest_framework/image_list.html" %}
 {% elif name == "Place List List" %}
     {% include "rest_framework/place_list.html" %}
 {% elif name == "Keyword List List" %}

--- a/helevents/templates/rest_framework/api.html
+++ b/helevents/templates/rest_framework/api.html
@@ -19,6 +19,8 @@
     {{ block.super }}
 {% elif name == "Event List" %}
     {% include "rest_framework/event_list.html" %}
+{% elif name == "Image List" %}
+    {% include "rest_framework/image_list.html" %}
 {% elif name == "Place List List" %}
     {% include "rest_framework/place_list.html" %}
 {% elif name == "Keyword List List" %}

--- a/helevents/templates/rest_framework/image_list.html
+++ b/helevents/templates/rest_framework/image_list.html
@@ -1,0 +1,33 @@
+<div class="panel panel-default">
+    <div class="panel-body">
+        <h2 id="using-image-endpoint">Using the image endpoint</h2>
+        <p>Here, images for events are listed. Default ordering is decreasing order by <code>-last_modified_time</code>.</p>
+        <h4 id="image-text">Image text</h4>
+        <p>To find images that contain a specific string, use the query parameter <code>text</code>.</p>
+        <p>Example:</p>
+        <pre><code>image/?text=lapset</code></pre>
+        <p><a href="?text=lapset" title="json">See the result</a></p>
+        
+        <h3 id="image-publisher">Image publisher</h3>
+        <p>To find out images that are published by a specific organization, use the query
+        parameter <code>publisher</code>, separating values by commas if you wish to query for several publishers.</p>
+        <p>Existing publisher organizations are found at the <code>organization</code> endpoint.</p>
+        <p>Example:</p>
+        <pre><code>image/?publisher=ytj:0586977-6</code></pre>
+        <p><a href="?publisher=ytj:0586977-6" title="json">See the result</a></p>
+
+        <h3 id="image-data-source">Image data source</h3>
+        <p>To find out images that originate from a specific source system, use the query parameter
+        <code>data_source</code>, separating values by commas if you wish to query for several data sources.</p>
+        <p>Example:</p>
+        <pre><code>image/?data_source=helmet</code></pre>
+        <p><a href="?data_source=helmet" title="json">See the result</a></p>
+
+        <h4 id="ordering">Ordering</h4>
+        <p>Default ordering is descending order by <code>-last_modified_time</code>.
+            You may also order results by <code>id</code> and <code>name</code>.
+            For example:</p>
+        <pre><code>image/?sort=name</code></pre>
+        <p><a href="?sort=name" title="json">See the result</a></p>
+    </div>
+</div>


### PR DESCRIPTION
## Description
e.g. https://linkedcomponents-ui-dev.agw.arodevtest.hel.fi/fi/administration/images?text=musiikki calls https://linkedevents-api-dev.agw.arodevtest.hel.fi/v1/image/?page=1&page_size=10&sort=-last_modified_time&text=musiikki&nocache=true to get images filtered by name or image alt text. However the text filtering is not implemented to API so far. Also sorting by id and name are missing.

Purpose of this PR is to implemented those missing features.

PR content:
- Support filtering images by text included in name or alt text
- Allow to sorter images by id and name
- Add documentation for image list endpoint

## Closes
[LINK-348](https://helsinkisolutionoffice.atlassian.net/browse/LINK-348)

[LINK-348]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ