### PR TITLE
LIIKUNTA-450 | Fetch data directly from Elis in kulke importer

### DIFF
--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -301,8 +301,6 @@ class KulkeImporter(Importer):
     languages_to_detect = []
 
     def setup(self):
-        self.eventcodes_set = set()
-        self.file = open("eventcodes.txt", "w")
         self.languages_to_detect = [
             lang[0].replace("-", "_")
             for lang in settings.LANGUAGES
@@ -493,7 +491,6 @@ class KulkeImporter(Importer):
             return clean(text(k))
 
         eid = int(event_el.attrib["id"])
-        self.eventcodes_set.add(text_content("servicecode"))
         if text_content("servicecode") != "Pelkkä ilmoitus" and not is_course:
             # Skip courses when importing events
             return False
@@ -938,10 +935,6 @@ class KulkeImporter(Importer):
     def import_events(self):
         logger.info("Importing Kulke events")
         self._import_events()
-        for i in self.eventcodes_set:
-            self.file.write(i)
-            self.file.write("\n")
-        self.file.close()
 
     def import_courses(self):
         logger.info("Importing Kulke courses")

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 EVENTS_URL_TEMPLATE = urljoin(
     settings.ELIS_EVENT_API_URL,
-    "events/?searchstarttime={begin_date}&sort=starttime&show=100&offset={offset}&language={language}",
+    "event?searchstarttime={begin_date}&sort=starttime&show=100&offset={offset}&language={language}",
 )
 CATEGORY_URL = urljoin(settings.ELIS_EVENT_API_URL, "category")
 EVENT_API_TIMEOUT = 30

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -260,9 +260,6 @@ USE_TZ = True
 
 LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
-# Kulke importer looks here for its input files
-IMPORT_FILE_PATH = os.path.join(BASE_DIR, "data")
-
 # Static files (CSS, JavaScript, Images)
 
 STATIC_URL = env("STATIC_URL")

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -53,6 +53,10 @@ env = environ.Env(
     DATABASE_URL=(str, "postgis:///linkedevents"),
     DEBUG=(bool, False),
     ELASTICSEARCH_URL=(str, None),
+    ELIS_EVENT_API_URL=(
+        str,
+        "http://elis.helsinki1.hki.local/event-api/",
+    ),
     ENABLE_EXTERNAL_USER_EVENTS=(bool, True),
     ENABLE_REGISTRATION_ENDPOINTS=(bool, False),
     EXTERNAL_USER_PUBLISHER_ID=(str, "others"),
@@ -394,6 +398,9 @@ SEAT_RESERVATION_DURATION = env("SEAT_RESERVATION_DURATION")
 # Urls to Linked Events UI and Linked Registration UI
 LINKED_EVENTS_UI_URL = env("LINKED_EVENTS_UI_URL")
 LINKED_REGISTRATIONS_UI_URL = env("LINKED_REGISTRATIONS_UI_URL")
+
+# Used in kulke importer
+ELIS_EVENT_API_URL = env("ELIS_EVENT_API_URL")
 
 
 def haystack_connection_for_lang(language_code):


### PR DESCRIPTION
### Description
Instead of reading event/category data from XML files exported from Elis using a script, directly call Elis API in the KulKe importer.

Also fix logging warnings for differing groups.