### PR TITLE
Drop custom mappings and use haystack autocomplete

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3732,7 +3732,7 @@ class SearchViewSet(
 
         queryset = SearchQuerySet()
         if input_val:
-            queryset = queryset.filter(autosuggest=input_val)
+            queryset = queryset.autocomplete(autosuggest=input_val)
         else:
             queryset = queryset.filter(text=AutoQuery(q_val))
 

--- a/events/custom_elasticsearch_search_backend.py
+++ b/events/custom_elasticsearch_search_backend.py
@@ -20,25 +20,10 @@ class CustomEsSearchBackend(Elasticsearch7SearchBackend):
 
     def __init__(self, connection_alias, **connection_options):
         super().__init__(connection_alias, **connection_options)
-        self.custom_mappings = connection_options.get("MAPPINGS")
         settings = connection_options.get("SETTINGS")
         if settings:
             default_settings = self.DEFAULT_SETTINGS["settings"]
             update(default_settings, settings)
-
-    def build_schema(self, fields):
-        content_field_name, mappings = super().build_schema(fields)
-        if not self.custom_mappings:
-            return (content_field_name, mappings)
-
-        for index_fieldname, mapping in self.custom_mappings.items():
-            target = mappings.setdefault(index_fieldname, {})
-            for key, value in mapping.items():
-                if value is None and key in target:
-                    del target[key]
-                else:
-                    target[key] = value
-        return (content_field_name, mappings)
 
     def build_search_kwargs(self, query_string, decay_functions=None, **kwargs):
         kwargs = super().build_search_kwargs(query_string, **kwargs)

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -391,7 +391,6 @@ def haystack_connection_for_lang(language_code):
                 "BASE_ENGINE": "events.custom_elasticsearch_search_backend.CustomEsSearchEngine",
                 "URL": env("ELASTICSEARCH_URL"),
                 "INDEX_NAME": "linkedevents-fi",
-                "MAPPINGS": CUSTOM_MAPPINGS,
                 "SETTINGS": {
                     "analysis": {
                         "analyzer": {
@@ -412,7 +411,6 @@ def haystack_connection_for_lang(language_code):
                 "BASE_ENGINE": "events.custom_elasticsearch_search_backend.CustomEsSearchEngine",
                 "URL": env("ELASTICSEARCH_URL"),
                 "INDEX_NAME": f"linkedevents-{language_code}",
-                "MAPPINGS": CUSTOM_MAPPINGS,
             }
         }
 
@@ -427,15 +425,6 @@ def dummy_haystack_connection_for_lang(language_code):
 
 
 HAYSTACK_SIGNAL_PROCESSOR = "haystack.signals.RealtimeSignalProcessor"
-
-CUSTOM_MAPPINGS = {
-    "autosuggest": {
-        "search_analyzer": "standard",
-        "index_analyzer": "edgengram_analyzer",
-        "analyzer": None,
-    },
-    "text": {"analyzer": "default"},
-}
 
 HAYSTACK_CONNECTIONS = {
     "default": {

--- a/local_settings.py.template
+++ b/local_settings.py.template
@@ -9,14 +9,3 @@ DATABASES = {
         'HOST': 'linkedevents-db'
     }
 }
-
-CUSTOM_MAPPINGS = {
-    'autosuggest': {
-        'search_analyzer': 'standard',
-        'index_analyzer': 'edgengram_analyzer',
-        'analyzer': None
-    },
-    'text': {
-        'analyzer': 'default'
-    }
-}


### PR DESCRIPTION
Tested working on dev, as of writing this branch is running

https://linkedevents-api-dev.agw.arodevtest.hel.fi/v1/search/?input=exit (autocomplete, returns 24 results)
https://linkedevents-api-dev.agw.arodevtest.hel.fi/v1/search/?q=exit (document search, returns 4 results)

Basically this gets rid of the original implementation of CUSTOM_MAPPINGS which was presumably created to support autocomplete. Since this was long time ago in 2014, it's a wee bit unclear why the built-in autocomplete of haystack was not used. The index schema changes slightly with the removal of CUSTOM_MAPPINGS. The text analyzer changes from default to snowball and autosuggest analyzer becomes edgengram_analyzer, and search_analyzer and index_analyzer are no longer defined (not supported anyway since ES 2.0 ( https://web.archive.org/web/20160630190149/https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_mapping_changes.html#_analyzer_mappings )

https://helsinkisolutionoffice.atlassian.net/browse/LINK-1246

