### PR TITLE
LINK-1027 | Fix "some registrations not found" bug

### DIFF
--- a/registrations/tests/test_registration_admin_side.py
+++ b/registrations/tests/test_registration_admin_side.py
@@ -54,6 +54,22 @@ def test_create_registration(api_client, event, has_right_to_edit, expected_stat
     assert response.status_code == expected_status
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    [Event.TypeId.GENERAL, Event.TypeId.COURSE, Event.TypeId.VOLUNTEERING],
+)
+@pytest.mark.django_db
+def test_get_registration(api_client, event, event_type, registration):
+    event.type_id = event_type
+    event.save()
+
+    registration_url = reverse("registration-detail", kwargs={"pk": registration.id})
+    response = api_client.get(registration_url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == registration.id
+
+
 @pytest.mark.django_db
 def test_create_registration__only_one_registration_allowed(api_client, event):
     registration_url = reverse("registration-list")
@@ -311,7 +327,7 @@ def test_signup_age_is_mandatory_if_audience_min_or_max_age_specified(
     if date_of_birth:
         sign_up_data["date_of_birth"] = date_of_birth
 
-    # Crate registration
+    # Create registration
     api_client.force_authenticate(user)
     registration_data = {"event": event.id, "maximum_attendee_capacity": 1}
     if min_age:


### PR DESCRIPTION
## Description
Don't filter registrations by event_type by default. It causes 404 errors when requesting a single registration which has event_type course or volunteering

## Closes
[LINK-1027](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1027)

## Testing
**Producing the bug before the fix:**
1. Create an a new event
2. Create a registrations and use created event in it
3. Change event type of the event to course or volunteering
http://localhost:8080/v1/registration/[id]/ returns 404 error

e.g. https://linkedevents-api-dev.agw.arodevtest.hel.fi/v1/registration/28/?include=signups&nocache=true

[LINK-1027]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ