### PR TITLE
LINK-763, LINK-1096 | Replace %xx escapes with their single-character equivalent in id

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1072,7 +1072,7 @@ class KeywordSetSerializer(LinkedEventsSerializer):
     def to_internal_value(self, data):
         # extracting ids from the '@id':'http://testserver/v1/keyword/system:tunnettu_avainsana/' type record
         keyword_ids = [
-            i.get("@id", "").rstrip("/").split("/")[-1]
+            urllib.parse.unquote(i.get("@id", "").rstrip("/").split("/")[-1])
             for i in data.get("keywords", {})
         ]
         self.context["keywords"] = Keyword.objects.filter(id__in=keyword_ids)
@@ -3587,7 +3587,7 @@ class EventViewSet(JSONAPIViewMixin, BulkModelViewSet, viewsets.ReadOnlyModelVie
                 else:
                     event_list = [event.get(key, [])]
                 ids = [
-                    i["@id"].rstrip("/").split("/").pop()
+                    urllib.parse.unquote(i["@id"].rstrip("/").split("/").pop())
                     for i in event_list
                     if i and isinstance(i, dict) and i.get("@id", None)  # noqa E127
                 ]  # noqa E127


### PR DESCRIPTION
## Description
Motivation for this PR is to be able to use e.g. location ids with %xx escapes when creating a new event. See https://helsinkisolutionoffice.atlassian.net/browse/LINK-1096 to see details of the bug

Replace %xx escapes with their single-character equivalent when parsing object ids

## Closes
[LINK-763](https://helsinkisolutionoffice.atlassian.net/browse/LINK-763)
[LINK-1096](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1096)

[LINK-763]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-1096]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ