### PR TITLE
Delete events not found in Elis in kulke importer

### DIFF
--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -837,30 +837,27 @@ class KulkeImporter(Importer):
         for lang in self.languages:
             name_attr = f"name_{lang}"
             first_name = getattr(first_event, name_attr)
-            words = first_name.split(" ") if first_name else None
+            words = first_name.split(" ") if first_name else []
 
             if name_attr not in common_fields:
                 name = ""
                 member_event_names = [
                     getattr(event, name_attr) for event in member_events
                 ]
-                while words and all(
-                    member_event_name.startswith(name + words[0])
-                    if member_event_name
-                    else False
-                    for member_event_name in member_event_names
-                ):
-                    name += words.pop(0) + " "
 
-                if name:
-                    setattr(super_event, name_attr, name.rstrip())
-                else:
-                    # If a common part was not found, default to the first event's name
-                    setattr(
-                        super_event,
-                        name_attr,
-                        getattr(first_event, name_attr),
-                    )
+                # Try to find the common part of the names
+                for word in words:
+                    if all(
+                        member_event_name and member_event_name.startswith(name + word)
+                        for member_event_name in member_event_names
+                    ):
+                        name += word + " "
+                    else:
+                        name = name.rstrip()
+                        break
+
+                # If a common part was not found, default to the first event's name
+                setattr(super_event, name_attr, name or getattr(first_event, name_attr))
 
         # Gather common keywords present in *all* subevents
         common_keywords = functools.reduce(

--- a/events/models.py
+++ b/events/models.py
@@ -144,7 +144,10 @@ class BaseQuerySet(models.QuerySet):
 
 
 class BaseTreeQuerySet(TreeQuerySet, BaseQuerySet):
-    pass
+    def soft_delete(self):
+        return self.update(deleted=True)
+
+    soft_delete.alters_data = True
 
 
 class ReplacedByMixin:

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -43,6 +43,8 @@ class DefaultOrganizationEventFactory(EventFactory):
 
 
 class KeywordFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker("bs")
+
     data_source = factory.SubFactory(DataSourceFactory)
     publisher = factory.SubFactory(OrganizationFactory)
 

--- a/events/tests/importers/test_kulke.py
+++ b/events/tests/importers/test_kulke.py
@@ -224,7 +224,7 @@ class TestKulkeImporter(TestCase):
         event_2 = EventFactory(
             data_source=self.data_source, origin_id=2, start_time=now
         )
-        # Old event, outside of the date range of the Elis search -- won't be removed
+        # Old event, outside the date range of the Elis search -- won't be removed
         event_3 = EventFactory(
             data_source=self.data_source,
             origin_id=3,
@@ -236,9 +236,9 @@ class TestKulkeImporter(TestCase):
             begin_date=now - timedelta(days=60),
         )
 
-        self.assertFalse(Event.objects.filter(id=event_1.id).exists())
-        self.assertTrue(Event.objects.filter(id=event_2.id).exists())
-        self.assertTrue(Event.objects.filter(id=event_3.id).exists())
+        self.assertFalse(Event.objects.filter(id=event_1.id, deleted=False).exists())
+        self.assertTrue(Event.objects.filter(id=event_2.id, deleted=False).exists())
+        self.assertTrue(Event.objects.filter(id=event_3.id, deleted=False).exists())
 
     @pytest.mark.django_db
     def test__handle_removed_events_superevent(self):
@@ -269,10 +269,18 @@ class TestKulkeImporter(TestCase):
             begin_date=now - timedelta(days=60),
         )
 
-        self.assertFalse(Event.objects.filter(id=super_1_event_1.id).exists())
-        self.assertFalse(Event.objects.filter(id=super_1_event_2.id).exists())
-        self.assertFalse(Event.objects.filter(id=super_1.id).exists())
-        self.assertTrue(Event.objects.filter(id=super_2_event_1.id).exists())
-        self.assertTrue(Event.objects.filter(id=super_2_event_2.id).exists())
-        self.assertTrue(Event.objects.filter(id=super_2.id).exists())
-        self.assertFalse(Event.objects.filter(id=super_3.id).exists())
+        self.assertFalse(
+            Event.objects.filter(id=super_1_event_1.id, deleted=False).exists()
+        )
+        self.assertFalse(
+            Event.objects.filter(id=super_1_event_2.id, deleted=False).exists()
+        )
+        self.assertFalse(Event.objects.filter(id=super_1.id, deleted=False).exists())
+        self.assertTrue(
+            Event.objects.filter(id=super_2_event_1.id, deleted=False).exists()
+        )
+        self.assertTrue(
+            Event.objects.filter(id=super_2_event_2.id, deleted=False).exists()
+        )
+        self.assertTrue(Event.objects.filter(id=super_2.id, deleted=False).exists())
+        self.assertFalse(Event.objects.filter(id=super_3.id, deleted=False).exists())

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -17,3 +17,4 @@ pytest-django
 pytest-factoryboy
 python-jose
 requests-mock
+snakemd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -149,6 +149,8 @@ six==1.16.0
     #   freezegun
     #   python-dateutil
     #   requests-mock
+snakemd==2.1.0
+    # via -r requirements-dev.in
 sqlparse==0.4.4
     # via
     #   -c requirements.txt


### PR DESCRIPTION
If there are events that have previously been imported, but have since been removed in Elis, there's currently no mechanism to remove them from LE. This PR adds such a mechanism. Basically we check for any events that we have previously imported that no longer exist in Elis. We won't touch events that are older than the start date we use for the Elis search though.

Also, the fix for the empty name issue in my previous PR was not sufficient, so I fixed that. The logic for taking the common part when creating a super event name should now work in all supported languages.

When reviewing, please pay special attention to the logic for selecting which events to delete.

