### PR TITLE
LINK-1172 | Allow searching multiple event statuses in API

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3026,15 +3026,19 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
         queryset = queryset.filter(publication_status=PublicationStatus.PUBLIC)
 
     # Filter by event status
-    val = params.get("event_status", None)
-    if val and val.lower() == "eventscheduled":
-        queryset = queryset.filter(event_status=Event.Status.SCHEDULED)
-    elif val and val.lower() == "eventrescheduled":
-        queryset = queryset.filter(event_status=Event.Status.RESCHEDULED)
-    elif val and val.lower() == "eventcancelled":
-        queryset = queryset.filter(event_status=Event.Status.CANCELLED)
-    elif val and val.lower() == "eventpostponed":
-        queryset = queryset.filter(event_status=Event.Status.POSTPONED)
+    if status_param := params.get("event_status"):
+        statuses = []
+        for value in (s.lower() for s in status_param.split(",")):
+            if value == "eventscheduled":
+                statuses.append(Event.Status.SCHEDULED)
+            elif value == "eventrescheduled":
+                statuses.append(Event.Status.RESCHEDULED)
+            elif value == "eventcancelled":
+                statuses.append(Event.Status.CANCELLED)
+            elif value == "eventpostponed":
+                statuses.append(Event.Status.POSTPONED)
+
+        queryset = queryset.filter(event_status__in=statuses)
 
     # Filter by language, checking both string content and in_language field
     val = params.get("language", None)

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -578,6 +578,14 @@ def test_event_status_filter(
     get_list_and_assert_events("event_status=eventrescheduled", [event2])
     get_list_and_assert_events("event_status=eventcancelled", [event3])
     get_list_and_assert_events("event_status=eventpostponed", [event4])
+    get_list_and_assert_events(
+        "event_status=eventscheduled,eventpostponed",
+        [event, event4],
+    )
+    get_list_and_assert_events(
+        "event_status=eventscheduled,eventrescheduled,eventcancelled,eventpostponed",
+        [event, event2, event3, event4],
+    )
 
 
 @pytest.mark.django_db

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -203,6 +203,11 @@
         <pre><code>event/?event_status=EventCancelled</code></pre>
         <p><a href="?event_status=EventCancelled" title="json">See the result</a></p>
 
+        <p>It is also possible to use multiple <code>event_status</code> parameters in a single query.
+            Statuses must be separated by a comma.</p>
+        <p>Example:</p>
+        <pre><code>event/?event_status=EventCancelled,EventPostponed</code></pre>
+
         <h3 id="event-type">Event type</h3>
         <p>Events in Linkedevents (indicated by the <code>type_id</code> field) may be event (<code>General</code>),
              course (<code>Course</code>) or volunteering (<code>Volunteering</code>). By default, only events


### PR DESCRIPTION
# Description

Allows passing multiple parameters to `event_status` -field separated by a comma. Returns events that match any of the given statuses. i.e. `?event_status=EventCancelled,EventRescheduled`

## Closes
[LINK-1172](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1172)


[LINK-1172]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ