### PR TITLE
LINK-1080 | Add Helsinki service task scripts

### DIFF
--- a/helevents/service_tasks/daily_tasks.sh
+++ b/helevents/service_tasks/daily_tasks.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo ---------------------------------
+echo "Starting daily import"
+echo ---------------------------------
+
+timeout --preserve-status -s INT 10m python manage.py event_import yso --all
+if [ $? -ne 0 ]; then
+    echo "YSO update signaled failure"
+fi
+
+timeout --preserve-status -s INT 15m python manage.py event_import harrastushaku --courses
+if [ $? -ne 0 ]; then
+    echo "Harrastushaku update signaled failure"
+fi
+
+
+timeout --preserve-status -s INT 20m python manage.py event_import osoite --places
+if [ $? -ne 0 ]; then
+    echo "PKS osoiteluettelo update signaled failure"
+fi
+
+echo "---------------------------------"
+echo "Daily import finished"
+echo "---------------------------------"

--- a/helevents/service_tasks/hourly_tasks.sh
+++ b/helevents/service_tasks/hourly_tasks.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+echo ---------------------------------
+echo "Starting hourly tasks"
+echo ---------------------------------
+
+timeout --preserve-status -s INT 2m python manage.py event_import tprek --places
+if [ $? -ne 0 ]; then
+    echo "tprek importer signaled failure"
+fi
+
+echo "--- Starting kulke importer ---"
+
+timeout --preserve-status -s INT 5m python manage.py event_import kulke --events
+if [ $? -ne 0 ]; then
+    echo "kulke importer signaled failure"
+fi
+
+echo "--- Starting lippupiste importer ---"
+
+timeout --preserve-status -s INT 5m python manage.py event_import lippupiste --events
+if [ $? -ne 0 ]; then
+    echo "lippupiste importer signaled failure"
+fi
+
+echo "--- Starting helmet importer ---"
+
+timeout --preserve-status -s INT 10m python manage.py event_import helmet --events
+if [ $? -ne 0 ]; then
+    echo "helmet importer signaled failure"
+fi
+
+echo "--- Updating local event cache ---"
+
+nice python manage.py populate_local_event_cache
+if [ $? -ne 0 ]; then
+    echo "populate local event cache signaled failure"
+fi
+
+echo "--- Starting keyword and place n_events update ---"
+
+nice python manage.py update_n_events
+if [ $? -ne 0 ]; then
+    echo "keyword and place n_events update signaled failure"
+fi
+
+echo "--- Updating has_upcoming_events flags ---"
+
+nice python manage.py update_has_upcoming_events
+if [ $? -ne 0 ]; then
+    echo "update_has_upcoming_events update signaled failure"
+fi
+
+echo "--- Starting haystack index update ---"
+
+nice python manage.py update_index -a 1
+if [ $? -ne 0 ]; then
+    echo "haystack index update signaled failure"
+fi
+
+echo "---------------------------------"
+echo "Hourly import finished"
+echo "---------------------------------"


### PR DESCRIPTION
Added bash scripts for running hourly and daily periodic service tasks which include importers and cache-related stuff. The main purpose for these is to be run in the new Helsinki production environment. The implementations are pretty much copied straight from the old production Helsinki environment, the only changes being file-logging and healthcheck.io usage removal.