### PR TITLE
LINK-1147 | Bump django-orghierachy to get Open Ahjo importer

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -90,7 +90,7 @@ pathspec==0.11.0
     # via black
 pep8-naming==0.13.3
     # via -r requirements-dev.in
-pip-tools==6.12.1
+pip-tools==6.13.0
     # via -r requirements-dev.in
 platformdirs==3.1.0
     # via
@@ -172,7 +172,7 @@ urllib3==1.26.14
     #   requests
 werkzeug==2.2.3
     # via -r requirements-dev.in
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ django-leaflet
 django-modeltranslation>=0.18.4
 django-mptt>=0.10.0
 django-munigeo>=0.3.8
-django-orghierarchy>=0.1.32
+django-orghierarchy
 django-redis
 django-reversion
 django~=3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,7 @@ django==3.2.18
     #   django-leaflet
     #   django-modeltranslation
     #   django-munigeo
+    #   django-orghierarchy
     #   django-parler
     #   django-parler-rest
     #   django-redis
@@ -102,7 +103,7 @@ django-mptt==0.14.0
     #   django-orghierarchy
 django-munigeo==0.3.8
     # via -r requirements.in
-django-orghierarchy==0.1.32
+django-orghierarchy==0.2.0
     # via -r requirements.in
 django-parler==2.3
     # via


### PR DESCRIPTION
Latest django-orghierarchy can import organizations from Open Ahjo API.

Example for using this importer:

```bash
python manage.py import_organizations https://dev.hel.fi/paatokset/v1/organization/?limit=1000 -c openahjo -s OpenAhjoAPI:ahjo
```