### PR TITLE
LINK-1250 | Events without registration

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2522,9 +2522,13 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
     # Filter by string (case insensitive). This searches from all fields
     # which are marked translatable in translation.py
 
+    # filter to get events with or without a registration.
     val = params.get("registration", None)
-    if val:
+    if val and parse_bool(val, "registration"):
         queryset = queryset.exclude(registration=None)
+    elif val:
+        queryset = queryset.filter(registration=None)
+
     val = params.get("enrolment_open", None)
     if val:
         queryset = (
@@ -2539,6 +2543,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                 Q(free__gte=1) | Q(registration__maximum_attendee_capacity__isnull=True)
             )
         )
+
     val = params.get("enrolment_open_waitlist", None)
     if val:
         queryset = (
@@ -2558,6 +2563,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                 | Q(registration__waiting_list_capacity__isnull=True)
             )
         )
+
     val = params.get("local_ongoing_text", None)
     if val:
         language = params.get("language", "fi")
@@ -2574,6 +2580,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
             deleted=False,
             local=True,
         )
+
     cache = caches["ongoing_events"]
     val = params.get("local_ongoing_OR", None)
     if val:

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1117,3 +1117,17 @@ def test_private_datasource_events(
     other_data_source.save()
     get_list_and_assert_events("", [event, event3])
     get_list_and_assert_events(f"data_source={other_data_source.id}", [event2])
+
+
+@pytest.mark.django_db
+def test_get_event_list_verify_registration_filter(
+    api_client, event, event2, event3, registration, registration2
+):
+    event.registration = registration
+    event.save()
+    event2.registration = registration2
+    event2.save()
+    event3.registration = None
+    event3.save()
+    get_list_and_assert_events(f"registration=true", [event, event2])
+    get_list_and_assert_events(f"registration=false", [event3])

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -313,5 +313,17 @@ For example:</p>
 For example:</p>
 <pre><code>event/?enrolment_open_waitilist=true</code></pre>
 <p><a href="?enrolment_open_waitilist=true" title="json">See the result</a></p>
+<h3 id="event-registration">Event with registration</h3>
+<p>To find out events with a registration, use the query parameter
+<code>registration</code>.
+<p>Example:</p>
+<pre><code>event/?registration=true</code></pre>
+<p><a href="?registration=true" title="json">See the result</a></p>
+<h3 id="event-without-registration">Event without registration</h3>
+<p>To find out events without a registration, use the query parameter
+<code>registration!</code>.
+<p>Example:</p>
+<pre><code>event/?registration!=true</code></pre>
+<p><a href="?registration!=true" title="json">See the result</a></p>
     </div>
 </div>


### PR DESCRIPTION
## Description
Modify registration parameter to return events with a registration when true, and without a registration when false

## Closes
[LINK-1250](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1250)

[LINK-1250]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ