### PR TITLE
LINK-664 | Support include parameter in registration endpoints

### DIFF
--- a/helcourses/templates/rest_framework/api.html
+++ b/helcourses/templates/rest_framework/api.html
@@ -32,6 +32,8 @@
     {% include "rest_framework/language_list.html" %}
 {% elif name == "Organization List" %}
     {% include "rest_framework/organization_list.html" %}
+{% elif name == "Registration List" %}
+    {% include "rest_framework/registration_list.html" %}
 {% else %}
 {% endif %}
 {% endblock %}

--- a/helevents/templates/rest_framework/api.html
+++ b/helevents/templates/rest_framework/api.html
@@ -33,6 +33,8 @@
     {% include "rest_framework/language_list.html" %}
 {% elif name == "Organization List" %}
     {% include "rest_framework/organization_list.html" %}
+{% elif name == "Registration List" %}
+    {% include "rest_framework/registration_list.html" %}
 {% else %}
 {% endif %}
 {% endblock %}

--- a/helevents/templates/rest_framework/registration_list.html
+++ b/helevents/templates/rest_framework/registration_list.html
@@ -1,0 +1,38 @@
+<div class="panel panel-default">
+    <div class="panel-body">
+        <h2 id="filtering-retrieved-registration">Filtering retrieved registration</h2>
+        <p>Query parameters can be used to filter the retrieved registrations by the following criteria.</p>
+
+        <h3 id="event-text">Event text</h3>
+        <p>To find out registrations that contain a specific string in any of its event's text
+        fields, use the query parameter <code>text</code>.</p>
+        <p>Example:</p>
+        <pre><code>registration/?text=shostakovich</code></pre>
+        <p><a href="?text=shostakovich" title="json">See the result</a></p>
+
+        <h3 id="event-type">Event type</h4>
+        <p>You may use the query parameter <code>event_type</code>, comma separated, to get
+        only registrations with event of specific types.
+        <p>Example:</p>
+        <pre><code>registration/?event_type=course</code></pre>
+        <p><a href="?event_type=course" title="json">See the result</a></p>
+            
+        <h3 id="getting-detailed-data">Getting detailed data</h2>
+        <p>In the default case, event, keywords, locations, and other fields that
+        refer to separate resources are only displayed as simple references.</p>
+        <p>If you want to include the complete data from related resources in
+        the current response, use the keyword <code>include</code>.</p> 
+        <p><strong> Please note, however,
+        that including all the resources inlined in *every* event will result in a huge number
+        of duplicate data in the json, making the json very slow to generate and process and causing
+        considerable API load and long response times when too many such requests are made. Therefore,
+        if you are listing the maximum number of events (100) or updating your cache with all events,
+        please consider caching the keyword and location data separately to prevent unnecessary API
+        slowdown and continuous repeated work. Keyword and location data seldom change and are easily
+        fetched from their own endpoints separately.
+        </strong></p>
+        <p>Example:</p>
+        <pre><code>registration/?include=event,keywords</code></pre>
+        <p><a href="?include=event,keywords" title="json">See the result</a></p>
+    </div>
+</div>

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -153,6 +153,18 @@ class RegistrationViewSet(
         DataSourceResourceEditPermission,
     ]
 
+    def perform_create(self, serializer):
+        # Check object level permissions for event which has the relevant data_source.
+        event = serializer.validated_data.get("event")
+        self.check_object_permissions(self.request, event)
+        super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        # Check object level permissions for event which has the relevant data_source.
+        event = serializer.validated_data.get("event", serializer.instance.event)
+        self.check_object_permissions(self.request, event)
+        super().perform_update(serializer)
+
     def filter_queryset(self, queryset):
         events = Event.objects.exclude(registration=None)
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -123,6 +123,25 @@ class Registration(models.Model):
         verbose_name=_("Mandatory fields"),
     )
 
+    @property
+    def data_source(self):
+        return self.event.data_source
+
+    @property
+    def publisher(self):
+        return self.event.publisher
+
+    def can_be_edited_by(self, user):
+        """Check if current registration can be edited by the given user"""
+        if user.is_superuser:
+            return True
+        return user.is_admin(self.event.publisher)
+
+    def is_user_editable_resources(self):
+        return bool(
+            self.event.data_source and self.event.data_source.user_editable_resources
+        )
+
 
 class SignUp(models.Model):
     class AttendeeStatus:

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -1,0 +1,56 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django_orghierarchy.models import Organization
+
+from events.models import DataSource, Event
+from registrations.models import Registration
+
+
+class TestRegistration(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create(username="testuser")
+
+        self.data_source = DataSource.objects.create(
+            id="ds",
+            name="data-source",
+            api_key="test_api_key",
+            user_editable_resources=True,
+        )
+        self.org = Organization.objects.create(
+            name="org",
+            origin_id="org",
+            data_source=self.data_source,
+        )
+        self.event = Event.objects.create(
+            id="ds:event",
+            name="event",
+            data_source=self.data_source,
+            publisher=self.org,
+        )
+        self.registration = Registration.objects.create(
+            event=self.event,
+        )
+
+    def test_can_be_edited_by_super_user(self):
+        self.user.is_superuser = True
+        self.user.save()
+
+        can_be_edited = self.registration.can_be_edited_by(self.user)
+        self.assertTrue(can_be_edited)
+
+    def test_cannot_be_edited_by_random_user(self):
+        can_be_edited = self.registration.can_be_edited_by(self.user)
+        self.assertFalse(can_be_edited)
+
+    def test_cannot_be_edited_by_regular_user(self):
+        self.org.regular_users.add(self.user)
+
+        can_be_edited = self.registration.can_be_edited_by(self.user)
+        self.assertFalse(can_be_edited)
+
+    def test_can_be_edited_by_admin_user(self):
+        self.org.admin_users.add(self.user)
+
+        can_be_edited = self.registration.can_be_edited_by(self.user)
+        self.assertTrue(can_be_edited)

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -1,0 +1,195 @@
+import pytest
+from rest_framework import status
+
+from events.models import Event
+from events.tests.conftest import APIClient
+from events.tests.test_event_get import get_list_and_assert_events
+from events.tests.utils import versioned_reverse as reverse
+
+# === util methods ===
+
+
+def get_list(api_client: APIClient, query_string: str = None):
+    url = reverse("registration-list")
+
+    if query_string:
+        url = "%s?%s" % (url, query_string)
+
+    return api_client.get(url)
+
+
+def assert_registrations_in_response(
+    registrations: list, response: dict, query: str = ""
+):
+    response_registration_ids = {event["id"] for event in response.data["data"]}
+    expected_registration_ids = {registration.id for registration in registrations}
+    if query:
+        assert (
+            response_registration_ids == expected_registration_ids
+        ), f"\nquery: {query}"
+    else:
+        assert response_registration_ids == expected_registration_ids
+
+
+def get_list_and_assert_registrations(
+    api_client: APIClient, query: str, registrations: list
+):
+    response = get_list(api_client, query_string=query)
+    assert_registrations_in_response(registrations, response, query)
+
+
+def get_detail(api_client: APIClient, pk: str, query: str = None):
+    detail_url = reverse("registration-detail", kwargs={"pk": pk})
+
+    if query:
+        detail_url = "%s?%s" % (detail_url, query)
+
+    return api_client.get(detail_url)
+
+
+def get_detail_and_assert_registration(
+    api_client: APIClient, pk: str, query: str = None
+):
+    response = get_detail(api_client, pk, query)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == pk
+
+    return response
+
+
+# === tests ===
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [Event.TypeId.GENERAL, Event.TypeId.COURSE, Event.TypeId.VOLUNTEERING],
+)
+@pytest.mark.django_db
+def test_get_registration(api_client, event, event_type, registration):
+    event.type_id = event_type
+    event.save()
+
+    get_detail_and_assert_registration(api_client, registration.id)
+
+
+@pytest.mark.django_db
+def test_get_registration_with_event_included(api_client, event, registration):
+    response = get_detail_and_assert_registration(
+        api_client, registration.id, "include=event"
+    )
+    response_event = response.data["event"]
+    assert response_event["id"] == event.id
+    assert list(response_event["name"].values())[0] == event.name
+    assert list(response_event["description"].values())[0] == event.description
+    assert response_event["publisher"] == event.publisher.id
+
+
+@pytest.mark.django_db
+def test_get_registration_with_event_and_location_included(
+    api_client, event, place, registration
+):
+    event.location = place
+    event.save()
+
+    response = get_detail_and_assert_registration(
+        api_client, registration.id, "include=event,location"
+    )
+    response_location = response.data["event"]["location"]
+    assert response_location["id"] == place.id
+    assert list(response_location["name"].values())[0] == place.name
+
+
+@pytest.mark.django_db
+def test_get_registration_with_event_and_keywords_included(
+    api_client, event, keyword, registration
+):
+    event.keywords.add(keyword)
+    event.save()
+
+    response = get_detail_and_assert_registration(
+        api_client, registration.id, "include=event,keywords"
+    )
+    response_keyword = response.data["event"]["keywords"][0]
+    assert response_keyword["id"] == keyword.id
+    assert list(response_keyword["name"].values())[0] == keyword.name
+
+
+@pytest.mark.django_db
+def test_get_registration_with_event_and_in_language_included(
+    api_client, event, languages, registration
+):
+    language = languages[0]
+    event.in_language.add(language)
+    event.save()
+
+    response = get_detail_and_assert_registration(
+        api_client, registration.id, "include=event,in_language"
+    )
+    response_language = response.data["event"]["in_language"][0]
+    assert response_language["id"] == language.id
+
+
+@pytest.mark.django_db
+def test_get_registration_with_event_and_audience_included(
+    api_client, event, keyword, registration
+):
+    event.audience.add(keyword)
+    event.save()
+
+    response = get_detail_and_assert_registration(
+        api_client, registration.id, "include=event,audience"
+    )
+    response_audience = response.data["event"]["audience"][0]
+    assert response_audience["id"] == keyword.id
+    assert list(response_audience["name"].values())[0] == keyword.name
+
+
+@pytest.mark.django_db
+def test_registration_list(
+    api_client, registration, registration2, registration3, registration4
+):
+    get_list_and_assert_registrations(
+        api_client, "", (registration, registration2, registration3, registration4)
+    )
+
+
+@pytest.mark.django_db
+def test_registration_list_admin_user_filter(
+    api_client, registration, registration2, registration3, user
+):
+    api_client.force_authenticate(user)
+
+    get_list_and_assert_registrations(
+        api_client, "", (registration, registration2, registration3)
+    )
+    get_list_and_assert_registrations(
+        api_client, "admin_user=true", (registration, registration3)
+    )
+
+
+@pytest.mark.django_db
+def test_registration_list_event_type_filter(
+    api_client, event, event2, event3, registration, registration2, registration3
+):
+    event.type_id = Event.TypeId.GENERAL
+    event.save()
+    event2.type_id = Event.TypeId.COURSE
+    event2.save()
+    event3.type_id = Event.TypeId.VOLUNTEERING
+    event3.save()
+
+    get_list_and_assert_registrations(
+        api_client, "", (registration, registration2, registration3)
+    )
+    get_list_and_assert_registrations(api_client, "event_type=general", (registration,))
+    get_list_and_assert_registrations(api_client, "event_type=course", (registration2,))
+    get_list_and_assert_registrations(
+        api_client, "event_type=volunteering", (registration3,)
+    )
+
+
+@pytest.mark.django_db
+def test_filter_events_with_registrations(api_client, event, event2, registration):
+    get_list_and_assert_events("", (event, event2), api_client)
+    get_list_and_assert_events("registration=true", (event,), api_client)
+    get_list_and_assert_events("registration=false", (event2,), api_client)

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -1,0 +1,179 @@
+import pytest
+from rest_framework import status
+
+from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.test_registration_admin_side import get_event_url
+
+
+def create_registration(api_client, registration_data, data_source=None):
+    if data_source:
+        api_client.credentials(apikey=data_source.api_key)
+
+    create_url = reverse("registration-list")
+    response = api_client.post(create_url, registration_data, format="json")
+    return response
+
+
+def assert_create_registration(api_client, registration_data, data_source=None):
+    response = create_registration(api_client, registration_data, data_source)
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data["event"] == registration_data["event"]
+
+    return response
+
+
+@pytest.mark.django_db
+def test_create_registration(user, api_client, event):
+    api_client.force_authenticate(user)
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    assert_create_registration(api_client, registration_data)
+
+
+@pytest.mark.django_db
+def test_only_one_registration_per_event_is_allowed(
+    user, api_client, event, registration
+):
+    api_client.force_authenticate(user)
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_cannot_create_registration_with_event_in_invalid_format(
+    api_client, organization, user
+):
+    api_client.force_authenticate(user)
+    registration_data = {"event": "invalid-format"}
+
+    response = create_registration(api_client, registration_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["event"][0] == "Incorrect JSON. Expected JSON, received str."
+
+
+@pytest.mark.django_db
+def test_cannot_create_registration_with_nonexistent_event(
+    api_client, organization, user
+):
+    api_client.force_authenticate(user)
+    registration_data = {"event": {"@id": "nonexistent-id"}}
+
+    response = create_registration(api_client, registration_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test__unauthenticated_user_cannot_create_registration(api_client, event):
+    api_client.force_authenticate(None)
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__non_admin_cannot_create_registration(api_client, event, user):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__user_from_other_organization_cannot_create_registration(
+    api_client, event, user2
+):
+    api_client.force_authenticate(user2)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_datasource_permission_missing(api_client, event, other_data_source, user):
+    event.data_source = other_data_source
+    event.save()
+    api_client.force_authenticate(user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__api_key_with_organization_can_create_registration(
+    api_client, data_source, event, organization
+):
+    data_source.owner = organization
+    data_source.save()
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    assert_create_registration(api_client, registration_data, data_source)
+
+
+@pytest.mark.django_db
+def test__api_key_with_wrong_data_source_cannot_create_registration(
+    api_client, data_source, event, organization, other_data_source
+):
+    other_data_source.owner = organization
+    other_data_source.save()
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    response = create_registration(api_client, registration_data, other_data_source)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__unknown_api_key_cannot_create_keywordset(api_client, event):
+    api_client.credentials(apikey="unknown")
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__empty_api_key_cannot_create_keywordset(api_client, event):
+    api_client.credentials(apikey="")
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__non_user_editable_resources_cannot_create_registration(
+    api_client, data_source, event, organization, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = False
+    data_source.save()
+    api_client.force_authenticate(user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    response = create_registration(api_client, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__user_editable_resources_can_create_registration(
+    api_client, data_source, event, organization, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = True
+    data_source.save()
+    api_client.force_authenticate(user=user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+    assert_create_registration(api_client, registration_data, data_source)

--- a/registrations/tests/test_registration_put.py
+++ b/registrations/tests/test_registration_put.py
@@ -1,0 +1,167 @@
+import pytest
+from rest_framework import status
+
+from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.test_registration_admin_side import get_event_url
+from registrations.tests.test_registration_post import create_registration
+
+# === util methods ===
+
+
+def update_registration(api_client, pk, registration_data, data_source=None):
+    edit_url = reverse("registration-detail", kwargs={"pk": pk})
+
+    if data_source:
+        api_client.credentials(apikey=data_source.api_key)
+
+    response = api_client.put(edit_url, registration_data, format="json")
+    return response
+
+
+def assert_update_registration(api_client, pk, registration_data, data_source=None):
+    response = update_registration(api_client, pk, registration_data, data_source)
+    print(response.data)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == pk
+
+
+# === tests ===
+
+
+@pytest.mark.django_db
+def test__update_registration(api_client, event, user):
+    api_client.force_authenticate(user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
+
+    response = create_registration(api_client, registration_data)
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+
+    assert_update_registration(api_client, response.data["id"], registration_data)
+
+
+@pytest.mark.django_db
+def test__non_admin_cannot_update_registration(api_client, event, registration, user):
+    event.publisher.admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(api_client, registration.id, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__admin_can_update_registration_from_another_data_source(
+    api_client, event2, other_data_source, organization, registration2, user
+):
+    other_data_source.owner = organization
+    other_data_source.user_editable_resources = True
+    other_data_source.save()
+    api_client.force_authenticate(user)
+
+    event2.publisher = organization
+    event2.save()
+
+    registration_data = {
+        "event": {"@id": get_event_url(event2.id)},
+        "audience_max_age": 10,
+    }
+    assert_update_registration(api_client, registration2.id, registration_data)
+
+
+@pytest.mark.django_db
+def test__correct_api_key_can_update_registration(
+    api_client, event, data_source, organization, registration
+):
+    data_source.owner = organization
+    data_source.save()
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    assert_update_registration(
+        api_client, registration.id, registration_data, data_source
+    )
+
+
+@pytest.mark.django_db
+def test__api_key_from_wrong_data_source_cannot_update_registration(
+    api_client, event, organization, other_data_source, registration
+):
+    other_data_source.owner = organization
+    other_data_source.save()
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(
+        api_client, registration.id, registration_data, other_data_source
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__api_key_without_organization_cannot_update_registration(
+    api_client, data_source, event, registration
+):
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(
+        api_client, registration.id, registration_data, data_source
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__unknown_api_key_cannot_update_registration(api_client, event, registration):
+    api_client.credentials(apikey="unknown")
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(api_client, registration.id, registration_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__non_user_editable_resources_cannot_update_registration(
+    api_client, data_source, event, organization, registration, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = False
+    data_source.save()
+    api_client.force_authenticate(user)
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(api_client, registration.id, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__user_editable_resources_can_update_registration(
+    api_client, data_source, event, organization, registration, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = True
+    data_source.save()
+    api_client.force_authenticate(user)
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "audience_max_age": 10,
+    }
+    assert_update_registration(api_client, registration.id, registration_data)

--- a/registrations/tests/test_registration_put.py
+++ b/registrations/tests/test_registration_put.py
@@ -165,3 +165,20 @@ def test__user_editable_resources_can_update_registration(
         "audience_max_age": 10,
     }
     assert_update_registration(api_client, registration.id, registration_data)
+
+
+@pytest.mark.django_db
+def test__admin_cannot_update_registrations_event(
+    api_client, event2, registration, user
+):
+    """Organization admin user cannot update registration's event to an event for
+    which they are not admin.
+    """
+    api_client.force_authenticate(user)
+
+    registration_data = {
+        "event": {"@id": get_event_url(event2.id)},
+        "audience_max_age": 10,
+    }
+    response = update_registration(api_client, registration.id, registration_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
## Description
At the moment UI has to first load registration data and after that event information in separate request. Motivation for this PR is to allow to request event data via registration endpoints

## Closes
[LINK-664](https://helsinkisolutionoffice.atlassian.net/browse/LINK-664)

## Testing
e.g. http://localhost:8080/v1/registration/?include=event,location,keywords,in_language,audience


[LINK-664]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Link to UI PRs: https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/175 and https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/48