### PR TITLE
LINK-1320 | Fix event keyword_set_OR filter

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2666,6 +2666,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
         for keyword_set in keyword_sets:
             keywords = keyword_set.keywords.all()
             all_keywords.update(keywords)
+        queryset = queryset.filter(keywords__in=all_keywords)
 
     if "local_ongoing_OR_set" in "".join(params):
         count = 1

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -986,24 +986,27 @@ def test_keywordset_search(
     keyword_set,
     keyword_set2,
 ):
-    event.keywords.add(keyword, keyword3)
+    keyword_set.keywords.set([keyword])
+    keyword_set.save()
+    keyword_set2.keywords.set([keyword2])
+    keyword_set.save()
+
+    event.keywords.set([keyword, keyword3])
     event.save()
-    event2.keywords.add(keyword2, keyword3)
+    event2.keywords.set([keyword2, keyword3])
     event2.save()
-    event3.keywords.add(keyword, keyword2)
+    event3.keywords.set([keyword, keyword2])
     event3.save()
 
+    get_list_and_assert_events(f"keyword_set_AND={keyword_set.id}", [event, event3])
+    get_list_and_assert_events(f"keyword_set_AND={keyword_set2.id}", [event2, event3])
     get_list_and_assert_events(
-        f"keyword_set_AND={keyword_set.id},{keyword_set2.id}", [event, event2]
+        f"keyword_set_AND={keyword_set.id},{keyword_set2.id}", [event3]
     )
+    get_list_and_assert_events(f"keyword_set_OR={keyword_set.id}", [event, event3])
+    get_list_and_assert_events(f"keyword_set_OR={keyword_set2.id}", [event2, event3])
     get_list_and_assert_events(
         f"keyword_set_OR={keyword_set.id},{keyword_set2.id}", [event, event2, event3]
-    )
-
-    event3.keywords.remove(keyword, keyword2)
-    event3.save()
-    get_list_and_assert_events(
-        f"keyword_set_AND={keyword_set.id},{keyword_set2.id}", [event, event2]
     )
 
 


### PR DESCRIPTION
## Description
queryset.filter was never called when handling keyword_set_OR filter. Added queryset.filter to the end of that parameter handling.

## Closes
[LINK-1320](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1320)

[LINK-1320]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ