### PR TITLE
LINK-1322 | Save admin and regular users when creating an organization

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -17,7 +17,6 @@ import django_filters
 import pytz
 import regex
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.contrib.postgres.search import SearchQuery, TrigramSimilarity
@@ -1483,18 +1482,58 @@ class OrganizationListSerializer(OrganizationBaseSerializer):
         return obj.regular_users.count() > 0
 
 
+class OrganizationUsersField(serializers.SlugRelatedField):
+    def __init__(self, **kwargs):
+        super().__init__(queryset=User.objects.all(), slug_field="username", **kwargs)
+
+    def to_representation(self, obj):
+        return UserSerializer(obj).data
+
+
 class OrganizationDetailSerializer(OrganizationListSerializer):
-    regular_users = serializers.SerializerMethodField()
-    admin_users = serializers.SerializerMethodField()
+    user_fields = ["admin_users", "regular_users"]
 
-    def validate(self, data):
-        if Organization.objects.filter(id=str(self.request.data["id"])):
-            raise DRFPermissionDenied(
-                f"Organization with id {self.request.data['id']} already exists."
-            )
-        return super().validate(data)
+    admin_users = OrganizationUsersField(
+        many=True,
+        required=False,
+    )
 
-    def connected_organizations(self, connected_orgs, created_org):
+    regular_users = OrganizationUsersField(
+        many=True,
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.instance:
+            self.fields["data_source"].read_only = True
+            self.fields["origin_id"].read_only = True
+
+    def to_representation(self, obj):
+        ret = super().to_representation(obj)
+
+        user = self.context["user"]
+        # Show admin users and regular users only to admins
+        user_fields = set(self.user_fields)
+        if user.is_anonymous or not user.is_admin_of(obj):
+            for field in user_fields:
+                del ret[field]
+
+        return ret
+
+    def validate_parent_organization(self, value):
+        if value:
+            user = self.request.user
+
+            if user.is_anonymous or not utils.organization_can_be_edited_by(
+                value, user
+            ):
+                raise DRFPermissionDenied(_("User has no rights to this organization"))
+
+        return value
+
+    def connect_organizations(self, connected_orgs, created_org):
         internal_types = {
             "sub_organizations": Organization.NORMAL,
             "affiliated_organizations": Organization.AFFILIATED,
@@ -1506,6 +1545,11 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
             created_org.children.add(*conn_org)
 
     def create(self, validated_data):
+        # Add current user to admin users
+        if "admin_users" not in validated_data:
+            validated_data["admin_users"] = []
+        validated_data["admin_users"].append(self.user)
+
         connected_organizations = ["sub_organizations", "affiliated_organizations"]
         conn_orgs_in_request = {}
         for org_type in connected_organizations:
@@ -1519,44 +1563,21 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
                     raise ParseError(
                         f"{org_type} should be a list, you provided {type(self.request.data[org_type])}"
                     )
-        if "parent_organization" in self.request.data.keys():
-            user = self.request.user
-            parent_id = (
-                self.request.data["parent_organization"].rstrip("/").split("/")[-1]
-            )
-            potential_parent = Organization.objects.filter(id=parent_id)
-            if potential_parent.count() == 0:
-                raise ParseError(
-                    f"{self.request.data['parent_organization']} does not exist."
-                )
-            if user:
-                if utils.organization_can_be_edited_by(potential_parent[0], user):
-                    pass
-                else:
-                    raise DRFPermissionDenied("User has no rights to this organization")
-            else:
-                raise DRFPermissionDenied(
-                    "User must be logged in to create organizations."
-                )
+
         org = super().create(validated_data)
-        self.connected_organizations(conn_orgs_in_request, org)
+        self.connect_organizations(conn_orgs_in_request, org)
+
         return org
 
-    def get_regular_users(self, obj):
-        user = self.context["user"]
-        if not isinstance(user, AnonymousUser) and user.is_admin_of(obj):
-            return UserSerializer(
-                obj.regular_users.all(), read_only=True, many=True
-            ).data
-        else:
-            return []
+    def update(self, instance, validated_data):
+        # Prevent user to accidentally remove himself from admin
+        if validated_data.get("admin_users") is not None:
+            admin_users = validated_data.pop("admin_users")
+            instance.admin_users.clear()
+            instance.admin_users.add(*admin_users)
+            instance.admin_users.add(self.user)
 
-    def get_admin_users(self, obj):
-        user = self.context["user"]
-        if not isinstance(user, AnonymousUser) and user.is_admin_of(obj):
-            return UserSerializer(obj.admin_users.all(), read_only=True, many=True).data
-        else:
-            return []
+        return super().update(instance, validated_data)
 
     class Meta:
         model = Organization
@@ -1583,89 +1604,17 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
         )
 
 
-class OrganizationUpdateSerializer(OrganizationListSerializer):
-    regular_users = serializers.SerializerMethodField()
-    admin_users = serializers.SerializerMethodField()
-
-    def __init__(self, instance=None, context=None, *args, **kwargs):
-        instance.can_be_edited_by = utils.organization_can_be_edited_by
-        if not instance.can_be_edited_by(instance, context["request"].user):
-            raise DRFPermissionDenied(
-                f"User {context['request'].user} can't modify {instance}"
-            )
-        self.method = "PUT"
-        self.hide_ld_context = True
-        self.skip_fields = ""
-        self.user = context["request"].user
-        if "data_source" not in context["request"].data.keys():
-            context["request"].data["data_source"] = instance.data_source
-        if "origin_id" not in context["request"].data.keys():
-            context["request"].data["origin_id"] = instance.origin_id
-        if "name" not in context["request"].data.keys():
-            context["request"].data["name"] = instance.name
-        super(LinkedEventsSerializer, self).__init__(
-            instance=instance, context=context, **kwargs
-        )
-        self.admin_users = context["request"].data.pop("admin_users", {"username": ""})
-        self.regular_users = context["request"].data.pop(
-            "regular_users", {"username": ""}
-        )
-
-    def update(self, instance, validated_data):
-        if isinstance(self.admin_users, dict) and isinstance(self.regular_users, dict):
-            pass
-        else:
-            raise ParseError("Dictionaries expected for admin and regular_users.")
-        if ("username" not in self.admin_users.keys()) or (
-            "username" not in self.regular_users.keys()
-        ):
-            raise ParseError(
-                "Username field should be used to pass admin_users and regular_users"
-            )
-
-        admin_users = User.objects.filter(username__in=self.admin_users["username"])
-        regular_users = User.objects.filter(username__in=self.regular_users["username"])
-        instance.admin_users.clear()
-        instance.admin_users.add(*admin_users)
-        instance.admin_users.add(
-            self.user
-        )  # so that the user does not accidentally remove himself from admin
-        instance.regular_users.clear()
-        instance.regular_users.add(*regular_users)
-        super().update(instance, validated_data)
-        return instance
-
-    def get_regular_users(self, obj):
-        return UserSerializer(obj.regular_users.all(), read_only=True, many=True).data
-
-    def get_admin_users(self, obj):
-        return UserSerializer(obj.admin_users.all(), read_only=True, many=True).data
-
-    class Meta:
-        model = Organization
-        fields = "__all__"
-
-
 class OrganizationViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.ListModelMixin,
-    mixins.CreateModelMixin,
-    viewsets.GenericViewSet,
+    viewsets.ModelViewSet,
 ):
     queryset = Organization.objects.all()
     permission_classes = (DataSourceOrganizationEditPermission,)
 
     def get_serializer_class(self, *args, **kwargs):
-        if self.action == "retrieve":
+        if self.action in ["create", "retrieve", "update"]:
             return OrganizationDetailSerializer
-        elif self.action == "create":
-            return OrganizationDetailSerializer
-        elif self.action == "update":
-            return OrganizationUpdateSerializer
         else:
             return OrganizationListSerializer
 

--- a/events/api.py
+++ b/events/api.py
@@ -1506,21 +1506,17 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.instance:
+        instance = self.instance
+        user = self.context["user"]
+
+        if instance:
             self.fields["data_source"].read_only = True
             self.fields["origin_id"].read_only = True
 
-    def to_representation(self, obj):
-        ret = super().to_representation(obj)
-
-        user = self.context["user"]
-        # Show admin users and regular users only to admins
-        user_fields = set(self.user_fields)
-        if user.is_anonymous or not user.is_admin_of(obj):
-            for field in user_fields:
-                del ret[field]
-
-        return ret
+            # Show admin users and regular users only to admins
+            if user.is_anonymous or not user.is_admin_of(instance):
+                for field in self.user_fields:
+                    self.fields.pop(field, None)
 
     def validate_parent_organization(self, value):
         if value:

--- a/events/api.py
+++ b/events/api.py
@@ -1482,7 +1482,7 @@ class OrganizationListSerializer(OrganizationBaseSerializer):
         return obj.regular_users.count() > 0
 
 
-class OrganizationUsersField(serializers.SlugRelatedField):
+class OrganizationUserField(serializers.SlugRelatedField):
     def __init__(self, **kwargs):
         super().__init__(queryset=User.objects.all(), slug_field="username", **kwargs)
 
@@ -1493,12 +1493,12 @@ class OrganizationUsersField(serializers.SlugRelatedField):
 class OrganizationDetailSerializer(OrganizationListSerializer):
     user_fields = ["admin_users", "regular_users"]
 
-    admin_users = OrganizationUsersField(
+    admin_users = OrganizationUserField(
         many=True,
         required=False,
     )
 
-    regular_users = OrganizationUsersField(
+    regular_users = OrganizationUserField(
         many=True,
         required=False,
     )

--- a/events/api.py
+++ b/events/api.py
@@ -1544,7 +1544,7 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
         # Add current user to admin users
         if "admin_users" not in validated_data:
             validated_data["admin_users"] = []
-        
+
         if self.user not in validated_data["admin_users"]:
             validated_data["admin_users"].append(self.user)
 

--- a/events/api.py
+++ b/events/api.py
@@ -1544,7 +1544,9 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
         # Add current user to admin users
         if "admin_users" not in validated_data:
             validated_data["admin_users"] = []
-        validated_data["admin_users"].append(self.user)
+        
+        if self.user not in validated_data["admin_users"]:
+            validated_data["admin_users"].append(self.user)
 
         connected_organizations = ["sub_organizations", "affiliated_organizations"]
         conn_orgs_in_request = {}

--- a/events/api.py
+++ b/events/api.py
@@ -1569,9 +1569,7 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
         # Prevent user to accidentally remove himself from admin
         if validated_data.get("admin_users") is not None:
             admin_users = validated_data.pop("admin_users")
-            instance.admin_users.clear()
-            instance.admin_users.add(*admin_users)
-            instance.admin_users.add(self.user)
+            instance.admin_users.set([*admin_users, self.user])
 
         return super().update(instance, validated_data)
 

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -8,6 +8,7 @@ from events.tests.utils import versioned_reverse as reverse
 organization_name = "test org"
 edited_organization_name = "new name"
 
+
 def organization_id(pk):
     obj_id = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
     return obj_id
@@ -79,7 +80,9 @@ def test_anonymous_user_cannot_see_organization_users(api_client, organization, 
 
 
 @pytest.mark.django_db
-def test_regular_user_cannot_see_organization_users(organization, user, user_api_client):
+def test_regular_user_cannot_see_organization_users(
+    organization, user, user_api_client
+):
     organization.regular_users.add(user)
     organization.admin_users.remove(user)
 
@@ -89,9 +92,7 @@ def test_regular_user_cannot_see_organization_users(organization, user, user_api
 
 
 @pytest.mark.django_db
-def test_admin_user_can_create_organization(
-    data_source, organization, user_api_client
-):
+def test_admin_user_can_create_organization(data_source, organization, user_api_client):
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
@@ -105,9 +106,7 @@ def test_admin_user_can_create_organization(
 
 
 @pytest.mark.django_db
-def test_cannot_create_organization_with_existing_id(
-    organization, user_api_client
-):
+def test_cannot_create_organization_with_existing_id(organization, user_api_client):
     payload = {
         "data_source": organization.data_source.id,
         "origin_id": organization.origin_id,
@@ -229,7 +228,9 @@ def test_create_organization_with_affiliated_organizations(
 
 
 @pytest.mark.django_db
-def test_user_is_automatically_added_to_admins_users(data_source, user, user_api_client):
+def test_user_is_automatically_added_to_admins_users(
+    data_source, user, user_api_client
+):
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
@@ -243,7 +244,9 @@ def test_user_is_automatically_added_to_admins_users(data_source, user, user_api
 
 
 @pytest.mark.django_db
-def test_admin_user_add_users_to_new_organization(data_source, user, user2, user_api_client):
+def test_admin_user_add_users_to_new_organization(
+    data_source, user, user2, user_api_client
+):
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
@@ -289,7 +292,7 @@ def test_anonymous_user_cannot_update_organization(api_client, organization):
 def test_regular_user_cannot_update_organization(organization, user, user_api_client):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
-    
+
     payload = {
         "id": organization.id,
         "name": edited_organization_name,
@@ -315,7 +318,9 @@ def test_admin_user_from_other_organization_cannot_update_organization(
 
 
 @pytest.mark.django_db
-def test_admin_user_can_edit_users(organization, super_user, user, user2, user_api_client):
+def test_admin_user_can_edit_users(
+    organization, super_user, user, user2, user_api_client
+):
     organization.admin_users.add(super_user)
 
     payload = {

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -1,143 +1,200 @@
 import pytest
 from django_orghierarchy.models import Organization
+from rest_framework import status
 
+from events.api import OrganizationDetailSerializer
 from events.tests.utils import versioned_reverse as reverse
 
 
-@pytest.mark.django_db
-def test_post_no_parent(user, organization, data_source, api_client):
+def organization_id(pk):
+    obj_id = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
+    return obj_id
+
+
+def get_organization(api_client, pk):
+    url = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
+
+    response = api_client.get(url, format="json")
+    return response
+
+
+def create_organization(api_client, organization_data):
     url = reverse("organization-list")
+
+    response = api_client.post(url, organization_data, format="json")
+    return response
+
+
+def assert_create_organization(api_client, organization_data):
+    response = create_organization(api_client, organization_data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    return response
+
+
+def delete_organization(api_client, pk):
+    url = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
+
+    response = api_client.delete(url)
+    return response
+
+
+def assert_delete_organization(api_client, pk):
+    response = delete_organization(api_client, pk)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    return response
+
+
+def update_organization(api_client, pk, organization_data):
+    url = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
+
+    response = api_client.put(url, organization_data, format="json")
+    return response
+
+
+def assert_update_organization(api_client, pk, organization_data):
+    response = update_organization(api_client, pk, organization_data)
+    assert response.status_code == status.HTTP_200_OK
+    return response
+
+
+@pytest.mark.django_db
+def test_admin_user_can_create_organization(
+    api_client, data_source, organization, user
+):
     api_client.force_authenticate(user)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 201
+    response = assert_create_organization(api_client, payload)
     assert response.data["name"] == payload["name"]
 
 
 @pytest.mark.django_db
-def test_post_existing_id_fails(user, organization, data_source, api_client):
-    url = reverse("organization-list")
+def test_cannot_create_organization_with_existing_id(
+    api_client, data_source, organization, user
+):
     api_client.force_authenticate(user)
 
     payload = {
-        "data_source": data_source.id,
+        "data_source": organization.data_source.id,
+        "origin_id": organization.origin_id,
         "id": organization.id,
-        "origin_id": "test_organization2",
         "name": "test org",
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 403
+    response = create_organization(api_client, payload)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["non_field_errors"][0].code == "unique"
 
 
 @pytest.mark.django_db
-def test_post_parent_user_has_rights(user, organization, data_source, api_client):
-    url = reverse("organization-list")
+def test_admin_user_can_create_organization_with_parent(
+    api_client, data_source, organization, user
+):
     api_client.force_authenticate(user)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
-        "parent_organization": f"{url}{organization.id}/",
+        "parent_organization": organization_id(organization.pk),
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 201
+    response = assert_create_organization(api_client, payload)
     assert response.data["parent_organization"] == payload["parent_organization"]
 
 
 @pytest.mark.django_db
-def test_post_parent_user_has_no_rights(
-    user2, organization, organization2, data_source, api_client
+def test_cannot_create_organization_with_parent_user_has_no_rights(
+    api_client, data_source, organization, organization2, user2
 ):
-    url = reverse("organization-list")
     api_client.force_authenticate(user2)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
-        "parent_organization": f"{url}{organization.id}/",
+        "parent_organization": organization_id(organization.pk),
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 403
+    response = create_organization(api_client, payload)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert str(response.data["detail"]) == "User has no rights to this organization"
 
 
 @pytest.mark.django_db
-def test_post_sub_organizations_successfull(
-    user, organization, organization2, data_source, api_client
+def test_create_organization_with_sub_organizations(
+    api_client, data_source, organization, organization2, user
 ):
-    url = reverse("organization-list")
     api_client.force_authenticate(user)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
-        "sub_organizations": [organization.id, organization2.id],
+        "sub_organizations": [
+            organization_id(organization.id),
+            organization_id(organization2.id),
+        ],
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 201
+    response = assert_create_organization(api_client, payload)
     org_id = response.data["id"]
-    response = api_client.get(url + org_id + "/", format="json")
-    assert set(
-        [i.strip("/").split("/")[-1] for i in response.data["sub_organizations"]]
-    ) == set(payload["sub_organizations"])
+    response = get_organization(api_client, org_id)
+    assert set(response.data["sub_organizations"]) == set(payload["sub_organizations"])
 
 
 @pytest.mark.django_db
-def test_post_sub_organizations_wrong_id(
-    user, organization, organization2, data_source, api_client
+def test_cannot_add_sub_organization_with_wrong_id(
+    api_client, data_source, organization, organization2, user
 ):
-    url = reverse("organization-list")
     api_client.force_authenticate(user)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
-        "sub_organizations": ["wrong.id", organization2.id],
+        "sub_organizations": ["wrong.id", organization_id(organization2.id)],
     }
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 201
+    response = assert_create_organization(api_client, payload)
     org_id = response.data["id"]
-    response = api_client.get(url + org_id + "/", format="json")
-    assert [
-        i.strip("/").split("/")[-1] for i in response.data["sub_organizations"]
-    ] == [organization2.id]
+    response = get_organization(api_client, org_id)
+    assert set(response.data["sub_organizations"]) == set(
+        [organization_id(organization2.id)]
+    )
 
 
 @pytest.mark.django_db
-def test_post_affiliated_organizations_successfull(
-    user, organization, organization2, data_source, api_client
+def test_create_organization_with_affiliated_organizations(
+    api_client, data_source, organization, organization2, user
 ):
-    url = reverse("organization-list")
     api_client.force_authenticate(user)
 
+    origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
-        "id": data_source.id + "test_organization2",
-        "origin_id": "test_organization2",
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
         "name": "test org",
         "affiliated_organizations": [
-            f"{url}{organization.id}/",
-            f"{url}{organization2.id}/",
+            organization_id(organization.id),
+            organization_id(organization2.id),
         ],
     }
 
@@ -145,103 +202,168 @@ def test_post_affiliated_organizations_successfull(
         i.internal_type = Organization.AFFILIATED
         i.save()
 
-    response = api_client.post(url, payload, format="json")
-    assert response.status_code == 201
+    response = assert_create_organization(api_client, payload)
     org_id = response.data["id"]
-    response = api_client.get(url + org_id + "/", format="json")
+    response = get_organization(api_client, org_id)
     assert set(response.data["affiliated_organizations"]) == set(
         payload["affiliated_organizations"]
     )
 
 
 @pytest.mark.django_db
-def test_put_user_has_rights(user, organization, api_client):
-    url = reverse("organization-list")
+def test_user_is_automatically_added_to_admins_users(api_client, data_source, user):
+    api_client.force_authenticate(user)
+
+    origin_id = "test_organization2"
+    payload = {
+        "data_source": data_source.id,
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
+        "name": "test org",
+    }
+
+    response = assert_create_organization(api_client, payload)
+    assert response.data["admin_users"][0]["username"] == user.username
+
+
+@pytest.mark.django_db
+def test_admin_user_add_users_to_new_organization(api_client, data_source, user, user2):
+    api_client.force_authenticate(user)
+
+    origin_id = "test_organization2"
+    payload = {
+        "data_source": data_source.id,
+        "origin_id": origin_id,
+        "id": f"{data_source.id}:{origin_id}",
+        "name": "test org",
+        "admin_users": [user.username, user2.username],
+        "regular_users": [user2.username],
+    }
+
+    response = assert_create_organization(api_client, payload)
+    assert set(payload["admin_users"]) == set(
+        [i["username"] for i in response.data["admin_users"]]
+    )
+    assert set(payload["regular_users"]) == set(
+        [i["username"] for i in response.data["regular_users"]]
+    )
+
+
+@pytest.mark.django_db
+def test_admin_user_can_update_organization(api_client, organization, user):
     api_client.force_authenticate(user)
 
     payload = {
-        "data_source": organization.data_source.id,
         "id": organization.id,
         "name": "new name",
-        "origin_id": "test_organization",
     }
 
-    response = api_client.put(f"{url}{organization.id}/", payload, format="json")
+    response = assert_update_organization(api_client, organization.id, payload)
     assert response.data["name"] == payload["name"]
 
 
 @pytest.mark.django_db
-def test_put_user_has_no_rights(user, user2, organization, api_client):
-    url = reverse("organization-list")
+def test_anonymous_user_can_update_organization(api_client, organization):
+    payload = {
+        "id": organization.id,
+        "name": "new name",
+    }
+
+    response = update_organization(api_client, organization.id, payload)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_update_organization(api_client, organization, user):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    payload = {
+        "id": organization.id,
+        "name": "new name",
+    }
+
+    response = update_organization(api_client, organization.id, payload)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_admin_user_from_other_organization_cannot_update_organization(
+    api_client, organization, user, user2
+):
     api_client.force_authenticate(user2)
 
     payload = {
-        "data_source": organization.data_source.id,
         "id": organization.id,
         "name": "new name",
-        "origin_id": "test_organization",
     }
 
-    response = api_client.put(f"{url}{organization.id}/", payload, format="json")
-    assert response.status_code == 403
+    response = update_organization(api_client, organization.id, payload)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test_delete_user_has_rights(user, organization, api_client):
-    url = reverse("organization-list")
-    api_client.force_authenticate(user)
-
-    response = api_client.delete(f"{url}{organization.id}/")
-    assert response.status_code == 204
-    response = api_client.get(f"{url}{organization.id}/", format="json")
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-def test_delete_user_has_no_rights(user, user2, organization, api_client):
-    url = reverse("organization-list")
-    api_client.force_authenticate(user2)
-
-    response = api_client.delete(f"{url}{organization.id}/")
-    assert response.status_code == 403
-
-
-@pytest.mark.django_db
-def test_add_users_wrong_field_format(user, user2, organization, api_client):
-    url = reverse("organization-list")
-    api_client.force_authenticate(user)
-
-    payload = {"id": organization.id, "admin_users": [user.username, user2.username]}
-
-    response = api_client.put(f"{url}{organization.id}/", payload, format="json")
-    assert response.data["detail"].code == "parse_error"
-
-
-@pytest.mark.django_db
-def test_edit_users(user, user2, super_user, organization, api_client):
-    url = reverse("organization-list")
+def test_admin_user_can_edit_users(api_client, organization, super_user, user, user2):
     api_client.force_authenticate(user)
     organization.admin_users.add(super_user)
 
     payload = {
         "id": organization.id,
-        "admin_users": {"username": [user.username, user2.username]},
-        "regular_users": {"username": [user2.username]},
+        "name": organization.name,
+        "admin_users": [user.username, user2.username],
+        "regular_users": [user2.username],
     }
 
-    response = api_client.put(f"{url}{organization.id}/", payload, format="json")
-    assert set(payload["admin_users"]["username"]) == set(
+    response = assert_update_organization(api_client, organization.pk, payload)
+    assert set(payload["admin_users"]) == set(
         [i["username"] for i in response.data["admin_users"]]
     )
-    assert len(response.data["regular_users"]) == 1
+    assert set(payload["regular_users"]) == set(
+        [i["username"] for i in response.data["regular_users"]]
+    )
 
 
 @pytest.mark.django_db
-def test_user_does_not_remove_itself_from_admins(user, user2, organization, api_client):
-    url = reverse("organization-list")
+def test_user_cannot_remove_itself_from_admins(user, organization, api_client):
     api_client.force_authenticate(user)
 
-    payload = {"id": organization.id, "admin_users": {"username": [user2.username]}}
+    payload = {"id": organization.id, "name": organization.name, "admin_users": []}
 
-    response = api_client.put(f"{url}{organization.id}/", payload, format="json")
-    assert len(response.data["admin_users"]) == 2
+    response = assert_update_organization(api_client, organization.pk, payload)
+    assert response.data["admin_users"][0]["username"] == user.username
+
+
+@pytest.mark.django_db
+def test_admin_user_can_delete_organization(api_client, organization, user):
+    api_client.force_authenticate(user)
+
+    assert_delete_organization(api_client, organization.id)
+    response = get_organization(api_client, organization.id)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_anonymous_user_can_delete_organization(api_client, organization):
+    response = delete_organization(api_client, organization.id)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_delete_organization(api_client, organization, user):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    response = delete_organization(api_client, organization.id)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_admin_user_from_other_organization_cannot_delete_organization(
+    api_client, organization, user, user2
+):
+    api_client.force_authenticate(user2)
+
+    response = delete_organization(api_client, organization.id)
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -5,6 +5,8 @@ from rest_framework import status
 from events.api import OrganizationDetailSerializer
 from events.tests.utils import versioned_reverse as reverse
 
+organization_name = "test org"
+edited_organization_name = "new name"
 
 def organization_id(pk):
     obj_id = reverse(OrganizationDetailSerializer.view_name, kwargs={"pk": pk})
@@ -59,11 +61,10 @@ def assert_update_organization(api_client, pk, organization_data):
 
 
 @pytest.mark.django_db
-def test_admin_user_can_see_organization_users(api_client, organization, user):
+def test_admin_user_can_see_organization_users(organization, user, user_api_client):
     organization.regular_users.add(user)
-    api_client.force_authenticate(user)
 
-    response = get_organization(api_client, organization.id)
+    response = get_organization(user_api_client, organization.id)
     assert response.data["admin_users"]
     assert response.data["regular_users"]
 
@@ -78,68 +79,61 @@ def test_anonymous_user_cannot_see_organization_users(api_client, organization, 
 
 
 @pytest.mark.django_db
-def test_regular_user_cannot_see_organization_users(api_client, organization, user):
+def test_regular_user_cannot_see_organization_users(organization, user, user_api_client):
     organization.regular_users.add(user)
     organization.admin_users.remove(user)
-    api_client.force_authenticate(user)
 
-    response = get_organization(api_client, organization.id)
+    response = get_organization(user_api_client, organization.id)
     assert response.data.get("admin_users") == None
     assert response.data.get("regular_users") == None
 
 
 @pytest.mark.django_db
 def test_admin_user_can_create_organization(
-    api_client, data_source, organization, user
+    data_source, organization, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     assert response.data["name"] == payload["name"]
 
 
 @pytest.mark.django_db
 def test_cannot_create_organization_with_existing_id(
-    api_client, data_source, organization, user
+    organization, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     payload = {
         "data_source": organization.data_source.id,
         "origin_id": organization.origin_id,
         "id": organization.id,
-        "name": "test org",
+        "name": organization_name,
     }
 
-    response = create_organization(api_client, payload)
+    response = create_organization(user_api_client, payload)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["non_field_errors"][0].code == "unique"
 
 
 @pytest.mark.django_db
 def test_admin_user_can_create_organization_with_parent(
-    api_client, data_source, organization, user
+    data_source, organization, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "parent_organization": organization_id(organization.pk),
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     assert response.data["parent_organization"] == payload["parent_organization"]
 
 
@@ -154,7 +148,7 @@ def test_cannot_create_organization_with_parent_user_has_no_rights(
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "parent_organization": organization_id(organization.pk),
     }
 
@@ -165,46 +159,42 @@ def test_cannot_create_organization_with_parent_user_has_no_rights(
 
 @pytest.mark.django_db
 def test_create_organization_with_sub_organizations(
-    api_client, data_source, organization, organization2, user
+    data_source, organization, organization2, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "sub_organizations": [
             organization_id(organization.id),
             organization_id(organization2.id),
         ],
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     org_id = response.data["id"]
-    response = get_organization(api_client, org_id)
+    response = get_organization(user_api_client, org_id)
     assert set(response.data["sub_organizations"]) == set(payload["sub_organizations"])
 
 
 @pytest.mark.django_db
 def test_cannot_add_sub_organization_with_wrong_id(
-    api_client, data_source, organization, organization2, user
+    data_source, organization, organization2, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "sub_organizations": ["wrong.id", organization_id(organization2.id)],
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     org_id = response.data["id"]
-    response = get_organization(api_client, org_id)
+    response = get_organization(user_api_client, org_id)
     assert set(response.data["sub_organizations"]) == set(
         [organization_id(organization2.id)]
     )
@@ -212,16 +202,14 @@ def test_cannot_add_sub_organization_with_wrong_id(
 
 @pytest.mark.django_db
 def test_create_organization_with_affiliated_organizations(
-    api_client, data_source, organization, organization2, user
+    data_source, organization, organization2, user_api_client
 ):
-    api_client.force_authenticate(user)
-
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "affiliated_organizations": [
             organization_id(organization.id),
             organization_id(organization2.id),
@@ -232,45 +220,41 @@ def test_create_organization_with_affiliated_organizations(
         i.internal_type = Organization.AFFILIATED
         i.save()
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     org_id = response.data["id"]
-    response = get_organization(api_client, org_id)
+    response = get_organization(user_api_client, org_id)
     assert set(response.data["affiliated_organizations"]) == set(
         payload["affiliated_organizations"]
     )
 
 
 @pytest.mark.django_db
-def test_user_is_automatically_added_to_admins_users(api_client, data_source, user):
-    api_client.force_authenticate(user)
-
+def test_user_is_automatically_added_to_admins_users(data_source, user, user_api_client):
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     assert response.data["admin_users"][0]["username"] == user.username
 
 
 @pytest.mark.django_db
-def test_admin_user_add_users_to_new_organization(api_client, data_source, user, user2):
-    api_client.force_authenticate(user)
-
+def test_admin_user_add_users_to_new_organization(data_source, user, user2, user_api_client):
     origin_id = "test_organization2"
     payload = {
         "data_source": data_source.id,
         "origin_id": origin_id,
         "id": f"{data_source.id}:{origin_id}",
-        "name": "test org",
+        "name": organization_name,
         "admin_users": [user.username, user2.username],
         "regular_users": [user2.username],
     }
 
-    response = assert_create_organization(api_client, payload)
+    response = assert_create_organization(user_api_client, payload)
     assert set(payload["admin_users"]) == set(
         [i["username"] for i in response.data["admin_users"]]
     )
@@ -280,15 +264,13 @@ def test_admin_user_add_users_to_new_organization(api_client, data_source, user,
 
 
 @pytest.mark.django_db
-def test_admin_user_can_update_organization(api_client, organization, user):
-    api_client.force_authenticate(user)
-
+def test_admin_user_can_update_organization(organization, user_api_client):
     payload = {
         "id": organization.id,
-        "name": "new name",
+        "name": edited_organization_name,
     }
 
-    response = assert_update_organization(api_client, organization.id, payload)
+    response = assert_update_organization(user_api_client, organization.id, payload)
     assert response.data["name"] == payload["name"]
 
 
@@ -296,7 +278,7 @@ def test_admin_user_can_update_organization(api_client, organization, user):
 def test_anonymous_user_cannot_update_organization(api_client, organization):
     payload = {
         "id": organization.id,
-        "name": "new name",
+        "name": edited_organization_name,
     }
 
     response = update_organization(api_client, organization.id, payload)
@@ -304,17 +286,16 @@ def test_anonymous_user_cannot_update_organization(api_client, organization):
 
 
 @pytest.mark.django_db
-def test_regular_user_cannot_update_organization(api_client, organization, user):
+def test_regular_user_cannot_update_organization(organization, user, user_api_client):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
-    api_client.force_authenticate(user)
-
+    
     payload = {
         "id": organization.id,
-        "name": "new name",
+        "name": edited_organization_name,
     }
 
-    response = update_organization(api_client, organization.id, payload)
+    response = update_organization(user_api_client, organization.id, payload)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -326,7 +307,7 @@ def test_admin_user_from_other_organization_cannot_update_organization(
 
     payload = {
         "id": organization.id,
-        "name": "new name",
+        "name": edited_organization_name,
     }
 
     response = update_organization(api_client, organization.id, payload)
@@ -334,8 +315,7 @@ def test_admin_user_from_other_organization_cannot_update_organization(
 
 
 @pytest.mark.django_db
-def test_admin_user_can_edit_users(api_client, organization, super_user, user, user2):
-    api_client.force_authenticate(user)
+def test_admin_user_can_edit_users(organization, super_user, user, user2, user_api_client):
     organization.admin_users.add(super_user)
 
     payload = {
@@ -345,7 +325,7 @@ def test_admin_user_can_edit_users(api_client, organization, super_user, user, u
         "regular_users": [user2.username],
     }
 
-    response = assert_update_organization(api_client, organization.pk, payload)
+    response = assert_update_organization(user_api_client, organization.pk, payload)
     assert set(payload["admin_users"]) == set(
         [i["username"] for i in response.data["admin_users"]]
     )
@@ -355,21 +335,17 @@ def test_admin_user_can_edit_users(api_client, organization, super_user, user, u
 
 
 @pytest.mark.django_db
-def test_user_cannot_remove_itself_from_admins(user, organization, api_client):
-    api_client.force_authenticate(user)
-
+def test_user_cannot_remove_itself_from_admins(organization, user, user_api_client):
     payload = {"id": organization.id, "name": organization.name, "admin_users": []}
 
-    response = assert_update_organization(api_client, organization.pk, payload)
+    response = assert_update_organization(user_api_client, organization.pk, payload)
     assert response.data["admin_users"][0]["username"] == user.username
 
 
 @pytest.mark.django_db
-def test_admin_user_can_delete_organization(api_client, organization, user):
-    api_client.force_authenticate(user)
-
-    assert_delete_organization(api_client, organization.id)
-    response = get_organization(api_client, organization.id)
+def test_admin_user_can_delete_organization(organization, user_api_client):
+    assert_delete_organization(user_api_client, organization.id)
+    response = get_organization(user_api_client, organization.id)
     assert response.status_code == 404
 
 
@@ -380,12 +356,11 @@ def test_anonymous_user_can_delete_organization(api_client, organization):
 
 
 @pytest.mark.django_db
-def test_regular_user_cannot_delete_organization(api_client, organization, user):
+def test_regular_user_cannot_delete_organization(organization, user, user_api_client):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
-    api_client.force_authenticate(user)
 
-    response = delete_organization(api_client, organization.id)
+    response = delete_organization(user_api_client, organization.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -59,6 +59,36 @@ def assert_update_organization(api_client, pk, organization_data):
 
 
 @pytest.mark.django_db
+def test_admin_user_can_see_organization_users(api_client, organization, user):
+    organization.regular_users.add(user)
+    api_client.force_authenticate(user)
+
+    response = get_organization(api_client, organization.id)
+    assert response.data["admin_users"]
+    assert response.data["regular_users"]
+
+
+@pytest.mark.django_db
+def test_anonymous_user_cannot_see_organization_users(api_client, organization, user):
+    organization.regular_users.add(user)
+
+    response = get_organization(api_client, organization.id)
+    assert response.data.get("admin_users") == None
+    assert response.data.get("regular_users") == None
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_see_organization_users(api_client, organization, user):
+    organization.regular_users.add(user)
+    organization.admin_users.remove(user)
+    api_client.force_authenticate(user)
+
+    response = get_organization(api_client, organization.id)
+    assert response.data.get("admin_users") == None
+    assert response.data.get("regular_users") == None
+
+
+@pytest.mark.django_db
 def test_admin_user_can_create_organization(
     api_client, data_source, organization, user
 ):

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -293,7 +293,7 @@ def test_admin_user_can_update_organization(api_client, organization, user):
 
 
 @pytest.mark.django_db
-def test_anonymous_user_can_update_organization(api_client, organization):
+def test_anonymous_user_cannot_update_organization(api_client, organization):
     payload = {
         "id": organization.id,
         "name": "new name",


### PR DESCRIPTION
## Description
At the moment `admin_users` and `regular_users` of an organization are not saved when creating a new organization. Fix this by using OrganizationDetailSerializer also when updating an organization instead of having separate serializer for update and having all logic to create/update organization in a single serializer. 
Change format of users in payload from
```
"admin_users": {
    "username": [
      "u-ui745qfmxmi63dvsbjmavaacea"
    ]
  },
```
to
```
"admin_users": ["u-ui745qfmxmi63dvsbjmavaacea"],
```
Show `admin_users` and `regular_users` field only for admin users and hide them if user has insufficient permissions.

PR for UI implementation: https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/189

## Closes
[LINK-1322](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1322)


[LINK-1322]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ