### PR TITLE
LINK-1289 | Add registration model to Django admin

### DIFF
--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -1,0 +1,51 @@
+from admin_auto_filters.filters import AutocompleteFilter
+from django.contrib import admin
+from django.utils.translation import ugettext as _
+from reversion.admin import VersionAdmin
+
+from registrations.models import Registration
+
+
+class EventFilter(AutocompleteFilter):
+    title = _("Event")
+    field_name = "event"
+
+
+class RegistrationAdmin(VersionAdmin):
+    fields = (
+        "id",
+        "event",
+        "enrolment_start_time",
+        "enrolment_end_time",
+        "minimum_attendee_capacity",
+        "maximum_attendee_capacity",
+        "waiting_list_capacity",
+        "instructions",
+        "confirmation_message",
+        "audience_min_age",
+        "audience_max_age",
+    )
+    list_display = (
+        "id",
+        "event",
+        "enrolment_start_time",
+        "enrolment_end_time",
+    )
+    list_filter = (EventFilter,)
+    autocomplete_fields = ("event",)
+
+    def save_model(self, request, obj, form, change):
+        if obj.pk is None:
+            obj.created_by = request.user
+        else:
+            obj.last_modified_by = request.user
+        obj.save()
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return ["id", "event"]
+        else:
+            return ["id"]
+
+
+admin.site.register(Registration, RegistrationAdmin)

--- a/registrations/tests/factories.py
+++ b/registrations/tests/factories.py
@@ -1,0 +1,33 @@
+import factory
+
+from events.models import DataSource, Event
+from registrations.models import Registration
+
+
+class DataSourceFactory(factory.django.DjangoModelFactory):
+    id = factory.Sequence(lambda n: "data-source-{0}".format(n))
+
+    class Meta:
+        model = DataSource
+
+
+class OrganizationFactory(factory.django.DjangoModelFactory):
+    data_source = factory.SubFactory(DataSourceFactory)
+
+    class Meta:
+        model = "django_orghierarchy.Organization"
+
+
+class EventFactory(factory.django.DjangoModelFactory):
+    data_source = factory.SubFactory(DataSourceFactory)
+    publisher = factory.SubFactory(OrganizationFactory)
+
+    class Meta:
+        model = Event
+
+
+class RegistrationFactory(factory.django.DjangoModelFactory):
+    event = factory.SubFactory(EventFactory)
+
+    class Meta:
+        model = Registration

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -1,0 +1,79 @@
+from django.contrib import admin
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+
+from registrations.admin import RegistrationAdmin
+from registrations.models import Event, Registration
+from registrations.tests.factories import RegistrationFactory
+
+
+def make_admin(username="testadmin", is_superuser=True):
+    user_model = get_user_model()
+    return user_model.objects.create(
+        username=username, is_staff=True, is_superuser=is_superuser
+    )
+
+
+class TestRegistrationAdmin(TestCase):
+    def setUp(self):
+        self.admin = make_admin()
+        self.site = AdminSite()
+        self.factory = RequestFactory()
+        self.registration = RegistrationFactory()
+
+    def test_registrations_admin_is_registered(self):
+        is_registered = admin.site.is_registered(Registration)
+        self.assertTrue(is_registered)
+
+    def test_readonly_fields(self):
+        registration_admin = RegistrationAdmin(Registration, self.site)
+        request = self.factory.get("/fake-url/")
+        request.user = self.admin
+
+        self.assertEquals(["id"], registration_admin.get_readonly_fields(request))
+        self.assertEquals(
+            ["id", "event"],
+            registration_admin.get_readonly_fields(request, self.registration),
+        )
+
+    def test_change_created_by_when_creating_registration(self):
+        self.client.force_login(self.admin)
+
+        # Create event for new registration
+        data_source = self.registration.event.data_source
+        publisher = self.registration.event.publisher
+        event2 = Event.objects.create(
+            id="event-2", data_source=data_source, publisher=publisher
+        )
+
+        # Create new registration
+        self.client.post(
+            "/admin/registrations/registration/add/",
+            {"event": event2.id, "_save": "Save"},
+        )
+
+        # Test that create_by values is set to current user
+        registration = Registration.objects.get(event=event2)
+        self.assertEquals(
+            self.admin,
+            registration.created_by,
+        )
+
+    def test_change_last_modified_by_when_updating_registration(self):
+        ra = RegistrationAdmin(Registration, self.site)
+        request = self.factory.get("/fake-url/")
+        request.user = self.admin
+
+        # Update registration
+        ra.save_model(
+            request,
+            self.registration,
+            form=ra.get_form(None),
+            change=ra.get_action("change"),
+        )
+        # Test that last_modified_by values is set to current user
+        self.assertEquals(
+            self.admin,
+            self.registration.last_modified_by,
+        )


### PR DESCRIPTION
## Description
Add registration model to Django admin

## Closes
[LINK-1289](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1289)

## Additional info
This PR and https://github.com/City-of-Helsinki/linkedevents/pull/575 will replace https://github.com/City-of-Helsinki/linkedevents/pull/565 which contains several separate features

[LINK-1289]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ