### PR TITLE
Remove deprecated codecov dependency from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install codecov -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Configure sysctl limits
         run: |


### PR DESCRIPTION
> On April 12, 2023, Codecov removed the codecov package from PyPI. Our intent was to remove a deprecated, rarely-used package from active support.

https://about.codecov.io/blog/message-regarding-the-pypi-package/

This PR fixes the broken CI caused by this.