### PR TITLE
YSO importer: Only accept supported languages when updating

### DIFF
--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -234,6 +234,8 @@ class YsoImporter(Importer):
 
     def update_keyword(self, keyword, graph, subject):
         for _, literal in graph.preferredLabel(subject):
+            if literal.language not in self.supported_languages:
+                continue
             with override(literal.language, deactivate=True):
                 if keyword.name != str(literal):
                     logger.debug(


### PR DESCRIPTION
In a similar way to importing alt labels, only accept supported languages when updating keywords. If a language is not supported (in this case configured in Django) the default language will apparently be used, which caused Finnish language to have mixed translations.

Refs LINK-1299