### PR TITLE
LINK-1299 | YSO importer keyword deprecation handles invalid YSO ids

### DIFF
--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -86,6 +86,8 @@ def deprecate_and_replace(graph, keyword):
             new_keyword = Keyword.objects.get(id=get_yso_id(replacement_subject))
         except Keyword.DoesNotExist:
             pass
+        except ValidationError:
+            logger.exception("New keyword has invalid YSO id")
     if new_keyword:
         logger.info("Keyword %s replaced by %s" % (keyword, new_keyword))
         new_keyword.events.add(*keyword.events.all())


### PR DESCRIPTION
Deprecate and replace functionality failed if an invalid YSO id was encountered.