### PR TITLE
LINK-1164: Allow event creation, modifying and deleting for external users

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3572,7 +3572,7 @@ class EventViewSet(
 
     def perform_destroy(self, instance):
         if not self.request.user.can_edit_event(
-            instance.publisher, instance.publication_status
+            instance.publisher, instance.publication_status, instance.created_by
         ):
             raise DRFPermissionDenied()
         instance.soft_delete()

--- a/events/api.py
+++ b/events/api.py
@@ -98,6 +98,7 @@ from events.permissions import (
     GuestPost,
     GuestRetrieve,
     UserIsAdminInAnyOrganization,
+    OrganizationUserEditPermission,
 )
 from events.renderers import DOCXRenderer
 from events.translation import (
@@ -908,7 +909,9 @@ class KeywordViewSet(
     queryset = Keyword.objects.all()
     queryset = queryset.select_related("publisher")
     serializer_class = KeywordSerializer
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
@@ -951,7 +954,9 @@ class KeywordListViewSet(
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ("n_events", "id", "name", "data_source")
     ordering = ("-data_source", "-n_events", "name")
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
 
     def get_queryset(self):
         """
@@ -1099,7 +1104,9 @@ class KeywordSetViewSet(
 ):
     queryset = KeywordSet.objects.all()
     serializer_class = KeywordSetSerializer
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
     permit_regular_user_edit = True
 
     def filter_queryset(self, queryset):
@@ -1296,7 +1303,9 @@ class PlaceRetrieveViewSet(
     queryset = Place.objects.all()
     queryset = queryset.select_related("publisher")
     serializer_class = PlaceSerializer
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -1359,7 +1368,9 @@ class PlaceListViewSet(
         "-data_source",
         "name",
     )  # we want to display tprek before osoite etc.
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
 
     def get_queryset(self):
         """
@@ -1825,7 +1836,9 @@ class ImageViewSet(
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ("last_modified_time", "id", "name")
     ordering = ("-last_modified_time",)
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
+    ]
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -3259,7 +3272,9 @@ class EventViewSet(
     )
     ordering = ("-last_modified_time",)
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [DOCXRenderer]
-    permission_classes = (DataSourceResourceEditPermission,)
+    permission_classes = [
+        OrganizationUserEditPermission & DataSourceResourceEditPermission
+    ]
     permit_regular_user_edit = True
 
     @staticmethod

--- a/events/api.py
+++ b/events/api.py
@@ -1573,7 +1573,7 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
 
     def get_regular_users(self, obj):
         user = self.context["user"]
-        if not isinstance(user, AnonymousUser) and user.is_admin(obj):
+        if not isinstance(user, AnonymousUser) and user.is_admin_of(obj):
             return UserSerializer(
                 obj.regular_users.all(), read_only=True, many=True
             ).data
@@ -1582,7 +1582,7 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
 
     def get_admin_users(self, obj):
         user = self.context["user"]
-        if not isinstance(user, AnonymousUser) and user.is_admin(obj):
+        if not isinstance(user, AnonymousUser) and user.is_admin_of(obj):
             return UserSerializer(obj.admin_users.all(), read_only=True, many=True).data
         else:
             return []

--- a/events/auth.py
+++ b/events/auth.py
@@ -5,8 +5,7 @@ from django_orghierarchy.models import Organization
 from rest_framework import authentication, exceptions
 
 from events.models import DataSource
-
-from .permissions import UserModelPermissionMixin
+from helevents.models import UserModelPermissionMixin
 
 
 class ApiKeyAuthentication(authentication.BaseAuthentication):

--- a/events/auth.py
+++ b/events/auth.py
@@ -1,33 +1,12 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 from django_orghierarchy.models import Organization
-from helusers.oidc import ApiTokenAuthentication
 from rest_framework import authentication, exceptions
 
 from events.models import DataSource
 
 from .permissions import UserModelPermissionMixin
-from .utils import get_or_create_default_organization
-
-
-class LinkedEventsApiOidcAuthentication(ApiTokenAuthentication):
-    def authenticate(self, request):
-        auth = super().authenticate(request)
-        user = auth[0] if auth else None
-
-        if (
-            user
-            and settings.ENABLE_USER_DEFAULT_ORGANIZATION
-            and settings.USER_DEFAULT_ORGANIZATION_ID
-            and not user.organization_memberships.exists()
-            and not user.admin_organizations.exists()
-        ):
-            if org := get_or_create_default_organization():
-                user.organization_memberships.add(org)
-
-        return auth
 
 
 class ApiKeyAuthentication(authentication.BaseAuthentication):

--- a/events/auth.py
+++ b/events/auth.py
@@ -55,10 +55,10 @@ class ApiKeyUser(get_user_model(), UserModelPermissionMixin):
     def get_default_organization(self):
         return self.data_source.owner
 
-    def is_admin(self, publisher):
+    def is_admin_of(self, publisher):
         return publisher in self.data_source.owner.get_descendants(include_self=True)
 
-    def is_regular_user(self, publisher):
+    def is_regular_user_of(self, publisher):
         return False
 
     @property

--- a/events/models.py
+++ b/events/models.py
@@ -136,7 +136,9 @@ class BaseQuerySet(models.QuerySet):
         if user.is_superuser:
             return True
         for event in self:
-            if not user.can_edit_event(event.publisher, event.publication_status):
+            if not user.can_edit_event(
+                event.publisher, event.publication_status, event.created_by
+            ):
                 return False
         return True
 

--- a/events/models.py
+++ b/events/models.py
@@ -264,15 +264,15 @@ class Image(models.Model):
 
     def can_be_edited_by(self, user):
         """Check if current image can be edited by the given user"""
-        if user.is_superuser or user.is_regular_user(self.publisher):
+        if user.is_superuser or user.is_regular_user_of(self.publisher):
             return True
-        return user.is_admin(self.publisher)
+        return user.is_admin_of(self.publisher)
 
     def can_be_deleted_by(self, user):
         """Check if current image can be deleted by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.publisher)
+        return user.is_admin_of(self.publisher)
 
 
 class ImageMixin(models.Model):
@@ -489,7 +489,7 @@ class Keyword(BaseModel, ImageMixin, ReplacedByMixin):
         """Check if current keyword can be edited by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.publisher)
+        return user.is_admin_of(self.publisher)
 
     class Meta:
         verbose_name = _("keyword")
@@ -533,7 +533,7 @@ class KeywordSet(BaseModel, ImageMixin):
         """Check if current keyword set can be edited by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.organization)
+        return user.is_admin_of(self.organization)
 
     def save(self, *args, **kwargs):
         if any([keyword.deprecated for keyword in self.keywords.all()]):
@@ -690,7 +690,7 @@ class Place(MPTTModel, BaseModel, SchemalessFieldMixin, ImageMixin, ReplacedByMi
         """Check if current place can be edited by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.publisher)
+        return user.is_admin_of(self.publisher)
 
 
 reversion.register(Place)
@@ -1031,7 +1031,7 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         if user.is_superuser:
             return True
         else:
-            return user.is_admin(self.publisher)
+            return user.is_admin_of(self.publisher)
 
     def can_be_edited_by(self, user):
         """Check if current event can be edited by the given user"""

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -6,6 +6,8 @@ from rest_framework.request import Request
 
 from events import utils
 
+from .auth import ApiKeyUser
+
 
 class GuestPost(BasePermission):
     def has_permission(self, request, view):
@@ -81,11 +83,6 @@ class DataSourceResourceEditPermission(IsAuthenticatedOrReadOnly):
         if request.method != "POST":
             return True
 
-        return self._has_data_source_permission_without_obj(request, view)
-
-    def _has_data_source_permission_without_obj(self, request, view):
-        from .auth import ApiKeyUser
-
         user_data_source, __ = utils.get_user_data_source_and_organization_from_request(
             request
         )
@@ -96,8 +93,9 @@ class DataSourceResourceEditPermission(IsAuthenticatedOrReadOnly):
 
         return True
 
-    def _has_data_source_permission_with_obj(self, request, view, obj):
-        from .auth import ApiKeyUser
+    def has_object_permission(self, request: Request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
 
         user_data_source, __ = utils.get_user_data_source_and_organization_from_request(
             request
@@ -115,12 +113,6 @@ class DataSourceResourceEditPermission(IsAuthenticatedOrReadOnly):
                 raise PermissionDenied(_("Data source is not editable"))
 
         return True
-
-    def has_object_permission(self, request: Request, view, obj):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        return self._has_data_source_permission_with_obj(request, view, obj)
 
 
 class DataSourceOrganizationEditPermission(IsAuthenticatedOrReadOnly):

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -56,10 +56,10 @@ class IsObjectEditableByOrganizationUser(BasePermission):
         )
         return (
             user.is_superuser
-            or user.is_admin(user_organization)
+            or user.is_admin_of(user_organization)
             or (
                 view_permits_regular_user_edit
-                and user.is_regular_user(user_organization)
+                and user.is_regular_user_of(user_organization)
             )
         )
 

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -1,88 +1,10 @@
-from functools import reduce
-
 from django.utils.translation import gettext as _
-from django_orghierarchy.models import Organization
 from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import BasePermission, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 
-from .models import PublicationStatus
-
-
-class UserModelPermissionMixin:
-    """Permission mixin for user models
-
-    A mixin class that provides permission check methods
-    for user models.
-    """
-
-    def is_admin(self, publisher):
-        """Check if current user is an admin user of the publisher organization"""
-        raise NotImplementedError()
-
-    def is_regular_user(self, publisher):
-        """Check if current user is a regular user of the publisher organization"""
-        raise NotImplementedError()
-
-    @property
-    def admin_organizations(self):
-        raise NotImplementedError()
-
-    @property
-    def organization_memberships(self):
-        raise NotImplementedError()
-
-    def can_edit_event(self, publisher, publication_status):
-        """Check if current user can edit (create, change, modify)
-        event with the given publisher and publication_status"""
-        if self.is_admin(publisher):
-            return True
-        if (
-            self.is_regular_user(publisher)
-            and publication_status == PublicationStatus.DRAFT
-        ):
-            return True
-        return False
-
-    def get_editable_events(self, queryset):
-        """Get editable events queryset from given queryset for current user"""
-        # distinct is not needed here, as admin_orgs and memberships should not overlap
-        return queryset.filter(
-            publisher__in=self.get_admin_organizations_and_descendants()
-        ) | queryset.filter(
-            publication_status=PublicationStatus.DRAFT,
-            publisher__in=self.organization_memberships.all(),
-        )
-
-    def get_admin_tree_ids(self):
-        # returns tree ids for all normal admin organizations and their replacements
-        admin_queryset = self.admin_organizations.filter(
-            internal_type="normal"
-        ).select_related("replaced_by")
-        admin_tree_ids = admin_queryset.values("tree_id")
-        admin_replaced_tree_ids = admin_queryset.filter(
-            replaced_by__isnull=False
-        ).values("replaced_by__tree_id")
-        return set(value["tree_id"] for value in admin_tree_ids) | set(
-            value["replaced_by__tree_id"] for value in admin_replaced_tree_ids
-        )
-
-    def get_admin_organizations_and_descendants(self):
-        # returns admin organizations and their descendants
-        if not self.admin_organizations.all():
-            return Organization.objects.none()
-        # regular admins have rights to all organizations below their level
-        admin_orgs = []
-        for admin_org in self.admin_organizations.all():
-            admin_orgs.append(admin_org.get_descendants(include_self=True))
-            if admin_org.replaced_by:
-                # admins of replaced organizations have these rights, too!
-                admin_orgs.append(
-                    admin_org.replaced_by.get_descendants(include_self=True)
-                )
-        # for multiple admin_orgs, we have to combine the querysets and filter distinct
-        return reduce(lambda a, b: a | b, admin_orgs).distinct()
+from events import utils
 
 
 class GuestPost(BasePermission):
@@ -162,10 +84,6 @@ class DataSourceResourceEditPermission(IsAuthenticatedOrReadOnly):
         return True
 
     def has_object_permission(self, request: Request, view, obj):
-
-        if not super().has_object_permission(request, view, obj):
-            return False
-
         if request.method in permissions.SAFE_METHODS:
             return True
 
@@ -173,19 +91,11 @@ class DataSourceResourceEditPermission(IsAuthenticatedOrReadOnly):
 
 
 class DataSourceOrganizationEditPermission(IsAuthenticatedOrReadOnly):
-    def has_permission(self, request, view):
-        return super().has_permission(request, view)
-
     def has_object_permission(self, request: Request, view, obj):
-        from .api import organization_can_be_edited_by
-
-        if not super().has_object_permission(request, view, obj):
-            return False
-
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return organization_can_be_edited_by(obj, request.user)
+        return utils.organization_can_be_edited_by(obj, request.user)
 
 
 class UserIsAdminInAnyOrganization(BasePermission):

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -442,15 +442,19 @@ def make_keyword():
         ]
 
         labels = [
-            KeywordLabel.objects.create(name="%s%s" % (kw_name, lang.id), language=lang)
+            KeywordLabel.objects.get_or_create(
+                name="%s%s" % (kw_name, lang.id), language=lang
+            )[0]
             for lang in lang_objs
         ]
 
-        obj = Keyword.objects.create(
+        obj, created = Keyword.objects.get_or_create(
             id=data_source.id + ":" + kw_name,
-            name=kw_name,
-            publisher=organization,
-            data_source=data_source,
+            defaults=dict(
+                name=kw_name,
+                publisher=organization,
+                data_source=data_source,
+            ),
         )
         for label in labels:
             obj.alt_labels.add(label)

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -1,7 +1,33 @@
 import factory
 
 from events import utils
-from registrations.tests.factories import EventFactory
+from events.models import DataSource, Event
+
+
+class DataSourceFactory(factory.django.DjangoModelFactory):
+    id = factory.Sequence(lambda n: "data-source-{0}".format(n))
+
+    class Meta:
+        model = DataSource
+
+
+class OrganizationFactory(factory.django.DjangoModelFactory):
+    data_source = factory.SubFactory(DataSourceFactory)
+
+    class Meta:
+        model = "django_orghierarchy.Organization"
+
+
+class EventFactory(factory.django.DjangoModelFactory):
+    data_source = factory.SubFactory(DataSourceFactory)
+    publisher = factory.SubFactory(OrganizationFactory)
+
+    class Meta:
+        model = Event
+
+    @factory.lazy_attribute_sequence
+    def id(self, n):
+        return f"{self.data_source.id}:{n}"
 
 
 class DefaultOrganizationEventFactory(EventFactory):

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -1,0 +1,16 @@
+import factory
+
+from events import utils
+from registrations.tests.factories import EventFactory
+
+
+class DefaultOrganizationEventFactory(EventFactory):
+    publisher = factory.LazyFunction(utils.get_or_create_default_organization)
+
+    @factory.lazy_attribute_sequence
+    def id(self, n):
+        return f"{self.data_source.id}:{n}"
+
+    @factory.lazy_attribute
+    def data_source(self):
+        return self.publisher.data_source

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -7,13 +7,10 @@ from django_orghierarchy.models import Organization
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ..api import (
-    EventSerializer,
-    get_authenticated_data_source_and_publisher,
-    OrganizationListSerializer,
-)
+from ..api import EventSerializer, OrganizationListSerializer
 from ..auth import ApiKeyAuth
 from ..models import DataSource, Image
+from ..utils import get_user_data_source_and_organization_from_request
 from .utils import versioned_reverse as reverse
 
 
@@ -47,7 +44,7 @@ def test_get_authenticated_data_source_and_publisher(data_source):
     data_source.save()
 
     request = MagicMock(auth=ApiKeyAuth(data_source))
-    ds, publisher = get_authenticated_data_source_and_publisher(request)
+    ds, publisher = get_user_data_source_and_organization_from_request(request)
     assert ds == data_source
     assert publisher == org
 

--- a/events/tests/test_auth.py
+++ b/events/tests/test_auth.py
@@ -102,17 +102,17 @@ class TestApiKeyUser(TestCase):
         )
 
     def test_is_admin(self):
-        is_admin = self.user.is_admin(self.org_1)
+        is_admin = self.user.is_admin_of(self.org_1)
         self.assertTrue(is_admin)
 
-        is_admin = self.user.is_admin(self.org_2)
+        is_admin = self.user.is_admin_of(self.org_2)
         self.assertFalse(is_admin)
 
     def test_is_regular_user(self):
-        is_regular_user = self.user.is_regular_user(self.org_1)
+        is_regular_user = self.user.is_regular_user_of(self.org_1)
         self.assertFalse(is_regular_user)
 
-        is_regular_user = self.user.is_regular_user(self.org_2)
+        is_regular_user = self.user.is_regular_user_of(self.org_2)
         self.assertFalse(is_regular_user)
 
 

--- a/events/tests/test_event_auth_api.py
+++ b/events/tests/test_event_auth_api.py
@@ -370,17 +370,6 @@ class TestEventAPI(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_random_user_create_event_denied(self):
-        url = reverse("event-list")
-        location_id = reverse("place-detail", kwargs={"pk": self.place.id})
-        data = self.make_minimal_event_dict(
-            self.system_data_source, self.org_1, location_id
-        )
-
-        self.client.force_authenticate(self.user)
-        response = self.client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     def test_random_user_update_public_event_denied(self):
         url = reverse("event-detail", kwargs={"pk": self.event_4.id})
         location_id = reverse("place-detail", kwargs={"pk": self.place.id})
@@ -411,17 +400,6 @@ class TestEventAPI(APITestCase):
 
         self.client.force_authenticate(self.user)
         response = self.client.post(url, [data_1, data_2], format="json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_random_user_bulk_update(self):
-        url = reverse("event-list")
-        location_id = reverse("place-detail", kwargs={"pk": self.place.id})
-        data = self.make_complex_event_dict(
-            self.system_data_source, self.org_1, location_id, self.languages
-        )
-
-        self.client.force_authenticate(self.user)
-        response = self.client.put(url, [data], format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_admin_get_own_public_event(self):

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -734,7 +734,7 @@ def test__correct_api_key_can_update_an_event_in_suborganization(
         complex_event_dict,
         credentials={"apikey": other_data_source.api_key},
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.data
     assert ApiKeyUser.objects.all().count() == 1
 
 

--- a/events/tests/test_external_user.py
+++ b/events/tests/test_external_user.py
@@ -14,7 +14,7 @@ from .utils import versioned_reverse as reverse
 
 @pytest.fixture(autouse=True)
 def setup(settings):
-    settings.USER_DEFAULT_ORGANIZATION_ID = "others"
+    settings.EXTERNAL_USER_PUBLISHER_ID = "others"
     settings.ENABLE_EXTERNAL_USER_EVENTS = True
 
 

--- a/events/tests/test_external_user.py
+++ b/events/tests/test_external_user.py
@@ -1,0 +1,192 @@
+import pytest
+from rest_framework import status
+
+from registrations.tests.factories import (
+    DataSourceFactory,
+    EventFactory,
+    OrganizationFactory,
+)
+
+from ..models import PublicationStatus
+from .factories import DefaultOrganizationEventFactory
+from .utils import assert_event_data_is_equal
+from .utils import versioned_reverse as reverse
+
+
+@pytest.fixture(autouse=True)
+def setup(settings):
+    settings.USER_DEFAULT_ORGANIZATION_ID = "others"
+
+
+@pytest.fixture
+def make_event_data(make_minimal_event_dict, location_id):
+    def _make_minimal_event_dict(event, **kwargs):
+        kwargs.setdefault("publication_status", "draft")
+        d = make_minimal_event_dict(event.data_source, event.publisher, location_id)
+        d["publisher"] = None
+        d.update(kwargs)
+        return d
+
+    return _make_minimal_event_dict
+
+
+@pytest.fixture
+def authed_api_client(api_client, external_user):
+    api_client.force_authenticate(user=external_user)
+    return api_client
+
+
+def create(api_client, event_data):
+    create_url = reverse("event-list")
+    return api_client.post(create_url, event_data, format="json")
+
+
+def update(api_client, event_id, event_data):
+    url = reverse("event-detail", kwargs={"pk": event_id})
+    return api_client.put(url, event_data, format="json")
+
+
+def bulk_update(api_client, event_data):
+    url = reverse("event-list")
+    return api_client.put(url, event_data, format="json")
+
+
+class TestEventCreate:
+    @pytest.fixture
+    def minimal_event(self, minimal_event_dict):
+        minimal_event_dict["publisher"] = None
+        minimal_event_dict["publication_status"] = "draft"
+
+        return minimal_event_dict
+
+    @pytest.mark.django_db
+    def test_should_be_able_to_create_event_draft(
+        self, authed_api_client, minimal_event, external_user
+    ):
+        response = create(authed_api_client, minimal_event)
+
+        minimal_event["publisher"] = "others"
+        assert_event_data_is_equal(minimal_event, response.data)
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_create_and_publish_event(
+        self,
+        authed_api_client,
+        minimal_event,
+        external_user,
+    ):
+        minimal_event["publication_status"] = "public"
+
+        response = create(authed_api_client, minimal_event)
+        assert response.status_code == 403
+
+
+class TestEventUpdate:
+    @pytest.mark.django_db
+    def test_should_be_able_to_edit_own_event_draft(
+        self, authed_api_client, make_event_data, external_user
+    ):
+        event = DefaultOrganizationEventFactory(
+            created_by=external_user, publication_status=PublicationStatus.DRAFT
+        )
+
+        response = update(authed_api_client, event.id, make_event_data(event))
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_edit_own_event_published(
+        self, authed_api_client, make_event_data, external_user
+    ):
+        event = DefaultOrganizationEventFactory(created_by=external_user)
+
+        response = update(
+            authed_api_client,
+            event.id,
+            make_event_data(event, publication_status="public"),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.data
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_edit_others_event_draft(
+        self, authed_api_client, external_user, external_user_2, make_event_data
+    ):
+        event = DefaultOrganizationEventFactory(
+            created_by=external_user_2, publication_status=PublicationStatus.DRAFT
+        )
+
+        response = update(authed_api_client, event.id, make_event_data(event))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.data
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_edit_own_draft_in_non_default_organization(
+        self, authed_api_client, external_user, make_event_data
+    ):
+        data_source = DataSourceFactory(user_editable_resources=True)
+        organization = OrganizationFactory(id="acme", data_source=data_source)
+        event = EventFactory(
+            created_by=external_user,
+            data_source=data_source,
+            publication_status=PublicationStatus.DRAFT,
+            publisher=organization,
+        )
+
+        response = update(authed_api_client, event.id, make_event_data(event))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.data
+
+
+class TestEventBulkUpdate:
+    @pytest.mark.django_db
+    def test_should_be_able_to_edit_own_events_draft(
+        self, authed_api_client, make_event_data, external_user
+    ):
+        event1 = DefaultOrganizationEventFactory(
+            created_by=external_user, publication_status=PublicationStatus.DRAFT
+        )
+        event2 = DefaultOrganizationEventFactory(
+            created_by=external_user, publication_status=PublicationStatus.DRAFT
+        )
+        event_data1 = make_event_data(event1)
+        event_data2 = make_event_data(event2)
+        event_data1["id"] = event1.id
+        event_data2["id"] = event2.id
+        event_data = [event_data1, event_data2]
+
+        response = bulk_update(authed_api_client, event_data)
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_edit_own_events_published(
+        self, authed_api_client, make_event_data, external_user
+    ):
+        event1 = DefaultOrganizationEventFactory(
+            created_by=external_user, publication_status=PublicationStatus.PUBLIC
+        )
+        event2 = DefaultOrganizationEventFactory(
+            created_by=external_user, publication_status=PublicationStatus.DRAFT
+        )
+        event_data1 = make_event_data(event1)
+        event_data2 = make_event_data(event2)
+        event_data1["id"] = event1.id
+        event_data2["id"] = event2.id
+        event_data = [event_data1, event_data2]
+
+        response = bulk_update(authed_api_client, event_data)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.data
+
+    @pytest.mark.django_db
+    def test_should_not_be_able_to_edit_others_event_draft(
+        self, authed_api_client, external_user, external_user_2, make_event_data
+    ):
+        event = DefaultOrganizationEventFactory(
+            created_by=external_user_2, publication_status=PublicationStatus.DRAFT
+        )
+
+        response = update(authed_api_client, event.id, make_event_data(event))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.data

--- a/events/tests/test_external_user.py
+++ b/events/tests/test_external_user.py
@@ -1,14 +1,13 @@
 import pytest
 from rest_framework import status
 
-from registrations.tests.factories import (
+from ..models import PublicationStatus
+from .factories import (
     DataSourceFactory,
+    DefaultOrganizationEventFactory,
     EventFactory,
     OrganizationFactory,
 )
-
-from ..models import PublicationStatus
-from .factories import DefaultOrganizationEventFactory
 from .utils import assert_event_data_is_equal
 from .utils import versioned_reverse as reverse
 
@@ -70,13 +69,6 @@ def delete(api_client, event_id):
 
 
 class TestEventCreate:
-    @pytest.fixture
-    def minimal_event(self, minimal_event_dict):
-        minimal_event_dict["publisher"] = None
-        minimal_event_dict["publication_status"] = "draft"
-
-        return minimal_event_dict
-
     @pytest.mark.django_db
     def test_should_be_able_to_create_event_draft(
         self, authed_api_client, minimal_event, external_user

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -5,9 +5,9 @@ from django.test import TestCase
 from django_orghierarchy.models import Organization
 
 from helevents.models import User, UserModelPermissionMixin
-from registrations.tests.factories import OrganizationFactory
 
 from ..models import DataSource, Event, PublicationStatus
+from .factories import OrganizationFactory
 
 
 class TestUserModelPermissionMixin(TestCase):

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -29,14 +29,14 @@ class TestUserModelPermissionMixin(TestCase):
     def test_is_admin(self):
         self.assertRaises(
             NotImplementedError,
-            self.instance.is_admin,
+            self.instance.is_admin_of,
             self.org,
         )
 
     def test_is_regular_user(self):
         self.assertRaises(
             NotImplementedError,
-            self.instance.is_regular_user,
+            self.instance.is_regular_user_of,
             self.org,
         )
 
@@ -60,12 +60,12 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
     with (
         patch.object(
             UserModelPermissionMixin,
-            "is_admin",
+            "is_admin_of",
             return_value=membership_status == "admin",
         ),
         patch.object(
             UserModelPermissionMixin,
-            "is_regular_user",
+            "is_regular_user_of",
             return_value=membership_status == "regular",
         ),
         patch.object(

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -46,13 +46,16 @@ class TestUserModelPermissionMixin(TestCase):
     [
         ("admin", True, True),
         ("regular", False, True),
-        ("external", False, False),
+        ("external", False, True),
     ],
 )
 @pytest.mark.django_db
 def test_can_edit_event(membership_status, expected_public, expected_draft):
-    org = OrganizationFactory()
     instance = UserModelPermissionMixin()
+    if membership_status == "external":
+        org = None
+    else:
+        org = OrganizationFactory()
 
     with (
         patch.object(
@@ -71,8 +74,14 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
             return_value=membership_status == "external",
         ),
     ):
-        assert instance.can_edit_event(org, PublicationStatus.PUBLIC) is expected_public
-        assert instance.can_edit_event(org, PublicationStatus.DRAFT) is expected_draft
+        assert (
+            instance.can_edit_event(org, PublicationStatus.PUBLIC, instance)
+            is expected_public
+        )
+        assert (
+            instance.can_edit_event(org, PublicationStatus.DRAFT, instance)
+            is expected_draft
+        )
 
 
 @pytest.mark.parametrize(

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -3,10 +3,9 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from django_orghierarchy.models import Organization
 
-from helevents.models import User
+from helevents.models import User, UserModelPermissionMixin
 
 from ..models import DataSource, Event, PublicationStatus
-from ..permissions import UserModelPermissionMixin
 
 
 class TestUserModelPermissionMixin(TestCase):

--- a/events/tests/utils.py
+++ b/events/tests/utils.py
@@ -75,7 +75,7 @@ def assert_data_is_equal(d1, d2, fields):
             if type(d1[key]) is list:
                 assert_lists_match(d1[key], d2[key])
             else:
-                assert d1[key] == d2[key]
+                assert d1[key] == d2[key], key
 
 
 def get(api_client, url, data=None):

--- a/events/utils.py
+++ b/events/utils.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 from django_orghierarchy.models import Organization
 from rest_framework.exceptions import ParseError, PermissionDenied
 
+from events.auth import ApiKeyAuth
 from events.models import DataSource, Keyword, Place
 from events.sql import count_events_for_keywords, count_events_for_places
 from helevents.models import User
@@ -259,7 +260,6 @@ def get_user_data_source_and_organization_from_request(
     :param request: the request object
     :return: a tuple containing the data source and organization
     """
-    from events.auth import ApiKeyAuth
 
     # api_key takes precedence over user
     if isinstance(request.auth, ApiKeyAuth):

--- a/events/utils.py
+++ b/events/utils.py
@@ -226,9 +226,9 @@ def get_or_create_default_organization() -> Optional[Organization]:
     """Create (if needed) the default organization to which users can be added if they
     don't belong to any organization.
     """
-    if not settings.USER_DEFAULT_ORGANIZATION_ID:
+    if not settings.EXTERNAL_USER_PUBLISHER_ID:
         warnings.warn(
-            "USER_DEFAULT_ORGANIZATION_ID is empty, will not set or create "
+            "EXTERNAL_USER_PUBLISHER_ID is empty, will not set or create "
             "default organization."
         )
         return None
@@ -241,7 +241,7 @@ def get_or_create_default_organization() -> Optional[Organization]:
         },
     )
     organization, _ = Organization.objects.get_or_create(
-        id=settings.USER_DEFAULT_ORGANIZATION_ID,
+        id=settings.EXTERNAL_USER_PUBLISHER_ID,
         defaults={"name": "Muu", "data_source": data_source},
     )
     return organization

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -1,6 +1,84 @@
+from functools import reduce
+
+from django_orghierarchy.models import Organization
 from helusers.models import AbstractUser
 
-from events.permissions import UserModelPermissionMixin
+from events.models import PublicationStatus
+
+
+class UserModelPermissionMixin:
+    """Permission mixin for user models
+
+    A mixin class that provides permission check methods
+    for user models.
+    """
+
+    def is_admin(self, publisher):
+        """Check if current user is an admin user of the publisher organization"""
+        raise NotImplementedError()
+
+    def is_regular_user(self, publisher):
+        """Check if current user is a regular user of the publisher organization"""
+        raise NotImplementedError()
+
+    @property
+    def admin_organizations(self):
+        raise NotImplementedError()
+
+    @property
+    def organization_memberships(self):
+        raise NotImplementedError()
+
+    def can_edit_event(self, publisher, publication_status):
+        """Check if current user can edit (create, change, modify)
+        event with the given publisher and publication_status"""
+        if self.is_admin(publisher):
+            return True
+        if (
+            self.is_regular_user(publisher)
+            and publication_status == PublicationStatus.DRAFT
+        ):
+            return True
+        return False
+
+    def get_editable_events(self, queryset):
+        """Get editable events queryset from given queryset for current user"""
+        # distinct is not needed here, as admin_orgs and memberships should not overlap
+        return queryset.filter(
+            publisher__in=self.get_admin_organizations_and_descendants()
+        ) | queryset.filter(
+            publication_status=PublicationStatus.DRAFT,
+            publisher__in=self.organization_memberships.all(),
+        )
+
+    def get_admin_tree_ids(self):
+        # returns tree ids for all normal admin organizations and their replacements
+        admin_queryset = self.admin_organizations.filter(
+            internal_type="normal"
+        ).select_related("replaced_by")
+        admin_tree_ids = admin_queryset.values("tree_id")
+        admin_replaced_tree_ids = admin_queryset.filter(
+            replaced_by__isnull=False
+        ).values("replaced_by__tree_id")
+        return set(value["tree_id"] for value in admin_tree_ids) | set(
+            value["replaced_by__tree_id"] for value in admin_replaced_tree_ids
+        )
+
+    def get_admin_organizations_and_descendants(self):
+        # returns admin organizations and their descendants
+        if not self.admin_organizations.all():
+            return Organization.objects.none()
+        # regular admins have rights to all organizations below their level
+        admin_orgs = []
+        for admin_org in self.admin_organizations.all():
+            admin_orgs.append(admin_org.get_descendants(include_self=True))
+            if admin_org.replaced_by:
+                # admins of replaced organizations have these rights, too!
+                admin_orgs.append(
+                    admin_org.replaced_by.get_descendants(include_self=True)
+                )
+        # for multiple admin_orgs, we have to combine the querysets and filter distinct
+        return reduce(lambda a, b: a | b, admin_orgs).distinct()
 
 
 class User(AbstractUser, UserModelPermissionMixin):

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -23,11 +23,11 @@ class UserModelPermissionMixin:
             and not self.admin_organizations.exists()
         )
 
-    def is_admin(self, publisher):
+    def is_admin_of(self, publisher):
         """Check if current user is an admin user of the publisher organization"""
         raise NotImplementedError()
 
-    def is_regular_user(self, publisher):
+    def is_regular_user_of(self, publisher):
         """Check if current user is a regular user of the publisher organization"""
         raise NotImplementedError()
 
@@ -54,14 +54,14 @@ class UserModelPermissionMixin:
 
     def can_create_event(self, publisher, publication_status):
         """Check if current user can create an event with the given publisher and publication_status"""
-        if self.is_admin(publisher):
+        if self.is_admin_of(publisher):
             return True
         # Non-admins can only create drafts.
         return publication_status == PublicationStatus.DRAFT
 
     def can_edit_event(self, publisher, publication_status, created_by=None):
         """Check if current user can edit an event with the given publisher and publication_status"""
-        if self.is_admin(publisher):
+        if self.is_admin_of(publisher):
             return True
 
         # Non-admins can only edit drafts.
@@ -74,7 +74,7 @@ class UserModelPermissionMixin:
                 return self.is_external and created_by == self
             else:
                 # Regular users can edit drafts from organizations they are members of.
-                return self.is_regular_user(publisher)
+                return self.is_regular_user_of(publisher)
 
         return False
 
@@ -152,12 +152,12 @@ class User(AbstractUser, UserModelPermissionMixin):
 
         return admin_org or regular_org
 
-    def is_admin(self, publisher):
+    def is_admin_of(self, publisher):
         if publisher is None:
             return False
         return publisher in self.get_admin_organizations_and_descendants()
 
-    def is_regular_user(self, publisher):
+    def is_regular_user_of(self, publisher):
         if publisher is None:
             return False
         return self.organization_memberships.filter(id=publisher.id).exists()

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -1,5 +1,6 @@
 from functools import reduce
 
+from django.utils.functional import cached_property
 from django_orghierarchy.models import Organization
 from helusers.models import AbstractUser
 
@@ -13,6 +14,14 @@ class UserModelPermissionMixin:
     for user models.
     """
 
+    @cached_property
+    def is_external(self):
+        """Check if the user is an external user"""
+        return (
+            not self.organization_memberships.exists()
+            and not self.admin_organizations.exists()
+        )
+
     def is_admin(self, publisher):
         """Check if current user is an admin user of the publisher organization"""
         raise NotImplementedError()
@@ -23,10 +32,23 @@ class UserModelPermissionMixin:
 
     @property
     def admin_organizations(self):
+        """
+        Get a queryset of organizations that the user is an admin of.
+
+        Is replaced by django_orghierarchy.models.Organization's
+        admin_organizations relation unless implemented in a subclass.
+        """
         raise NotImplementedError()
 
     @property
     def organization_memberships(self):
+        """
+        Get a queryset of organizations that the user is a member of.
+
+        Is replaced by django_orghierarchy.models.Organization's
+        organization_memberships relation unless implemented
+        in a subclass.
+        """
         raise NotImplementedError()
 
     def can_edit_event(self, publisher, publication_status):

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -63,7 +63,7 @@ class UserModelPermissionMixin:
 
         # Non-admins can only edit drafts.
         if publication_status == PublicationStatus.DRAFT:
-            if (
+            if settings.ENABLE_EXTERNAL_USER_EVENTS and (
                 publisher is None
                 or publisher.id == settings.USER_DEFAULT_ORGANIZATION_ID
             ):
@@ -78,12 +78,15 @@ class UserModelPermissionMixin:
     def get_editable_events(self, queryset):
         """Get editable events queryset from given queryset for current user"""
         if self.is_external:
-            # External users can only edit their own drafts from the default organization.
-            return queryset.filter(
-                created_by=self,
-                publisher__id=settings.USER_DEFAULT_ORGANIZATION_ID,
-                publication_status=PublicationStatus.DRAFT,
-            )
+            if settings.ENABLE_EXTERNAL_USER_EVENTS:
+                # External users can only edit their own drafts from the default organization.
+                return queryset.filter(
+                    created_by=self,
+                    publisher__id=settings.USER_DEFAULT_ORGANIZATION_ID,
+                    publication_status=PublicationStatus.DRAFT,
+                )
+            else:
+                return queryset.none()
 
         # distinct is not needed here, as admin_orgs and memberships should not overlap
         return queryset.filter(

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -64,8 +64,7 @@ class UserModelPermissionMixin:
         # Non-admins can only edit drafts.
         if publication_status == PublicationStatus.DRAFT:
             if settings.ENABLE_EXTERNAL_USER_EVENTS and (
-                publisher is None
-                or publisher.id == settings.USER_DEFAULT_ORGANIZATION_ID
+                publisher is None or publisher.id == settings.EXTERNAL_USER_PUBLISHER_ID
             ):
                 # External users can only edit their own drafts from the default organization.
                 return self.is_external and created_by == self
@@ -82,7 +81,7 @@ class UserModelPermissionMixin:
                 # External users can only edit their own drafts from the default organization.
                 return queryset.filter(
                     created_by=self,
-                    publisher__id=settings.USER_DEFAULT_ORGANIZATION_ID,
+                    publisher__id=settings.EXTERNAL_USER_PUBLISHER_ID,
                     publication_status=PublicationStatus.DRAFT,
                 )
             else:

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -54,10 +54,7 @@ class UserModelPermissionMixin:
 
     def can_create_event(self, publisher, publication_status):
         """Check if current user can create an event with the given publisher and publication_status"""
-        if self.is_admin_of(publisher):
-            return True
-        # Non-admins can only create drafts.
-        return publication_status == PublicationStatus.DRAFT
+        return self.can_edit_event(publisher, publication_status, created_by=self)
 
     def can_edit_event(self, publisher, publication_status, created_by=None):
         """Check if current user can edit an event with the given publisher and publication_status"""

--- a/helevents/tests/test_models.py
+++ b/helevents/tests/test_models.py
@@ -53,44 +53,44 @@ class TestUser(TestCase):
         self.org.admin_users.add(self.user)
 
         # test for admin organization
-        is_admin = self.user.is_admin(self.org)
+        is_admin = self.user.is_admin_of(self.org)
         self.assertTrue(is_admin)
 
         # test for child organization
-        is_admin = self.user.is_admin(self.child_org)
+        is_admin = self.user.is_admin_of(self.child_org)
         self.assertTrue(is_admin)
 
         # test for affiliated organization
-        is_admin = self.user.is_admin(self.child_org)
+        is_admin = self.user.is_admin_of(self.child_org)
         self.assertTrue(is_admin)
 
         # test for some other organization
-        is_admin = self.user.is_admin(self.org_1)
+        is_admin = self.user.is_admin_of(self.org_1)
         self.assertFalse(is_admin)
 
     def test_is_regular_user(self):
         self.org.regular_users.add(self.user)
 
         # test for admin organization
-        is_admin = self.user.is_admin(self.org)
+        is_admin = self.user.is_admin_of(self.org)
         self.assertFalse(is_admin)
-        is_regular_user = self.user.is_regular_user(self.org)
+        is_regular_user = self.user.is_regular_user_of(self.org)
         self.assertTrue(is_regular_user)
 
         # test for child organization
-        is_admin = self.user.is_admin(self.child_org)
+        is_admin = self.user.is_admin_of(self.child_org)
         self.assertFalse(is_admin)
-        is_regular_user = self.user.is_regular_user(self.child_org)
+        is_regular_user = self.user.is_regular_user_of(self.child_org)
         self.assertFalse(is_regular_user)
 
         # test for affiliated organization
-        is_admin = self.user.is_admin(self.affiliated_org)
+        is_admin = self.user.is_admin_of(self.affiliated_org)
         self.assertFalse(is_admin)
-        is_regular_user = self.user.is_regular_user(self.affiliated_org)
+        is_regular_user = self.user.is_regular_user_of(self.affiliated_org)
         self.assertFalse(is_regular_user)
 
         # test for some other organization
-        is_admin = self.user.is_admin(self.org_1)
+        is_admin = self.user.is_admin_of(self.org_1)
         self.assertFalse(is_admin)
-        is_regular_user = self.user.is_regular_user(self.org_1)
+        is_regular_user = self.user.is_regular_user_of(self.org_1)
         self.assertFalse(is_regular_user)

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -55,6 +55,7 @@ env = environ.Env(
     ELASTICSEARCH_URL=(str, None),
     ENABLE_EXTERNAL_USER_EVENTS=(bool, True),
     ENABLE_REGISTRATION_ENDPOINTS=(bool, False),
+    EXTERNAL_USER_PUBLISHER_ID=(str, "others"),
     EXTRA_INSTALLED_APPS=(list, []),
     INSTANCE_NAME=(str, "Linked Events"),
     INTERNAL_IPS=(list, []),
@@ -91,7 +92,6 @@ env = environ.Env(
     TOKEN_AUTH_FIELD_FOR_CONSENTS=(str, "https://api.hel.fi/auth"),
     TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, True),
     TRUST_X_FORWARDED_HOST=(bool, False),
-    USER_DEFAULT_ORGANIZATION_ID=(str, "others"),
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -294,9 +294,12 @@ LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 ACCOUNT_LOGOUT_ON_GET = True
 
-# Default organization to which a user will be assigned if user doesn't
-# have any organization. Default organization is created if it doesn't exist.
-USER_DEFAULT_ORGANIZATION_ID = env("USER_DEFAULT_ORGANIZATION_ID")
+
+# Enable external user event create/update/delete.
+ENABLE_EXTERNAL_USER_EVENTS = env.bool("ENABLE_EXTERNAL_USER_EVENTS")
+
+# Publisher used for events created by users without organization (i.e. external users)
+EXTERNAL_USER_PUBLISHER_ID = env("EXTERNAL_USER_PUBLISHER_ID")
 
 #
 # REST Framework
@@ -582,5 +585,3 @@ OIDC_API_TOKEN_AUTH = {
 }
 
 OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
-
-ENABLE_EXTERNAL_USER_EVENTS = env.bool("ENABLE_EXTERNAL_USER_EVENTS")

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -53,6 +53,7 @@ env = environ.Env(
     DATABASE_URL=(str, "postgis:///linkedevents"),
     DEBUG=(bool, False),
     ELASTICSEARCH_URL=(str, None),
+    ENABLE_EXTERNAL_USER_EVENTS=(bool, True),
     ENABLE_REGISTRATION_ENDPOINTS=(bool, False),
     EXTRA_INSTALLED_APPS=(list, []),
     INSTANCE_NAME=(str, "Linked Events"),
@@ -581,3 +582,5 @@ OIDC_API_TOKEN_AUTH = {
 }
 
 OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
+
+ENABLE_EXTERNAL_USER_EVENTS = env.bool("ENABLE_EXTERNAL_USER_EVENTS")

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -54,7 +54,6 @@ env = environ.Env(
     DEBUG=(bool, False),
     ELASTICSEARCH_URL=(str, None),
     ENABLE_REGISTRATION_ENDPOINTS=(bool, False),
-    ENABLE_USER_DEFAULT_ORGANIZATION=(bool, False),
     EXTRA_INSTALLED_APPS=(list, []),
     INSTANCE_NAME=(str, "Linked Events"),
     INTERNAL_IPS=(list, []),
@@ -294,8 +293,6 @@ LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 ACCOUNT_LOGOUT_ON_GET = True
 
-# User will be assigned to a default organization if user doesn't have any
-ENABLE_USER_DEFAULT_ORGANIZATION = env("ENABLE_USER_DEFAULT_ORGANIZATION")
 # Default organization to which a user will be assigned if user doesn't
 # have any organization. Default organization is created if it doesn't exist.
 USER_DEFAULT_ORGANIZATION_ID = env("USER_DEFAULT_ORGANIZATION_ID")
@@ -324,7 +321,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "events.auth.ApiKeyAuthentication",
-        "events.auth.LinkedEventsApiOidcAuthentication",
+        "helusers.oidc.ApiTokenAuthentication",
     ),
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     "VIEW_NAME_FUNCTION": "linkedevents.utils.get_view_name",

--- a/linkedevents/tests/conftest.py
+++ b/linkedevents/tests/conftest.py
@@ -56,6 +56,28 @@ def user2():
 
 
 @pytest.fixture
+def external_user():
+    """A user that doesn't belong to any organization."""
+    return get_user_model().objects.create(
+        username="external_user",
+        first_name="External",
+        last_name="User",
+        email="external@user.test",
+    )
+
+
+@pytest.fixture
+def external_user_2():
+    """Another user that doesn't belong to any organization."""
+    return get_user_model().objects.create(
+        username="external_user_2",
+        first_name="External2",
+        last_name="User",
+        email="external2@user.test",
+    )
+
+
+@pytest.fixture
 def super_user():
     return get_user_model().objects.create(
         username="super_user",
@@ -104,6 +126,7 @@ def organization_class():
 @pytest.mark.django_db
 @pytest.fixture
 def organization(data_source, user):
+    """Organization with a single admin user (user)."""
     org, created = Organization.objects.get_or_create(
         id=data_source.id + ":test_organization",
         origin_id="test_organization",
@@ -118,6 +141,7 @@ def organization(data_source, user):
 @pytest.mark.django_db
 @pytest.fixture
 def organization2(other_data_source, user2):
+    """Organization with a single admin user (user2)."""
     org, created = Organization.objects.get_or_create(
         id=other_data_source.id + ":test_organization2",
         origin_id="test_organization2",
@@ -132,6 +156,7 @@ def organization2(other_data_source, user2):
 @pytest.mark.django_db
 @pytest.fixture
 def organization3(other_data_source, user2):
+    """Organization with a single admin user (user2)."""
     org, created = Organization.objects.get_or_create(
         id=other_data_source.id + ":test_organization3",
         origin_id="test_organization3",

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -20,7 +20,11 @@ from events.api import (
     UserDataSourceAndOrganizationMixin,
 )
 from events.models import Event
-from events.permissions import DataSourceResourceEditPermission, GuestPost
+from events.permissions import (
+    DataSourceResourceEditPermission,
+    GuestPost,
+    OrganizationUserEditPermission,
+)
 from linkedevents.registry import register_view
 from registrations.exceptions import ConflictException
 from registrations.models import Registration, SeatReservationCode, SignUp
@@ -50,7 +54,7 @@ class RegistrationViewSet(
     queryset = Registration.objects.all()
 
     permission_classes = [
-        DataSourceResourceEditPermission,
+        DataSourceResourceEditPermission & OrganizationUserEditPermission
     ]
 
     def perform_create(self, serializer):
@@ -105,7 +109,9 @@ class RegistrationViewSet(
     @action(
         methods=["post"],
         detail=True,
-        permission_classes=[DataSourceResourceEditPermission],
+        permission_classes=[
+            DataSourceResourceEditPermission & OrganizationUserEditPermission
+        ],
     )
     def send_message(self, request, pk=None, version=None):
         registration = self.get_object()
@@ -181,7 +187,11 @@ class SignUpViewSet(
     permission_classes = [
         GuestPost
         | AuthenticateWithCancellationCode
-        | (AuthenticatedGet & DataSourceResourceEditPermission)
+        | (
+            AuthenticatedGet
+            & DataSourceResourceEditPermission
+            & OrganizationUserEditPermission
+        )
     ]
 
     def create(self, request, *args, **kwargs):

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -212,7 +212,7 @@ class Registration(models.Model):
         """Check if current registration can be edited by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.event.publisher)
+        return user.is_admin_of(self.event.publisher)
 
     def is_user_editable_resources(self):
         return bool(
@@ -342,7 +342,7 @@ class SignUp(models.Model):
         """Check if current signup can be edited by the given user"""
         if user.is_superuser:
             return True
-        return user.is_admin(self.publisher)
+        return user.is_admin_of(self.publisher)
 
     def is_user_editable_resources(self):
         return bool(self.data_source and self.data_source.user_editable_resources)

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -158,7 +158,9 @@ class RegistrationBaseSerializer(serializers.ModelSerializer):
             #  only the organization admins should be able to access the signup information
             user = self.context["user"]
             event = obj.event
-            if not isinstance(user, AnonymousUser) and user.is_admin(event.publisher):
+            if not isinstance(user, AnonymousUser) and user.is_admin_of(
+                event.publisher
+            ):
                 queryset = SignUp.objects.filter(registration__id=obj.id)
                 return SignUpSerializer(queryset, many=True, read_only=True).data
             else:

--- a/registrations/tests/factories.py
+++ b/registrations/tests/factories.py
@@ -25,6 +25,10 @@ class EventFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Event
 
+    @factory.lazy_attribute_sequence
+    def id(self, n):
+        return f"{self.data_source.id}:{n}"
+
 
 class RegistrationFactory(factory.django.DjangoModelFactory):
     event = factory.SubFactory(EventFactory)

--- a/registrations/tests/factories.py
+++ b/registrations/tests/factories.py
@@ -1,33 +1,7 @@
 import factory
 
-from events.models import DataSource, Event
+from events.tests.factories import EventFactory
 from registrations.models import Registration
-
-
-class DataSourceFactory(factory.django.DjangoModelFactory):
-    id = factory.Sequence(lambda n: "data-source-{0}".format(n))
-
-    class Meta:
-        model = DataSource
-
-
-class OrganizationFactory(factory.django.DjangoModelFactory):
-    data_source = factory.SubFactory(DataSourceFactory)
-
-    class Meta:
-        model = "django_orghierarchy.Organization"
-
-
-class EventFactory(factory.django.DjangoModelFactory):
-    data_source = factory.SubFactory(DataSourceFactory)
-    publisher = factory.SubFactory(OrganizationFactory)
-
-    class Meta:
-        model = Event
-
-    @factory.lazy_attribute_sequence
-    def id(self, n):
-        return f"{self.data_source.id}:{n}"
 
 
 class RegistrationFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
## Description
This PR allows event creation, modifying and deletion for external users, i.e. users that do not belong to an organization. This means that this also adds support for non-organization users. There's also a lot of refactoring involved.

## Related issue(s)
Related issue: [LINK-1164](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1164)

## Change list
(in no order of importance)
- New users are no longer automatically assigned to a default organization
- `publisher` field in event payload is no longer required
  - If missing or null, it gets automatically replaced
  - If creating, it uses the default organization
  - If updating, it uses the target event's organization
- Remove the organization logic from `DataSourceResourceEditPermission`
- New permissions:
  - `IsReadOnly`, check if HTTP method is in safe methods aka read-only methods
  - `UserBelongsToOrganization`, check if user belongs to an organization
  - `IsObjectEditableByOrganizationUser`, check if user has rights to edit an object within their organization
  - `OrganizationUserEditPermission`, a composite of the previous permissions
- Replace view permission classes to `DataSourceResourceEditPermission & OrganizationUserEditPermission`
- Reorganize code to get rid of circular imports and to decouple code
  - `events.permissions.UserModelPermissionsMixin` -> `helevents.models.UserModelPermissionsMixin`
  - `events.api.organization_can_be_edited_by` -> `events.utils.organization_can_be_edited_by`
  - Code from `EventViewSet.user_data_source_and_organization` to `utils.get_user_data_source_and_organization_from_request`
- Rename methods in `UserModelPermissionsMixin` to better reflect their purpose
  - `is_admin(publisher)` -> `is_admin_of(publisher)`
  - `is_regular_user(publisher)` -> `is_regular_user_of(publisher)`
- Add `is_external` property in `UserModelPermissionsMixin` which tells whether the user is an external user or not
- Split `UserModelPermissionsMixin.can_create_event` from `UserModelPermissionsMixin.can_edit_event`
- Fix some of the tests and test data

[LINK-1164]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ