### PR TITLE
Add doc generation to Kulke importer

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -67,6 +67,10 @@ class Importer(object):
             self.bounding_box = None
         self.gps_to_target_ct = CoordTransform(gps_srs, target_srs)
 
+        # Don't run setup when generating documentation
+        if self.options.get("generate_docs"):
+            return
+
         self.setup()
 
         # this has to be run after setup, as it relies on organization and data source being set

--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -850,13 +850,10 @@ class EnkoraImporter(Importer):
         return event.deleted
 
     @staticmethod
-    def generate_documentation_md(
-        output_file: Optional[str] = None,
-    ) -> None:  # noqa: C901
+    def generate_documentation_md() -> str:  # noqa: C901
         """
         Generate MarkDown document out of Enkora importing rules.
-        :param output_file: (optional) Output file to write MarkDown document into.
-        :return: nothing
+        :return: documentation string
         """
         from snakemd import Inline, MDList, new_doc, Paragraph
 
@@ -994,16 +991,8 @@ class EnkoraImporter(Importer):
 
         doc.add_block(MDList(ul))
 
-        # Finally:
-        if output_file:
-            # Write MD to a file
-            with open(output_file, "wt") as out:
-                out.write(str(doc))
-        else:
-            # Print MD
-            print(doc)
-
         # Done!
+        return str(doc)
 
     def _handle_course(self, course: dict) -> dict:
         """

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime, time, timedelta
 from posixpath import join as urljoin
 from textwrap import dedent
-from typing import Iterator, Optional, Union
+from typing import Iterator, Union
 
 import dateutil
 import requests
@@ -1032,14 +1032,10 @@ class KulkeImporter(Importer):
                 )
 
     @staticmethod
-    def generate_documentation_md(
-        output_file: Optional[str] = None,
-    ) -> None:  # noqa: C901
+    def generate_documentation_md() -> str:
         """
         Generate MarkDown document covering Kulke importer logic and mappings.
-        :param output_file: (optional) Output file to write MarkDown document into.
-                            Writes to stdout if not given
-        :return: nothing
+        :return: documentation string
         """
 
         from snakemd import new_doc
@@ -1057,11 +1053,11 @@ class KulkeImporter(Importer):
         # Section about field mapping
         KulkeImporter._md_doc_fields(doc)
 
-        # Section about event locations.
+        # Section about event locations
         KulkeImporter._md_doc_location(doc)
 
         # Section about categories, with subsections about ignored categories,
-        # course categories, and YSO keywords.
+        # course categories, and YSO keywords
         doc.add_heading("Categories", level=2)
         KulkeImporter.md_doc_ignored_categories(doc)
         KulkeImporter._md_doc_courses(doc)
@@ -1070,14 +1066,7 @@ class KulkeImporter(Importer):
         # Section about super events
         KulkeImporter._md_doc_super_events(doc)
 
-        # Finally:
-        if output_file:
-            # Write MD to a file
-            with open(output_file, "wt") as out:
-                out.write(str(doc))
-        else:
-            # Print MD
-            print(doc)
+        return str(doc)
 
     @staticmethod
     def _md_doc_fields(doc):

--- a/events/management/commands/event_importer_doc.py
+++ b/events/management/commands/event_importer_doc.py
@@ -1,0 +1,65 @@
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import activate
+
+from events.importer.base import get_importers
+
+
+class Command(BaseCommand):
+    help = "Generate event importer documentation"
+
+    def __init__(self):
+        super().__init__()
+        self.importers = get_importers()
+        self.imp_list = ", ".join(sorted(self.importers.keys()))
+        self.missing_args_message = (
+            "Enter the name of the event importer module. Valid importers: {}".format(
+                self.imp_list
+            )
+        )
+
+    def add_arguments(self, parser):
+        parser.add_argument("module")
+        parser.add_argument(
+            "--output-file",
+            action="store",
+            dest="output_file",
+            help="Write output to a file, not to STDOUT.",
+        )
+
+    def handle(self, *args, **options):
+        module = options["module"]
+        if module not in self.importers:
+            raise CommandError(
+                "Importer %s not found. Valid importers: %s" % (module, self.imp_list)
+            )
+        imp_class = self.importers[module]
+
+        if hasattr(settings, "PROJECT_ROOT"):
+            root_dir = settings.PROJECT_ROOT
+        else:
+            root_dir = settings.BASE_DIR
+        importer = imp_class(
+            {
+                "data_path": os.path.join(root_dir, "data"),
+                "verbosity": int(options["verbosity"]),
+                "generate_docs": True,
+            }
+        )
+
+        # Activate the default language
+        # to make sure translated fields are populated correctly.
+        activate(settings.LANGUAGES[0][0])
+
+        name = "generate_documentation_md"
+        method = getattr(importer, name, None)
+        if not method:
+            raise CommandError(
+                "Importer {} does not support documentation generation".format(
+                    importer.name
+                )
+            )
+
+        method(options["output_file"])


### PR DESCRIPTION
Generate docs about the Kulke importer with the target audience being someone who creates events and needs to understand how the event will be represented in LE.

The docs will contain information about the various data transformations and mappings that the importer performs.