### PR TITLE
LINK-1271 | Endpoint to send message to all or selected registration signups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
 
     postgres:
+        platform: linux/amd64
         build:
             context: ./
             dockerfile: ./docker/postgres/Dockerfile
@@ -25,6 +26,7 @@ services:
         container_name: linkedevents-redis
 
     django:
+        platform: linux/amd64
         restart: unless-stopped
         build:
             context: ./

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -327,7 +327,7 @@ class RegistrationViewSet(
         try:
             send_mass_html_mail(messages, fail_silently=False)
         except SMTPException as e:
-            logger.error(e, exc_info=True)
+            logger.exception("Couldn't send mass HTML email.")
 
             return Response(
                 str(e),

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -282,16 +282,9 @@ class RegistrationViewSet(
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
 
-        # Get validated signup_ids from serializer.validated_data
-        signup_ids = serializer.validated_data.get("signups", None)
-
-        # Send message to defined signups if signups attribute is defined
-        # By default send message to all signups
-        if signup_ids:
-            signups = registration.signups.filter(pk__in=[i for i in signup_ids])
-        else:
-            signups = registration.signups.all()
-        signups.exclude(email=None)
+        signups = serializer.validated_data.get(
+            "signups", registration.signups.exclude(email=None)
+        )
 
         messages = []
         body = serializer.validated_data["body"]

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -341,6 +341,7 @@ class RegistrationViewSet(
                 "body": cleaned_body,
                 "cancellation_code": signup.cancellation_code,
                 "registration_id": registration.id,
+                "signup_id": signup.id,
             }
             rendered_body = render_to_string("message_to_signup.html", email_variables)
             message = (

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -326,9 +326,9 @@ class RegistrationViewSet(
 
         return Response(
             {
-                "emails": [su.email for su in signups],
                 "html_message": cleaned_body,
                 "message": plain_text_body,
+                "signups": [su.id for su in signups],
                 "subject": subject,
             },
             status=status.HTTP_200_OK,

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -164,3 +164,28 @@ class SeatReservationCodeSerializer(serializers.ModelSerializer):
 
     def get_expiration(self, obj):
         return obj.timestamp + timedelta(minutes=code_validity_duration(obj.seats))
+
+
+class MassEmailSerializer(serializers.Serializer):
+    subject = serializers.CharField()
+    body = serializers.CharField()
+    signups = serializers.ListField(
+        child=serializers.CharField(), allow_empty=False, required=False
+    )
+
+    def validate_signups(self, value):
+        registration = self.initial_data["registration"]
+        if value and self.context["request"].method == "POST":
+            signup_ids = [str(signup.id) for signup in registration.signups.all()]
+            errors = {}
+            for idx, id in enumerate(value):
+                if id not in signup_ids:
+                    errors[idx] = [
+                        _("Registration doesn't have signup with id {id}.").format(
+                            id=id
+                        )
+                    ]
+            if errors:
+                raise serializers.ValidationError(errors)
+
+        return value

--- a/registrations/templates/message_to_signup.html
+++ b/registrations/templates/message_to_signup.html
@@ -1,0 +1,20 @@
+{% extends 'base_email.html' %}
+{% load i18n %}
+
+{% block content %}
+  <tr>
+    <td class="content-cell" style="padding:0;margin:0;text-align:left;">
+      <div class="content-container" style="padding:0 16px;">
+        <div style="margin: 0px 0px 40px">
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">{{body |safe}}</p>
+        </div>
+        <div class="cta-button-wrapper" style="margin: 0px 0px 40px">
+          <a href="http://localhost:3001/fi/registration/{{registration_id}}/enrolment/{{cancellation_code}}/edit" target="_blank" rel="noopener" class="cta-button" style="background:#0000bf;border-radius:0px;border:none;height:56px;text-align:center;text-decoration:none;vertical-align:middle;padding:16px 24px;box-sizing:border-box;display:inline-block;">
+            <span style="color:#ffffff;font-size:16px;font-weight:500;line-height:24px;">{% blocktranslate %}Tarkastele ilmoittautumistasi täällä{% endblocktranslate %}</span>
+            <img alt="" aria-hidden="true" src="{{linked_events_ui_url}}/images/email/icon-arrow-right-white.png" style="height:24px;width:24px;margin-left:16px;vertical-align:top;" />
+          </a>
+        </div>
+      </div>
+    </td>
+  </tr>
+{% endblock content %}

--- a/registrations/templates/message_to_signup.html
+++ b/registrations/templates/message_to_signup.html
@@ -9,7 +9,7 @@
           <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">{{body |safe}}</p>
         </div>
         <div class="cta-button-wrapper" style="margin: 0px 0px 40px">
-          <a href="http://localhost:3001/fi/registration/{{registration_id}}/enrolment/{{cancellation_code}}/edit" target="_blank" rel="noopener" class="cta-button" style="background:#0000bf;border-radius:0px;border:none;height:56px;text-align:center;text-decoration:none;vertical-align:middle;padding:16px 24px;box-sizing:border-box;display:inline-block;">
+          <a href="{{linked_registrations_ui_url}}/fi/registration/{{registration_id}}/enrolment/{{signup_id}}/{{cancellation_code}}/edit" target="_blank" rel="noopener" class="cta-button" style="background:#0000bf;border-radius:0px;border:none;height:56px;text-align:center;text-decoration:none;vertical-align:middle;padding:16px 24px;box-sizing:border-box;display:inline-block;">
             <span style="color:#ffffff;font-size:16px;font-weight:500;line-height:24px;">{% blocktranslate %}Tarkastele ilmoittautumistasi täällä{% endblocktranslate %}</span>
             <img alt="" aria-hidden="true" src="{{linked_events_ui_url}}/images/email/icon-arrow-right-white.png" style="height:24px;width:24px;margin-left:16px;vertical-align:top;" />
           </a>

--- a/registrations/tests/conftest.py
+++ b/registrations/tests/conftest.py
@@ -1,2 +1,19 @@
 from events.tests.conftest import *  # noqa
 from linkedevents.tests.conftest import *  # noqa
+from registrations.models import SignUp
+
+
+@pytest.fixture
+def signup(registration):
+    return SignUp.objects.create(
+        registration=registration,
+        email="test@test.com",
+    )
+
+
+@pytest.fixture
+def signup2(registration):
+    return SignUp.objects.create(
+        registration=registration,
+        email="test2@test.com",
+    )

--- a/registrations/tests/conftest.py
+++ b/registrations/tests/conftest.py
@@ -17,3 +17,11 @@ def signup2(registration):
         registration=registration,
         email="test2@test.com",
     )
+
+
+@pytest.fixture
+def signup3(registration):
+    return SignUp.objects.create(
+        registration=registration,
+        email="test3@test.com",
+    )

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -28,6 +28,8 @@ def assert_send_message(
         assert mail.outbox[idx].body == send_message_data["body"]
         assert mail.outbox[idx].from_email == settings.SUPPORT_EMAIL
         assert [email] in valid_emails
+    
+    return response
 
 
 @pytest.mark.django_db
@@ -79,7 +81,8 @@ def test_send_message_to_selected_signups(
         "signups": [signup.id],
     }
 
-    assert_send_message(api_client, registration.id, send_message_data, [signup.email])
+    response = assert_send_message(api_client, registration.id, send_message_data, [signup.email])
+    assert response.data["signups"] == [signup.id]
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -1,0 +1,224 @@
+import pytest
+from django.conf import settings
+from django.core import mail
+from rest_framework import status
+
+from events.tests.utils import versioned_reverse as reverse
+
+
+def send_message(api_client, registration_id, send_message_data):
+    send_message_url = reverse(
+        "registration-send-message", kwargs={"pk": registration_id}
+    )
+    response = api_client.post(send_message_url, send_message_data, format="json")
+
+    return response
+
+
+def assert_send_message(
+    api_client, registration_id, send_message_data, expected_emails
+):
+    response = send_message(api_client, registration_id, send_message_data)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == len(expected_emails)
+    valid_emails = [mail.to for mail in mail.outbox]
+    for idx, email in enumerate(expected_emails):
+        assert mail.outbox[idx].subject == send_message_data["subject"]
+        assert mail.outbox[idx].body == send_message_data["body"]
+        assert mail.outbox[idx].from_email == settings.SUPPORT_EMAIL
+        assert [email] in valid_emails
+
+
+@pytest.mark.django_db
+def test_admin_user_can_send_message_to_all_signups(
+    api_client, registration, signup, signup2, user
+):
+    api_client.force_authenticate(user)
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    assert_send_message(
+        api_client, registration.id, send_message_data, [signup.email, signup2.email]
+    )
+
+
+@pytest.mark.parametrize(
+    "required_field",
+    [
+        "subject",
+        "body",
+    ],
+)
+@pytest.mark.django_db
+def test_required_fields_has_to_be_filled(
+    api_client, registration, required_field, signup, signup2, user
+):
+    api_client.force_authenticate(user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    assert_send_message(
+        api_client, registration.id, send_message_data, [signup.email, signup2.email]
+    )
+
+    send_message_data[required_field] = ""
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert str(response.data[required_field]) == "This field must be specified."
+
+
+@pytest.mark.django_db
+def test_send_message_to_selected_signups(
+    api_client, registration, signup, signup2, user
+):
+    api_client.force_authenticate(user)
+    send_message_data = {
+        "subject": "Message subject",
+        "body": "Message body",
+        "signups": [signup.id],
+    }
+
+    assert_send_message(api_client, registration.id, send_message_data, [signup.email])
+
+
+@pytest.mark.django_db
+def test_cannot_send_message_with_nonexistent_registration_id(
+    api_client, organization, user
+):
+    api_client.force_authenticate(user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, "nonexistent-id", send_message_data)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test__unauthenticated_user_cannot_send_message(api_client, registration):
+    api_client.force_authenticate(None)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__non_admin_cannot_send_message(api_client, registration, user):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__user_from_other_organization_cannot_send_message(
+    api_client, registration, user2
+):
+    api_client.force_authenticate(user2)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_cannot_send_message_if_missing_datasource_permission(
+    api_client, other_data_source, registration, user
+):
+    registration.event.data_source = other_data_source
+    registration.event.save()
+    api_client.force_authenticate(user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__api_key_with_organization_can_send_message(
+    api_client, data_source, organization, registration, signup, signup2
+):
+    data_source.owner = organization
+    data_source.save()
+    api_client.credentials(apikey=data_source.api_key)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    assert_send_message(
+        api_client, registration.id, send_message_data, [signup.email, signup2.email]
+    )
+
+
+@pytest.mark.django_db
+def test__api_key_with_wrong_data_source_cannot_send_message(
+    api_client, organization, other_data_source, registration
+):
+    other_data_source.owner = organization
+    other_data_source.save()
+
+    api_client.credentials(apikey=other_data_source.api_key)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__unknown_api_key_cannot_send_message(api_client, registration):
+    api_client.credentials(apikey="unknown")
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__empty_api_key_cannot_send_message(api_client, registration):
+    api_client.credentials(apikey="")
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test__non_user_editable_resources_cannot_send_message(
+    api_client, data_source, organization, registration, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = False
+    data_source.save()
+    api_client.force_authenticate(user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    response = send_message(api_client, registration.id, send_message_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test__user_editable_resources_can_create_registration(
+    api_client, data_source, organization, registration, signup, signup2, user
+):
+    data_source.owner = organization
+    data_source.user_editable_resources = True
+    data_source.save()
+    api_client.force_authenticate(user=user)
+
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    assert_send_message(
+        api_client, registration.id, send_message_data, [signup.email, signup2.email]
+    )

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -28,7 +28,7 @@ def assert_send_message(
         assert mail.outbox[idx].body == send_message_data["body"]
         assert mail.outbox[idx].from_email == settings.SUPPORT_EMAIL
         assert [email] in valid_emails
-    
+
     return response
 
 
@@ -72,17 +72,19 @@ def test_required_fields_has_to_be_filled(
 
 @pytest.mark.django_db
 def test_send_message_to_selected_signups(
-    api_client, registration, signup, signup2, user
+    api_client, registration, signup, signup2, signup3, user
 ):
     api_client.force_authenticate(user)
     send_message_data = {
         "subject": "Message subject",
         "body": "Message body",
-        "signups": [signup.id],
+        "signups": [signup.id, signup3.id],
     }
 
-    response = assert_send_message(api_client, registration.id, send_message_data, [signup.email])
-    assert response.data["signups"] == [signup.id]
+    response = assert_send_message(
+        api_client, registration.id, send_message_data, [signup.email, signup3.email]
+    )
+    assert response.data["signups"] == [signup.id, signup3.id]
 
 
 @pytest.mark.django_db

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -1,5 +1,35 @@
 from django.conf import settings
+from django.core.mail import EmailMultiAlternatives, get_connection
 
 
 def code_validity_duration(seats):
     return settings.SEAT_RESERVATION_DURATION + seats
+
+
+def send_mass_html_mail(
+    datatuple,
+    fail_silently=False,
+    auth_user=None,
+    auth_password=None,
+    connection=None,
+):
+    """
+    django.core.mail.send_mass_mail doesn't support sending html mails,
+
+    This method duplicates send_mass_mail except requires html_message for each message
+    and adds html alternative to each mail
+    """
+    connection = connection or get_connection(
+        username=auth_user,
+        password=auth_password,
+        fail_silently=fail_silently,
+    )
+    messages = []
+    for subject, message, html_message, from_email, recipient_list in datatuple:
+        mail = EmailMultiAlternatives(
+            subject, message, from_email, recipient_list, connection=connection
+        )
+        mail.attach_alternative(html_message, "text/html")
+        messages.append(mail)
+
+    return connection.send_messages(messages)


### PR DESCRIPTION
## Description

- Endpoint to send an email message to all or selected signups.
- Email uses Linked Registration email template for styling
- Email subject and body are required fields.
- User can send email to all signups of the registration by leaving signups attribute empty or send the email to selected signups

## Closes
[LINK-1271](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1271)

## Example request:
POST http://linkedevents-backend:8080/v1/registration/2/send_message/
```
{
    "body":"<p>Message1</p><p>Message2</p>",
    "subject": "MESSAGE SUBJECT",
    "signups": [2]
}
```

## Additional note
PR for FE: https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/180

[LINK-1271]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ