### PR TITLE
LINK-1362 | Prevent to signup to event if enrolment is not open

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -1,7 +1,7 @@
 from admin_auto_filters.filters import AutocompleteFilter
 from django.conf import settings
 from django.contrib import admin
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from leaflet.admin import LeafletGeoAdmin
 from modeltranslation.admin import TranslationAdmin
 from reversion.admin import VersionAdmin

--- a/events/api.py
+++ b/events/api.py
@@ -33,6 +33,7 @@ from django.urls import NoReverseMatch
 from django.utils import timezone, translation
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
+from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 from django_orghierarchy.models import Organization, OrganizationClass
 from haystack.query import AutoQuery
@@ -2580,7 +2581,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
     val = params.get("enrolment_open", None)
     if val:
         queryset = (
-            queryset.filter(registration__enrolment_end_time__gte=datetime.now())
+            queryset.filter(registration__enrolment_end_time__gte=localtime())
             .annotate(
                 free=(
                     F("registration__maximum_attendee_capacity")
@@ -2595,7 +2596,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
     val = params.get("enrolment_open_waitlist", None)
     if val:
         queryset = (
-            queryset.filter(registration__enrolment_end_time__gte=datetime.now())
+            queryset.filter(registration__enrolment_end_time__gte=localtime())
             .annotate(
                 free=(
                     (

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -733,8 +733,6 @@ def create_initial_licenses():
 def registration(event, user):
     return Registration.objects.create(
         event=event,
-        audience_min_age=6,
-        audience_max_age=18,
         created_by=user,
         last_modified_by=user,
         enrolment_start_time=localtime(),
@@ -750,8 +748,6 @@ def registration(event, user):
 def registration2(event2, user2):
     return Registration.objects.create(
         event=event2,
-        audience_min_age=6,
-        audience_max_age=18,
         created_by=user2,
         last_modified_by=user2,
         enrolment_start_time=localtime(),
@@ -767,8 +763,6 @@ def registration2(event2, user2):
 def registration3(event3, user):
     return Registration.objects.create(
         event=event3,
-        audience_min_age=6,
-        audience_max_age=18,
         created_by=user,
         last_modified_by=user,
         confirmation_message="Your registration is confirmed",

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -5,6 +5,7 @@ from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 
 # django
 from django.utils import timezone
+from django.utils.timezone import localtime
 from munigeo.models import (
     AdministrativeDivision,
     AdministrativeDivisionGeometry,
@@ -736,8 +737,8 @@ def registration(event, user):
         audience_max_age=18,
         created_by=user,
         last_modified_by=user,
-        enrolment_start_time=datetime.now(),
-        enrolment_end_time=datetime.now() + timedelta(days=10),
+        enrolment_start_time=localtime(),
+        enrolment_end_time=localtime() + timedelta(days=10),
         confirmation_message="Your registration is confirmed",
         maximum_attendee_capacity=20,
         waiting_list_capacity=20,
@@ -753,8 +754,8 @@ def registration2(event2, user2):
         audience_max_age=18,
         created_by=user2,
         last_modified_by=user2,
-        enrolment_start_time=datetime.now(),
-        enrolment_end_time=datetime.now() + timedelta(days=10),
+        enrolment_start_time=localtime(),
+        enrolment_end_time=localtime() + timedelta(days=10),
         confirmation_message="Your registration is confirmed",
         maximum_attendee_capacity=20,
         waiting_list_capacity=20,

--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -1,6 +1,6 @@
 from admin_auto_filters.filters import AutocompleteFilter
 from django.contrib import admin
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from reversion.admin import VersionAdmin
 
 from registrations.models import Registration

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -16,6 +16,7 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 
 from events.models import Event, Language
+from registrations.exceptions import ConflictException
 from registrations.utils import code_validity_duration
 
 User = settings.AUTH_USER_MODEL
@@ -225,6 +226,14 @@ class Registration(models.Model):
         return bool(
             self.event.data_source and self.event.data_source.user_editable_resources
         )
+
+    def validate_enrolment_times(self):
+        enrolment_start_time = self.enrolment_start_time
+        enrolment_end_time = self.enrolment_end_time
+        if enrolment_start_time and localtime() < enrolment_start_time:
+            raise ConflictException(_("Enrolment is not yet open."))
+        if enrolment_end_time and localtime() > enrolment_end_time:
+            raise ConflictException(_("Enrolment is already closed."))
 
 
 class SignUp(models.Model):

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -16,7 +16,6 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 
 from events.models import Event, Language
-from registrations.exceptions import ConflictException
 from registrations.utils import code_validity_duration
 
 User = settings.AUTH_USER_MODEL
@@ -226,14 +225,6 @@ class Registration(models.Model):
         return bool(
             self.event.data_source and self.event.data_source.user_editable_resources
         )
-
-    def validate_enrolment_times(self):
-        enrolment_start_time = self.enrolment_start_time
-        enrolment_end_time = self.enrolment_end_time
-        if enrolment_start_time and localtime() < enrolment_start_time:
-            raise ConflictException(_("Enrolment is not yet open."))
-        if enrolment_end_time and localtime() > enrolment_end_time:
-            raise ConflictException(_("Enrolment is already closed."))
 
 
 class SignUp(models.Model):

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -206,6 +206,10 @@ class CreateSignUpsSerializer(serializers.Serializer):
         reservation_code = data["reservation_code"]
         registration = data["registration"]
 
+        # Prevent to signup if enrolment is not open.
+        # Raises 409 error if enrolment is not open
+        registration.validate_enrolment_times()
+
         try:
             reservation = SeatReservationCode.objects.get(
                 code=reservation_code, registration=registration
@@ -300,6 +304,11 @@ class SeatReservationCodeSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(errors)
 
         registration = data["registration"]
+
+        # Prevent to reserve seats if enrolment is not open.
+        # Raises 409 error if enrolment is not open
+        registration.validate_enrolment_times()
+
         maximum_group_size = registration.maximum_group_size
 
         # Validate maximum group size

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytz
 from django.contrib.auth.models import AnonymousUser
@@ -224,7 +224,7 @@ class CreateSignUpsSerializer(serializers.Serializer):
         expiration = reservation.timestamp + timedelta(
             minutes=code_validity_duration(reservation.seats)
         )
-        if datetime.now().astimezone(pytz.utc) > expiration:
+        if localtime() > expiration:
             raise serializers.ValidationError(
                 {"reservation_code": "Reservation code has expired."}
             )

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -31,8 +31,8 @@ class TestRegistrationAdmin(TestCase):
         request = self.factory.get("/fake-url/")
         request.user = self.admin
 
-        self.assertEquals(["id"], registration_admin.get_readonly_fields(request))
-        self.assertEquals(
+        self.assertEqual(["id"], registration_admin.get_readonly_fields(request))
+        self.assertEqual(
             ["id", "event"],
             registration_admin.get_readonly_fields(request, self.registration),
         )
@@ -55,7 +55,7 @@ class TestRegistrationAdmin(TestCase):
 
         # Test that create_by values is set to current user
         registration = Registration.objects.get(event=event2)
-        self.assertEquals(
+        self.assertEqual(
             self.admin,
             registration.created_by,
         )
@@ -73,7 +73,7 @@ class TestRegistrationAdmin(TestCase):
             change=ra.get_action("change"),
         )
         # Test that last_modified_by values is set to current user
-        self.assertEquals(
+        self.assertEqual(
             self.admin,
             self.registration.last_modified_by,
         )

--- a/registrations/tests/test_registration_admin_side.py
+++ b/registrations/tests/test_registration_admin_side.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
+from django.utils.timezone import localtime
 
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import SignUp
@@ -19,16 +20,16 @@ def test_event_with_open_registrations_and_places_at_the_event(
     assert len(response.data["data"]) == 2
 
     # if registration is expired the respective event should not be returned
-    registration2.enrolment_start_time = datetime.now() - timedelta(days=10)
-    registration2.enrolment_end_time = datetime.now() - timedelta(days=5)
+    registration2.enrolment_start_time = localtime() - timedelta(days=10)
+    registration2.enrolment_end_time = localtime() - timedelta(days=5)
     registration2.save()
     response = api_client.get(f"{event_url}?enrolment_open=true", format="json")
     assert len(response.data["data"]) == 1
     assert registration.event.id == response.data["data"][0]["id"]
 
     # if there are no seats, the respective event should not be returned
-    registration2.enrolment_start_time = datetime.now()
-    registration2.enrolment_end_time = datetime.now() + timedelta(days=5)
+    registration2.enrolment_start_time = localtime()
+    registration2.enrolment_end_time = localtime() + timedelta(days=5)
     registration2.maximum_attendee_capacity = 1
     registration2.save()
     api_client.force_authenticate(user=None)
@@ -43,8 +44,8 @@ def test_event_with_open_registrations_and_places_at_the_event(
     assert registration.event.id == response.data["data"][0]["id"]
 
     # if maximum attendee capacity is None event should be returned
-    registration2.enrolment_start_time = datetime.now()
-    registration2.enrolment_end_time = datetime.now() + timedelta(days=5)
+    registration2.enrolment_start_time = localtime()
+    registration2.enrolment_end_time = localtime() + timedelta(days=5)
     registration2.maximum_attendee_capacity = None
     registration2.save()
     api_client.force_authenticate(user=None)
@@ -76,8 +77,8 @@ def test_event_with_open_registrations_and_places_at_the_event_or_waiting_list(
     assert len(response.data["data"]) == 2
 
     # if registration is expired the respective event should not be returned
-    registration2.enrolment_start_time = datetime.now() - timedelta(days=10)
-    registration2.enrolment_end_time = datetime.now() - timedelta(days=5)
+    registration2.enrolment_start_time = localtime() - timedelta(days=10)
+    registration2.enrolment_end_time = localtime() - timedelta(days=5)
     registration2.maximum_attendee_capacity = 20
     registration2.waiting_list_capacity = 10
     registration2.save()
@@ -88,8 +89,8 @@ def test_event_with_open_registrations_and_places_at_the_event_or_waiting_list(
     assert registration.event.id == response.data["data"][0]["id"]
 
     # no seats at event, places in waiting list
-    registration2.enrolment_start_time = datetime.now()
-    registration2.enrolment_end_time = datetime.now() + timedelta(days=5)
+    registration2.enrolment_start_time = localtime()
+    registration2.enrolment_end_time = localtime() + timedelta(days=5)
     registration2.maximum_attendee_capacity = 1
     registration2.waiting_list_capacity = 10
     registration2.save()
@@ -105,8 +106,8 @@ def test_event_with_open_registrations_and_places_at_the_event_or_waiting_list(
     assert len(response.data["data"]) == 2
 
     # no seats at event, no places in waiting list
-    registration2.enrolment_start_time = datetime.now()
-    registration2.enrolment_end_time = datetime.now() + timedelta(days=5)
+    registration2.enrolment_start_time = localtime()
+    registration2.enrolment_end_time = localtime() + timedelta(days=5)
     registration2.maximum_attendee_capacity = 1
     registration2.waiting_list_capacity = 0
     registration2.save()
@@ -116,8 +117,8 @@ def test_event_with_open_registrations_and_places_at_the_event_or_waiting_list(
     assert len(response.data["data"]) == 1
 
     # seats at event, waiting list capacity null
-    registration2.enrolment_start_time = datetime.now()
-    registration2.enrolment_end_time = datetime.now() + timedelta(days=5)
+    registration2.enrolment_start_time = localtime()
+    registration2.enrolment_end_time = localtime() + timedelta(days=5)
     registration2.maximum_attendee_capacity = 10
     registration2.waiting_list_capacity = None
     registration2.save()

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -171,8 +171,6 @@ def test_get_registration_with_event_and_audience_included(
 
 @pytest.mark.django_db
 def test_current_attendee_and_waitlist_count(api_client, registration, user):
-    registration.audience_min_age = None
-    registration.audience_max_age = None
     registration.maximum_attendee_capacity = 1
     registration.waiting_list_capacity = 1
     registration.save()

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -188,8 +188,6 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
     api_client, event, registration, user
 ):
     api_client.force_authenticate(user)
-    registration.audience_max_age = None
-    registration.audience_min_age = None
     registration.maximum_attendee_capacity = 1
     registration.save()
 


### PR DESCRIPTION
## Description
Fix some pytest warnings in registration tests
- Replace deprecated ugettext with gettext
- Replace deprecated assertEquals with assertEqual
- Use localtime instead of datetime.now

Prevent to reserve seats or signup if enrolment is not open

PR for frontend implementation: https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/188

## Closes
[LINK-1362](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1362)

[LINK-1362]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ