### PR TITLE
LINK-1306 | Define platform for postgres and django services in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
 
     postgres:
+        platform: linux/amd64
         build:
             context: ./
             dockerfile: ./docker/postgres/Dockerfile
@@ -25,6 +26,7 @@ services:
         container_name: linkedevents-redis
 
     django:
+        platform: linux/amd64
         restart: unless-stopped
         build:
             context: ./


### PR DESCRIPTION
## Description
`docker compose build` command returns  `no match for platform in manifest` error. The problem occurs at least with macOS 13.2.1 
Use `linux/amd64` as platform for postgres and django services in docker-compose.yml to fix the problem

## Closes
[LINK-1306](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1306)

## Screenshots
<img width="1153" alt="Screenshot 2023-05-04 at 14 41 57" src="https://user-images.githubusercontent.com/24706814/236194746-63f9ad5c-45a3-48e1-910a-d6eb12b89325.png">

<img width="697" alt="Screenshot 2023-05-04 at 14 44 27" src="https://user-images.githubusercontent.com/24706814/236194864-7f7d6442-a91c-4d27-b0b8-8c876163b3d9.png">



[LINK-1306]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ