### PR TITLE
LINK-1224 | Replace memcached cache backend with Redis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: flake8
         additional_dependencies: [pep8-naming, flake8-bugbear]
         exclude: "migrations"
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,13 @@ services:
             - postgres-data-volume:/var/lib/postgresql/data
         container_name: linkedevents-db
 
-    memcached:
-        image: memcached:1.6
+    redis:
+        image: redis:7.0
+        volumes:
+            - redis_data:/data
         ports:
-            - "127.0.0.1:11211:11211"
-        container_name: linkedevents-memcached
+            - "127.0.0.1:6379:6379"
+        container_name: linkedevents-redis
 
     django:
         restart: unless-stopped
@@ -37,12 +39,13 @@ services:
             - "8080:8000"
         depends_on:
             - postgres
-            - memcached
+            - redis
         container_name: linkedevents-backend
 
 volumes:
         postgres-data-volume:
         django-media-volume:
+        redis_data:
 
 networks:
     default:

--- a/docker/django/.env.example
+++ b/docker/django/.env.example
@@ -5,6 +5,6 @@ DATABASE_URL=postgis://linkedevents:linkedevents@linkedevents-db/linkedevents
 DEBUG=true
 INSTALL_TEMPLATE=helevents
 MEDIA_ROOT=/var/media/
-MEMCACHED_URL=linkedevents-memcached:11211
+REDIS_URL=redis://linkedevents-redis
 SECRET_KEY=mD0lDi30t3IJ83utHW8yFzV4p3J9SKv0VDSiZQ6wHhdbXPIeHNX2O0YRaPqC8utuDpZpcTAxnZ3n3e6q
 WAIT_FOR_IT_ADDRESS=linkedevents-db:5432

--- a/events/api.py
+++ b/events/api.py
@@ -21,7 +21,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.contrib.postgres.search import SearchQuery, TrigramSimilarity
-from django.core.cache import caches
+from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, F, Prefetch, Q, QuerySet
 from django.db.models.functions import Greatest
@@ -2581,7 +2581,6 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
             local=True,
         )
 
-    cache = caches["ongoing_events"]
     val = params.get("local_ongoing_OR", None)
     if val:
         rc = _terms_to_regex(val, "OR")

--- a/linkedevents/test_settings.py
+++ b/linkedevents/test_settings.py
@@ -21,10 +21,7 @@ for language in [lang[0] for lang in LANGUAGES]:
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    },
-    "ongoing_events": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    },
+    }
 }
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ django-modeltranslation>=0.18.4
 django-mptt>=0.10.0
 django-munigeo>=0.3.8
 django-orghierarchy>=0.1.32
+django-redis
 django-reversion
 django~=3.2
 djangorestframework
@@ -37,7 +38,6 @@ psycopg2-binary
 pyYAML
 python-dateutil
 python-docx
-python-memcached
 pytz
 rdflib==6.1.1
 regex

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ asgiref==3.6.0
     # via django
 asttokens==2.2.1
     # via stack-data
+async-timeout==4.0.2
+    # via redis
 attrs==22.2.0
     # via
     #   -r requirements.in
@@ -59,6 +61,7 @@ django==3.2.18
     #   django-munigeo
     #   django-parler
     #   django-parler-rest
+    #   django-redis
     #   django-reversion
     #   djangorestframework
     #   djangorestframework-bulk
@@ -107,6 +110,8 @@ django-parler==2.3
     #   django-parler-rest
 django-parler-rest==2.2
     # via django-munigeo
+django-redis==5.2.0
+    # via -r requirements.in
 django-reversion==5.0.4
     # via -r requirements.in
 djangorestframework==3.14.0
@@ -217,8 +222,6 @@ python-docx==0.8.11
     # via -r requirements.in
 python-jose==3.3.0
     # via django-helusers
-python-memcached==1.59
-    # via -r requirements.in
 python3-openid==3.2.0
     # via social-auth-core
 pytz==2022.7.1
@@ -233,6 +236,8 @@ pyyaml==6.0
     #   django-munigeo
 rdflib==6.1.1
     # via -r requirements.in
+redis==4.5.3
+    # via django-redis
 regex==2022.10.31
     # via -r requirements.in
 requests==2.28.2
@@ -267,7 +272,6 @@ six==1.16.0
     #   langdetect
     #   pyjwkest
     #   python-dateutil
-    #   python-memcached
     #   social-auth-app-django
     #   social-auth-core
     #   url-normalize


### PR DESCRIPTION
- Add django-redis as a requirement and remove python-memcached
- Replace memcached cache with Redis
- Add REDIS_URL to .env.example
- Add redis container and remove memcached in docker-compose.yml
- Remove separate ongoing_events cache, just use a separate timeout
- Ignore, but log errors related to Redis cache. This is similar
  to memcached in a way that connection error to memcached doesn't
  raise an exception.
- Only enable Redis cache if it's configured, use LocMemCache as default.

Note: Used https://github.com/City-of-Helsinki/kaavapino/blob/development/kaavapino/settings.py#L124 and https://github.com/City-of-Helsinki/kaavoitus-api/blob/development/api_project/settings.py#L174 as examples.