### PR TITLE
LINK-1347 | Fix deprecated keywords upon import

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -897,10 +897,13 @@ class KeywordViewSet(
             keyword = Keyword.objects.get(pk=kwargs["pk"])
         except Keyword.DoesNotExist:
             raise Http404()
-        if keyword.replaced_by:
-            keyword = keyword.get_replacement()
+        if replacement_keyword := keyword.get_replacement():
             return HttpResponsePermanentRedirect(
-                reverse("keyword-detail", kwargs={"pk": keyword.pk}, request=request)
+                reverse(
+                    "keyword-detail",
+                    kwargs={"pk": replacement_keyword.pk},
+                    request=request,
+                )
             )
         if keyword.deprecated:
             raise KeywordDeprecatedException()

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -173,6 +173,7 @@ class YsoImporter(Importer):
             try:
                 old_keyword = Keyword.objects.get(id=old_id)
                 new_keyword = Keyword.objects.get(id=new_id)
+                old_keyword.replace(new_keyword)
             except ObjectDoesNotExist:
                 continue
             logger.info(

--- a/events/models.py
+++ b/events/models.py
@@ -466,18 +466,18 @@ class Keyword(BaseModel, ImageMixin, ReplacedByMixin):
         old_replaced_by = None
         if self.id:
             try:
-                old_replaced_by = Keyword.objects.get(id=self.id).replaced_by
+                old_replaced_by = Keyword.objects.get(id=self.id).get_replacement()
             except Keyword.DoesNotExist:
                 pass
 
         super().save(*args, **kwargs)
 
-        if not old_replaced_by == self.replaced_by:
+        if not old_replaced_by == self.get_replacement():
             # Remap keyword sets
             qs = KeywordSet.objects.filter(keywords__id__exact=self.id)
             for kw_set in qs:
                 kw_set.keywords.remove(self)
-                kw_set.keywords.add(self.replaced_by)
+                kw_set.keywords.add(self.get_replacement())
                 kw_set.save()
 
             # Remap events
@@ -487,10 +487,10 @@ class Keyword(BaseModel, ImageMixin, ReplacedByMixin):
             for event in qs:
                 if self in event.keywords.all():
                     event.keywords.remove(self)
-                    event.keywords.add(self.replaced_by)
+                    event.keywords.add(self.get_replacement())
                 if self in event.audience.all():
                     event.audience.remove(self)
-                    event.audience.add(self.replaced_by)
+                    event.audience.add(self.get_replacement())
 
     def can_be_edited_by(self, user):
         """Check if current keyword can be edited by the given user"""

--- a/events/models.py
+++ b/events/models.py
@@ -158,6 +158,10 @@ class ReplacedByMixin:
 
     def get_replacement(self):
         replacement = self.replaced_by
+
+        if replacement is None:
+            return None
+
         while replacement.replaced_by is not None:
             replacement = replacement.replaced_by
         return replacement

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from events import utils
-from events.models import DataSource, Event
+from events.models import DataSource, Event, Keyword
 
 
 class DataSourceFactory(factory.django.DjangoModelFactory):
@@ -40,3 +40,15 @@ class DefaultOrganizationEventFactory(EventFactory):
     @factory.lazy_attribute
     def data_source(self):
         return self.publisher.data_source
+
+
+class KeywordFactory(factory.django.DjangoModelFactory):
+    data_source = factory.SubFactory(DataSourceFactory)
+    publisher = factory.SubFactory(OrganizationFactory)
+
+    class Meta:
+        model = Keyword
+
+    @factory.lazy_attribute_sequence
+    def id(self, n):
+        return f"{self.data_source.id}:{n}"


### PR DESCRIPTION
Kulke importer was running into some issues when trying to save an event (course) with deprecated keywords. This PR adds logic which will replace or just delete deprecated keywords from an event upon import. Also added fixes for the YSO keyword importer and the keyword replacement logic.

**Manual testing results**

I deprecated some keywords manually for event `kulke:59821`. Deprecated keyword without a replacement was removed and keyword with a replacement was replaced. Works-on-my-machine :rainbow:  :tm:

```
2023-06-23 00:11:28,994 events.importer.base DEBUG: Checking for deprecated keywords in attribute 'keywords' for event Manual Productions: kesäkurssi – 9-12 v klo 9-14.30 (kulke:59821) 2023-06-12 06:00:00+00:00
2023-06-23 00:11:29,018 events.importer.base WARNING: Replacing deprecated keyword kulke:753 with yso:p9999 from attribute 'keywords' for event Manual Productions: kesäkurssi – 9-12 v klo 9-14.30 (kulke:59821) 2023-06-12 06:00:00+00:00.
2023-06-23 00:11:29,026 events.importer.base WARNING: Removing deprecated keyword kulke:596 from attribute 'keywords' for event Manual Productions: kesäkurssi – 9-12 v klo 9-14.30 (kulke:59821) 2023-06-12 06:00:00+00:00. Couldn't find a replacement.
```

Keywords for the event in question after the import.
```
In [1]: e = Event.objects.get(pk="kulke:59821")

In [3]: for k in e.keywords.all():
   ...:     print(k.pk)
   ...: 
yso:p9999
kulke:729
kulke:629
kulke:301
kulke:46
kulke:53
yso:p9270
yso:p16650
yso:p7277
```

