### PR TITLE
LINK-1370 | Send email to participant when she's moved from waiting list to participant

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -763,9 +763,9 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
         VOLUNTEERING = 3
 
     TYPE_IDS = (
-        (TypeId.GENERAL, _("General")),
-        (TypeId.COURSE, _("Course")),
-        (TypeId.VOLUNTEERING, _("Volunteering")),
+        (TypeId.GENERAL, "General"),
+        (TypeId.COURSE, "Course"),
+        (TypeId.VOLUNTEERING, "Volunteering"),
     )
 
     class EventEnvironment(models.TextChoices):

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-30 11:31+0300\n"
+"POT-Creation-Date: 2023-07-03 12:43+0300\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <jori@3d.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -749,7 +749,7 @@ msgstr "Lisätietoja asiakaspalvelustamme"
 
 #: registrations/templates/message_to_signup.html:13
 #: registrations/templates/signup_confirmation.html:46
-#: registrations/templates/signup_confirmation_to_waiting_list.html:41
+#: registrations/templates/signup_confirmation_to_waiting_list.html:28
 #: registrations/templates/signup_transferred_as_participant.html:34
 msgid "Check your registration here"
 msgstr "Tarkastele ilmoittautumistasi täällä"
@@ -803,24 +803,7 @@ msgstr ""
 "Onnittelut! Olet onnistuneesti ilmoittautunut vapaaehtoistehtävään "
 "<strong>%(event)s</strong>."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:11
-#, python-format
-msgid "Registration for the event %(event)s waiting list has been saved."
-msgstr "Ilmoittautuminen tapahtuman %(event)s jonotuslistaan on tallennettu."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:14
-#, python-format
-msgid "Registration for the course %(event)s waiting list has been saved."
-msgstr "Ilmoittautuminen kurssin %(event)s jonotuslistaan on tallennettu."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:17
-#, python-format
-msgid ""
-"Registration for the volunteering %(event)s waiting list has been saved."
-msgstr ""
-"Ilmoittautuminen vapaaehtoistehtävän %(event)s jonotuslistaan on tallennettu."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:25
+#: registrations/templates/signup_confirmation_to_waiting_list.html:12
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event)s</strong> "
@@ -829,7 +812,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut tapahtuman <strong>%(event)s</strong> "
 "jonotuslistalle."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:28
+#: registrations/templates/signup_confirmation_to_waiting_list.html:15
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event)s</strong> "
@@ -838,7 +821,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut kurssin <strong>%(event)s</strong> "
 "jonotuslistalle."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:31
+#: registrations/templates/signup_confirmation_to_waiting_list.html:18
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering <strong>%(event)s</"
@@ -847,7 +830,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut vapaaehtoistehtävän <strong>%(event)s</"
 "strong> jonotuslistalle."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:35
+#: registrations/templates/signup_confirmation_to_waiting_list.html:22
 msgid ""
 "You will be transferred as a participant automatically when a seat becomes "
 "available."
@@ -856,29 +839,29 @@ msgstr "Sinut siirretään automaattisesti osallistujaksi paikan vapauduttua."
 #: registrations/templates/signup_transferred_as_participant.html:16
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the event "
-"<strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the event <strong>%(event)s</"
+"strong> to a participant."
 msgstr ""
-"Onnittelut! Sinut on siirretty tapahtuman <strong>%(event)s</strong> "
-"jonotuslistalta osallistujaksi."
+"Sinut on siirretty tapahtuman <strong>%(event)s</strong> jonotuslistalta "
+"osallistujaksi."
 
 #: registrations/templates/signup_transferred_as_participant.html:19
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the course "
-"<strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the course <strong>%(event)s</"
+"strong> to a participant."
 msgstr ""
-"Onnittelut! Sinut on siirretty kurssin <strong>%(event)s</strong> "
-"jonotuslistalta osallistujaksi."
+"Sinut on siirretty kurssin <strong>%(event)s</strong> jonotuslistalta "
+"osallistujaksi."
 
 #: registrations/templates/signup_transferred_as_participant.html:22
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the "
-"volunteering <strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the volunteering "
+"<strong>%(event)s</strong> to a participant."
 msgstr ""
-"Onnittelut! Sinut on siirretty vapaaehtoistehtävän <strong>%(event)s</"
-"strong> jonotuslistalta osallistujaksi."
+"Sinut on siirretty vapaaehtoistehtävän <strong>%(event)s</strong> "
+"jonotuslistalta osallistujaksi."
 
 #~ msgid "Admins"
 #~ msgstr "Ylläpitäjät"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-26 10:19+0300\n"
+"POT-Creation-Date: 2023-06-30 11:31+0300\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <jori@3d.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,18 +19,55 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.7.6\n"
 
+#: events/admin.py:197
+msgid "Contact info"
+msgstr "Yhteystiedot"
+
 #: events/models.py:77 events/models.py:168 events/models.py:185
-#: events/models.py:299 events/models.py:348 events/models.py:359
-#: events/models.py:1187 events/models.py:1203 events/models.py:1253
-#: registrations/models.py:29 registrations/models.py:258
+#: events/models.py:299 events/models.py:348 events/models.py:362
+#: events/models.py:1190 events/models.py:1206 events/models.py:1256
+#: registrations/models.py:37 registrations/models.py:266
 #: venv/lib/python3.9/site-packages/munigeo/models.py:83
 #: venv/lib/python3.9/site-packages/munigeo/models.py:112
 #: venv/lib/python3.9/site-packages/munigeo/models.py:141
 msgid "Name"
 msgstr "Nimi"
 
-#: events/models.py:198 events/models.py:390 events/models.py:553
-#: events/models.py:828
+#: events/models.py:87
+msgid "Resources may be edited by users"
+msgstr "Käyttäjät voivat muokata resursseja"
+
+#: events/models.py:90
+#: venv/lib/python3.9/site-packages/django_orghierarchy/models.py:20
+msgid "Organizations may be edited by users"
+msgstr "Käyttäjät voivat muokata organisaatioita"
+
+#: events/models.py:93
+msgid "Past events may be edited using API"
+msgstr "Menneitä tapahtumia voidaan muokata API:n kautta"
+
+#: events/models.py:96
+msgid "Past events may be created using API"
+msgstr "Menneitä tapahtumia voidaan luoda API:n kautta"
+
+#: events/models.py:100
+msgid "Do not show events created by this data_source by default."
+msgstr "Älä näytä tämän datalähteen luomia tapahtumia oletuksena."
+
+#: events/models.py:169
+msgid "Url"
+msgstr "Url"
+
+#: events/models.py:172 events/models.py:230
+msgid "License"
+msgstr "Lisenssi"
+
+#: events/models.py:173
+msgid "Licenses"
+msgstr "Lisenssit"
+
+#: events/models.py:198 events/models.py:393 events/models.py:556
+#: events/models.py:831
 msgid "Publisher"
 msgstr "Julkaisija"
 
@@ -43,187 +80,378 @@ msgstr "Kuva"
 msgid "Cropping"
 msgstr "Rajaus"
 
+#: events/models.py:236
+msgid "Photographer name"
+msgstr "Valokuvaajan nimi"
+
+#: events/models.py:239 events/models.py:1213
+msgid "Alt text"
+msgstr "Vaihtoehtoinen teksti"
+
 #: events/models.py:302
 msgid "Origin ID"
 msgstr "Lähdetunniste"
 
-#: events/models.py:354
+#: events/models.py:350
+msgid "Can be used as registration service language"
+msgstr "Voidaan käyttää ilmoittautumisen palvelukielenä"
+
+#: events/models.py:357
 msgid "language"
 msgstr "kieli"
 
-#: events/models.py:355
+#: events/models.py:358
 msgid "languages"
 msgstr "kielet"
 
-#: events/models.py:403 events/models.py:608
+#: events/models.py:406 events/models.py:611
 #, fuzzy
 #| msgid "event"
 msgid "event count"
 msgstr "tapahtumien lukumäärä"
 
-#: events/models.py:495
+#: events/models.py:407
+msgid "number of events with this keyword"
+msgstr "tapahtumien määrä tällä avainsanalla"
+
+#: events/models.py:498
 msgid "keyword"
 msgstr "Avainsana"
 
-#: events/models.py:496
+#: events/models.py:499
 msgid "keywords"
 msgstr "Avainsanat"
 
-#: events/models.py:557
+#: events/models.py:525
+msgid "Intended keyword usage"
+msgstr "Avainsanan suunniteltu käyttötarkoitus"
+
+#: events/models.py:530
+msgid "Organization which uses this set"
+msgstr "Organisaatio, joka käyttää tätä avainsanaryhmää"
+
+#: events/models.py:543
+msgid "KeywordSet can't have deprecated keywords"
+msgstr "Avainsanaryhmässä ei voi olla käytöstä poistettuja avainsanoja"
+
+#: events/models.py:560
 msgid "Place home page"
 msgstr "Paikan kotisivu"
 
-#: events/models.py:559 events/models.py:800
+#: events/models.py:562 events/models.py:803
 msgid "Description"
 msgstr "Kuvaus"
 
-#: events/models.py:566 events/models.py:1254 registrations/models.py:275
+#: events/models.py:569 events/models.py:1257 registrations/models.py:283
 msgid "E-mail"
 msgstr "Sähköposti"
 
-#: events/models.py:568
+#: events/models.py:571
 msgid "Telephone"
 msgstr "Puhelinnumero"
 
-#: events/models.py:574 registrations/models.py:31 registrations/models.py:327
+#: events/models.py:574
+msgid "Contact type"
+msgstr "Yhteydtiedon tyyppi"
+
+#: events/models.py:577 registrations/models.py:39 registrations/models.py:335
 msgid "Street address"
 msgstr "Katuosoite"
 
+#: events/models.py:580
+msgid "Address locality"
+msgstr "Osoitteen paikkakunta"
+
 #: events/models.py:583
+#, fuzzy
+#| msgid "Address locality"
+msgid "Address region"
+msgstr "Osoitteen paikkakunta"
+
+#: events/models.py:586
 msgid "Postal code"
 msgstr "Postinumero"
 
 #: events/models.py:589
+msgid "PO BOX"
+msgstr "Postilokero"
+
+#: events/models.py:592
 msgid "Country"
 msgstr "Maa"
 
-#: events/models.py:592
+#: events/models.py:595
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: events/models.py:617
+#: events/models.py:612
+msgid "number of events in this location"
+msgstr "tapahtumien määrä tässä paikassa"
+
+#: events/models.py:620
 msgid "place"
 msgstr "paikka"
 
-#: events/models.py:618
+#: events/models.py:621
 msgid "places"
 msgstr "paikat"
 
-#: events/models.py:722
+#: events/models.py:725
 msgid "opening hour specification"
 msgstr "aukioloaika"
 
-#: events/models.py:723
+#: events/models.py:726
 msgid "opening hour specifications"
 msgstr "aukioloajat"
 
-#: events/models.py:798
+#: events/models.py:756
+msgid "Recurring"
+msgstr "Toistuva tapahtuma"
+
+#: events/models.py:757
+msgid "Umbrella event"
+msgstr "Kattotapahtuma"
+
+#: events/models.py:772
+msgid "Outdoors"
+msgstr "Ulkona"
+
+#: events/models.py:773
+msgid "Indoors"
+msgstr "Sisällä"
+
+#: events/models.py:777
+msgid "User name"
+msgstr "Käyttäjän nimi"
+
+#: events/models.py:779
+msgid "User e-mail"
+msgstr "Käyttäjän sähköpostiosoite"
+
+#: events/models.py:781
+msgid "User phone number"
+msgstr "Käyttäjän puhelinnumero"
+
+#: events/models.py:787
+msgid "User organization"
+msgstr "Käyttäjän organisaatio"
+
+#: events/models.py:788
+msgid "Event organizer information."
+msgstr "Tapahtuman järjestäjän tiedot."
+
+#: events/models.py:794
+msgid "User consent"
+msgstr "Käyttäjän suostumus"
+
+#: events/models.py:795
+msgid "I consent to the processing of my personal data?"
+msgstr "Hyväksynkö henkilötietojeni käsittelyn?"
+
+#: events/models.py:801
 msgid "Event home page"
 msgstr "Tapahtuman kotisivu"
 
-#: events/models.py:802
+#: events/models.py:805
 msgid "Short description"
 msgstr "Lyhyt kuvaus"
 
-#: events/models.py:807
+#: events/models.py:810
 msgid "Date published"
 msgstr "Julkaisupäivämäärä"
 
-#: events/models.py:817
+#: events/models.py:820
 msgid "Headline"
 msgstr "Otsikko"
 
-#: events/models.py:842
+#: events/models.py:823
+msgid "Secondary headline"
+msgstr "Toissijainen otsikko"
+
+#: events/models.py:825
+msgid "Provider"
+msgstr "Palveluntarjoaja"
+
+#: events/models.py:827
+msgid "Provider's contact info"
+msgstr "Palveluntarjoajan yhteystiedot"
+
+#: events/models.py:837
+msgid "Environmental certificate"
+msgstr "Ympäristösertifikaatti"
+
+#: events/models.py:845
 msgid "Event status"
 msgstr "Tapahtuman tila"
 
-#: events/models.py:858
+#: events/models.py:852
+msgid "Event data publication status"
+msgstr "Tapahtumatietojen julkaisun tila"
+
+#: events/models.py:861
 msgid "Location extra info"
 msgstr "Paikan lisätiedot"
 
-#: events/models.py:870
+#: events/models.py:864
+msgid "Event environment"
+msgstr "Tapahtuman ympäristö"
+
+#: events/models.py:865
+msgid "Will the event be held outdoors?"
+msgstr "Pidetäänkö tapahtuma ulkona?"
+
+#: events/models.py:873
 msgid "Start time"
 msgstr "Alkuaika"
 
-#: events/models.py:873
+#: events/models.py:876
 msgid "End time"
 msgstr "Loppuaika"
 
-#: events/models.py:879 registrations/models.py:72
+#: events/models.py:882 registrations/models.py:80
 msgid "Minimum recommended age"
 msgstr "Suositeltu vähimmäisikä"
 
-#: events/models.py:882 registrations/models.py:75
+#: events/models.py:885 registrations/models.py:83
 msgid "Maximum recommended age"
 msgstr "Suurin suositeltu ikä"
 
-#: events/models.py:912
+#: events/models.py:915
 msgid "In language"
 msgstr "kielellä"
 
-#: events/models.py:928
+#: events/models.py:931
 msgid "maximum attendee capacity"
 msgstr "Paikkojen enimmäismäärä"
 
-#: events/models.py:934
+#: events/models.py:937
 msgid "minimum attendee capacity"
 msgstr "Paikkojen vähimmäismäärä"
 
-#: events/models.py:937
+#: events/models.py:940
 msgid "enrolment start time"
 msgstr "Ilmoittautumisen alkamisaika"
 
-#: events/models.py:940
+#: events/models.py:943
 msgid "enrolment end time"
 msgstr "Ilmoittautumisen päättymisaika"
 
-#: events/models.py:956
+#: events/models.py:959
 msgid "event"
 msgstr "tapahtuma"
 
-#: events/models.py:957
+#: events/models.py:960
 msgid "events"
 msgstr "tapahtumat"
 
-#: events/models.py:1168
+#: events/models.py:1008
+msgid "The event end time cannot be earlier than the start time."
+msgstr "Tapahtuman päättymisaika ei voi olla aikaisempi kuin alkamisaika."
+
+#: events/models.py:1020
+msgid "Trying to save event with deprecated keywords "
+msgstr "Yritetään tallentaa tapahtumaa vanhentuneilla avainsanoilla"
+
+#: events/models.py:1171
 msgid "Price"
 msgstr "Hinta"
 
-#: events/models.py:1170
+#: events/models.py:1173
 msgid "Web link to offer"
 msgstr "Linkki lipunmyyntiin"
 
-#: events/models.py:1173
+#: events/models.py:1176
 msgid "Offer description"
 msgstr "Hintatietojen kuvaus"
 
-#: events/models.py:1177
+#: events/models.py:1180
 msgid "Is free"
 msgstr "Vapaa pääsy"
+
+#: events/models.py:1258 notifications/models.py:47
+msgid "Subject"
+msgstr "Otsikko"
+
+#: events/models.py:1259 notifications/models.py:53
+msgid "Body"
+msgstr "Teksti"
+
+#: events/permissions.py:92 events/permissions.py:113
+msgid "Data source is not editable"
+msgstr "Tietolähde ei ole muokattavissa"
+
+#: events/permissions.py:127
+msgid "Only admins of any organization are allowed to see the content."
+msgstr ""
+"Vain minkä tahansa organisaation admin-käyttäjät voivat nähdä sisällön."
+
+#: events/utils.py:269
+msgid "Data source doesn't belong to any organization"
+msgstr "Tietolähde ei kuulu millekään organisaatiolle"
+
+#: notifications/apps.py:7
+msgid "Notifications"
+msgstr "Ilmoitukset"
+
+#: notifications/models.py:32
+msgid "Unpublished event deleted"
+msgstr "Julkaisematon tapahtuma poistettu"
 
 #: notifications/models.py:33
 msgid "Event published"
 msgstr "Tapahtuman julkaisupäivämäärä"
 
+#: notifications/models.py:34
+msgid "Draft posted"
+msgstr "Luonnos lähetetty"
+
+#: notifications/models.py:35
+msgid "User created"
+msgstr "Käyttäjä luotu"
+
+#: notifications/models.py:39
+msgid "Type"
+msgstr "Tyyppi"
+
+#: notifications/models.py:54
+msgid "Text body for email notifications"
+msgstr "Sähköposti-ilmoitusten tekstiosa"
+
+#: notifications/models.py:59
+msgid "HTML Body"
+msgstr "HTML-teksti"
+
+#: notifications/models.py:60
+msgid "HTML body for email notifications"
+msgstr "Sähköposti-ilmoitusten HTML-teksti"
+
+#: notifications/models.py:65
+msgid "Notification template"
+msgstr "Ilmoituspohja"
+
+#: notifications/models.py:66
+msgid "Notification templates"
+msgstr "Ilmoituspohjat"
+
 #: registrations/admin.py:10
 msgid "Event"
 msgstr "Tapahtuma"
 
-#: registrations/api.py:79
+#: registrations/api.py:84
 msgid "Registration with signups cannot be deleted"
 msgstr "Ilmoittautumista, jolla on osallistujia ei voi poistaa"
 
-#: registrations/api.py:274
+#: registrations/api.py:282
 #, python-brace-format
 msgid "Registration with id {pk} doesn't exist."
 msgstr "Ilmoittautumista tunnuksella {pk} ei ole olemassa."
 
-#: registrations/api.py:280
+#: registrations/api.py:288
 #, python-brace-format
 msgid "Only the admins of the organization {organization} have access rights."
 msgstr "Vain organisaation {organization} admin-käyttäjillä on oikeudet."
 
-#: registrations/api.py:309
+#: registrations/api.py:317
 #, python-brace-format
 msgid "attendee_status can take following values: {statuses}, not {val}"
 msgstr ""
@@ -233,141 +461,134 @@ msgstr ""
 msgid "Request conflict with the current state of the target resource"
 msgstr "Pyyntö on ristiriidassa kohderesurssin nykyisen tilan kanssa"
 
-#: registrations/models.py:28 registrations/models.py:268
+#: registrations/models.py:36 registrations/models.py:276
 msgid "City"
 msgstr "Kaupunki"
 
-#: registrations/models.py:30 registrations/models.py:291
+#: registrations/models.py:38 registrations/models.py:299
 msgid "Phone number"
 msgstr "Puhelinnumero"
 
-#: registrations/models.py:32 registrations/models.py:334
+#: registrations/models.py:40 registrations/models.py:342
 msgid "ZIP code"
 msgstr "Postinumero"
 
-#: registrations/models.py:78
+#: registrations/models.py:86
 msgid "Created at"
 msgstr "Luotu klo"
 
-#: registrations/models.py:80
+#: registrations/models.py:88
 msgid "Modified at"
 msgstr "Muokattu klo"
 
-#: registrations/models.py:99
+#: registrations/models.py:107
 msgid "Enrollment start time"
 msgstr "Ilmoittautumisen alkamisaika"
 
-#: registrations/models.py:102
+#: registrations/models.py:110
 msgid "Enrollment end time"
 msgstr "Ilmoittautumisen päättymisaika"
 
-#: registrations/models.py:106
+#: registrations/models.py:114
 msgid "Confirmation message"
 msgstr "Vahvistusviesti"
 
-#: registrations/models.py:109
+#: registrations/models.py:117
 msgid "Instructions"
 msgstr "Ohjeet"
 
-#: registrations/models.py:113
+#: registrations/models.py:121
 msgid "Maximum attendee capacity"
 msgstr "Paikkojen enimmäismäärä"
 
-#: registrations/models.py:116
+#: registrations/models.py:124
 msgid "Minimum attendee capacity"
 msgstr "Paikkojen vähimmäismäärä"
 
-#: registrations/models.py:119
+#: registrations/models.py:127
 msgid "Waiting list capacity"
 msgstr "Varasijapaikkojen lukumäärä"
 
-#: registrations/models.py:122
+#: registrations/models.py:130
 msgid "Maximum group size"
 msgstr "Ryhmän enimmäiskoko"
 
-#: registrations/models.py:136
+#: registrations/models.py:144
 msgid "Mandatory fields"
 msgstr "Pakolliset kentät"
 
-#: registrations/models.py:237
+#: registrations/models.py:245
 msgid "Waitlisted"
 msgstr "Varasijalla"
 
-#: registrations/models.py:238
+#: registrations/models.py:246
 msgid "Attending"
 msgstr "Osallistuu"
 
-#: registrations/models.py:248
+#: registrations/models.py:256
 msgid "No Notification"
 msgstr "Ei ilmoituksia"
 
-#: registrations/models.py:249
+#: registrations/models.py:257
 msgid "SMS"
 msgstr "Teksiviesti"
 
-#: registrations/models.py:250
+#: registrations/models.py:258
 msgid "E-Mail"
 msgstr "Sähköposti"
 
-#: registrations/models.py:251
+#: registrations/models.py:259
 msgid "Both SMS and email."
 msgstr "Tekstiviesti ja sähköposti"
 
-#: registrations/models.py:265
+#: registrations/models.py:273
 msgid "Date of birth"
 msgstr "Syntymäaika"
 
-#: registrations/models.py:278
+#: registrations/models.py:286
 msgid "Extra info"
 msgstr "Lisätiedot"
 
-#: registrations/models.py:284
+#: registrations/models.py:292
 msgid "Membership number"
 msgstr "Jäsennumero"
 
-#: registrations/models.py:298
+#: registrations/models.py:306
 msgid "Notification type"
 msgstr "Ilmoitusten tyyppi"
 
-#: registrations/models.py:304
+#: registrations/models.py:312
 msgid "Cancellation code"
 msgstr "Peruutuskoodi"
 
-#: registrations/models.py:307
+#: registrations/models.py:315
 msgid "Attendee status"
 msgstr "Osallistujan tila"
 
-#: registrations/models.py:391
-msgid "to event"
-msgstr "tapahtumaan"
-
-#: registrations/models.py:392
-msgid "to course"
-msgstr "kurssille"
-
-#: registrations/models.py:393
-msgid "to volunteering"
-msgstr "vapaaehtoistehtävään"
-
-#: registrations/models.py:404
-#, python-format
-msgid "Registration confirmation - %(event_name)s"
-msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
-
-#: registrations/models.py:406
+#: registrations/models.py:413
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Ilmoittautuminen peruttu - %(event_name)s"
 
-#: registrations/models.py:424
+#: registrations/models.py:417 registrations/models.py:425
+#, python-format
+msgid "Registration confirmation - %(event_name)s"
+msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
+
+#: registrations/models.py:421
+#, python-format
+msgid "Waiting list seat reserved - %(event_name)s"
+msgstr "Paikka jonotuslistalla varattu - %(event_name)s"
+
+#: registrations/models.py:448
 msgid "Number of seats"
 msgstr "Paikkojen lukumäärä"
 
-#: registrations/models.py:430
+#: registrations/models.py:454
 msgid "Seat reservation code"
 msgstr "Paikkavarauskoodi"
 
-#: registrations/models.py:433
+#: registrations/models.py:457
 msgid "Timestamp"
 msgstr "Aikaleima"
 
@@ -379,32 +600,40 @@ msgstr "cancellation_code-parametri on pakollinen"
 msgid "Cancellation code did not match"
 msgstr "Peruutuskoodi ei täsmää"
 
-#: registrations/serializers.py:44
+#: registrations/serializers.py:29
+msgid "Enrolment is not yet open."
+msgstr "Ilmoittautuminen ei ole vielä auki."
+
+#: registrations/serializers.py:31
+msgid "Enrolment is already closed."
+msgstr "Ilmoittautuminen on jo päättynyt."
+
+#: registrations/serializers.py:69
 msgid "The waiting list is already full"
 msgstr "Jonotuslista on jo täynnä"
 
-#: registrations/serializers.py:54
+#: registrations/serializers.py:79
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Olemassa olevan objektin attendee_status-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:61
+#: registrations/serializers.py:86
 msgid "You may not change the registration of an existing object."
 msgstr "Olemassa olevan objektin registration-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:82 registrations/serializers.py:89
-#: registrations/serializers.py:293
+#: registrations/serializers.py:107 registrations/serializers.py:114
+#: registrations/serializers.py:322
 msgid "This field must be specified."
 msgstr "Kenttä on pakollinen."
 
-#: registrations/serializers.py:105
+#: registrations/serializers.py:130
 msgid "The participant is too young."
 msgstr "Osallistuja on liian nuori."
 
-#: registrations/serializers.py:110
+#: registrations/serializers.py:135
 msgid "The participant is too old."
 msgstr "Osallistuja on liian vanha."
 
-#: registrations/serializers.py:168
+#: registrations/serializers.py:193
 #, python-brace-format
 msgid ""
 "Only the admins of the organization that published the event {event_id} have "
@@ -413,33 +642,34 @@ msgstr ""
 "Vain tapahtuman {event_id} julkaisseen organisaation admin-käyttäjillä on "
 "oikeudet."
 
-#: registrations/serializers.py:218
+#: registrations/serializers.py:247
 msgid "Reservation code doesn't exist."
 msgstr "Varauskoodia ei ole olemassa."
 
-#: registrations/serializers.py:240
+#: registrations/serializers.py:269
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Ilmoittautumisten määrä on suurempi kuin ryhmän enimmäiskoko: "
 "{max_group_size}."
 
-#: registrations/serializers.py:296
+#: registrations/serializers.py:325
 msgid "The value doesn't match."
 msgstr "Arvo ei täsmää."
 
-#: registrations/serializers.py:309
+#: registrations/serializers.py:343
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
-msgstr "Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
+msgstr ""
+"Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
 
-#: registrations/serializers.py:334
+#: registrations/serializers.py:368
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Paikkoja ei ole riittävästi jäljellä. Paikkoja jäljellä: {capacity_left}."
 
-#: registrations/serializers.py:350
+#: registrations/serializers.py:384
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -447,7 +677,7 @@ msgstr ""
 "Jonotuslistalle ei ole tarpeeksi paikkoja jäljellä. Paikkoja jäljellä "
 "jonotuslistalla: {capacity_left}."
 
-#: registrations/serializers.py:364
+#: registrations/serializers.py:398
 msgid "Cannot update expired seats reservation."
 msgstr "Vanhentunutta paikkavarausta ei voi päivittää."
 
@@ -467,48 +697,188 @@ msgstr "Helsingin kaupunki 2023"
 msgid "All rights reserved."
 msgstr "Kaikki oikeudet pidätetään."
 
-#: registrations/templates/cancellation_confirmation.html:8
+#: registrations/templates/cancellation_confirmation.html:9
 msgid "Registration cancelled"
 msgstr "Ilmoittautuminen peruttu"
 
-#: registrations/templates/cancellation_confirmation.html:9
+#: registrations/templates/cancellation_confirmation.html:14
 #, python-format
-msgid "Registration %(to_event_type)s %(event)s has been cancelled."
-msgstr "Ilmoittautuminen %(to_event_type)s %(event)s on peruttu."
+msgid "Registration to the event %(event)s has been cancelled."
+msgstr "Ilmoittautuminen tapahtumaan %(event)s on peruttu."
 
-#: registrations/templates/cancellation_confirmation.html:12
+#: registrations/templates/cancellation_confirmation.html:17
+#, python-format
+msgid "Registration to the course %(event)s has been cancelled."
+msgstr "Ilmoittautuminen kurssille %(event)s on peruttu."
+
+#: registrations/templates/cancellation_confirmation.html:20
+#, python-format
+msgid "Registration to the volunteering %(event)s has been cancelled."
+msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event)s on peruttu."
+
+#: registrations/templates/cancellation_confirmation.html:28
 #, python-format
 msgid ""
-"You have successfully canceled your registration %(to_event_type)s %(event)s."
+"You have successfully cancelled your registration to the event "
+"<strong>%(event)s</strong>."
 msgstr ""
-"Olet onnistuneesti peruuttanut ilmoittautumisesi %(to_event_type)s %(event)s."
+"Olet onnistuneesti peruuttanut ilmoittautumisesi tapahtumaan "
+"<strong>%(event)s</strong>."
 
-#: registrations/templates/cancellation_confirmation.html:15
+#: registrations/templates/cancellation_confirmation.html:31
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the course "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Olet onnistuneesti peruuttanut ilmoittautumisesi kurssille "
+"<strong>%(event)s</strong>."
+
+#: registrations/templates/cancellation_confirmation.html:34
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the volunteering "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Olet onnistuneesti peruuttanut ilmoittautumisesi vapaaehtoistehtävään "
+"<strong>%(event)s</strong>."
+
+#: registrations/templates/cancellation_confirmation.html:40
 msgid "More information from our customer service"
 msgstr "Lisätietoja asiakaspalvelustamme"
 
 #: registrations/templates/message_to_signup.html:13
-#: registrations/templates/signup_confirmation.html:17
+#: registrations/templates/signup_confirmation.html:46
+#: registrations/templates/signup_confirmation_to_waiting_list.html:41
+#: registrations/templates/signup_transferred_as_participant.html:34
 msgid "Check your registration here"
 msgstr "Tarkastele ilmoittautumistasi täällä"
 
-#: registrations/templates/signup_confirmation.html:8
+#: registrations/templates/signup_confirmation.html:9
+#: registrations/templates/signup_transferred_as_participant.html:9
 #, python-format
 msgid "Welcome %(username)s"
 msgstr "Tervetuloa %(username)s"
 
-#: registrations/templates/signup_confirmation.html:9
+#: registrations/templates/signup_confirmation.html:14
 #, python-format
-msgid "Registration %(to_event_type)s %(event)s saved."
-msgstr "Ilmoittautuminen %(to_event_type)s %(event)s tallennettu."
+msgid "Registration to the event %(event)s has been saved."
+msgstr "Ilmoittautuminen tapahtuman %(event)s jonotuslistaan on tallennettu."
 
-#: registrations/templates/signup_confirmation.html:12
+#: registrations/templates/signup_confirmation.html:17
+#, python-format
+msgid "Registration to the course %(event)s has been saved."
+msgstr "Ilmoittautuminen kurssin %(event)s jonotuslistaan on tallennettu."
+
+#: registrations/templates/signup_confirmation.html:20
+#, python-format
+msgid "Registration to the volunteering %(event)s has been saved."
+msgstr ""
+"Ilmoittautuminen vapaaehtoistehtävän %(event)s jonotuslistaan on tallennettu."
+
+#: registrations/templates/signup_confirmation.html:28
 #, python-format
 msgid ""
-"Congratulations! You have successfully registered %(to_event_type)s "
-"%(event)s."
+"Congratulations! You have successfully registered to the event "
+"<strong>%(event)s</strong>."
 msgstr ""
-"Onnittelut! Olet onnistuneesti ilmoittautunut %(to_event_type)s %(event)s."
+"Onnittelut! Olet onnistuneesti ilmoittautunut tapahtumaan <strong>%(event)s</"
+"strong>."
+
+#: registrations/templates/signup_confirmation.html:31
+#, python-format
+msgid ""
+"Congratulations! You have successfully registered to the course "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Onnittelut! Olet onnistuneesti ilmoittautunut kurssille <strong>%(event)s</"
+"strong>."
+
+#: registrations/templates/signup_confirmation.html:34
+#, python-format
+msgid ""
+"Congratulations! You have successfully registered to the volunteering "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Onnittelut! Olet onnistuneesti ilmoittautunut vapaaehtoistehtävään "
+"<strong>%(event)s</strong>."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:11
+#, python-format
+msgid "Registration for the event %(event)s waiting list has been saved."
+msgstr "Ilmoittautuminen tapahtuman %(event)s jonotuslistaan on tallennettu."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:14
+#, python-format
+msgid "Registration for the course %(event)s waiting list has been saved."
+msgstr "Ilmoittautuminen kurssin %(event)s jonotuslistaan on tallennettu."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:17
+#, python-format
+msgid ""
+"Registration for the volunteering %(event)s waiting list has been saved."
+msgstr ""
+"Ilmoittautuminen vapaaehtoistehtävän %(event)s jonotuslistaan on tallennettu."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:25
+#, python-format
+msgid ""
+"You have successfully registered for the event <strong>%(event)s</strong> "
+"waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut tapahtuman <strong>%(event)s</strong> "
+"jonotuslistalle."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:28
+#, python-format
+msgid ""
+"You have successfully registered for the course <strong>%(event)s</strong> "
+"waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut kurssin <strong>%(event)s</strong> "
+"jonotuslistalle."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:31
+#, python-format
+msgid ""
+"You have successfully registered for the volunteering <strong>%(event)s</"
+"strong> waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut vapaaehtoistehtävän <strong>%(event)s</"
+"strong> jonotuslistalle."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:35
+msgid ""
+"You will be transferred as a participant automatically when a seat becomes "
+"available."
+msgstr "Sinut siirretään automaattisesti osallistujaksi paikan vapauduttua."
+
+#: registrations/templates/signup_transferred_as_participant.html:16
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the event "
+"<strong>%(event)s</strong> to a participant."
+msgstr ""
+"Onnittelut! Sinut on siirretty tapahtuman <strong>%(event)s</strong> "
+"jonotuslistalta osallistujaksi."
+
+#: registrations/templates/signup_transferred_as_participant.html:19
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the course "
+"<strong>%(event)s</strong> to a participant."
+msgstr ""
+"Onnittelut! Sinut on siirretty kurssin <strong>%(event)s</strong> "
+"jonotuslistalta osallistujaksi."
+
+#: registrations/templates/signup_transferred_as_participant.html:22
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the "
+"volunteering <strong>%(event)s</strong> to a participant."
+msgstr ""
+"Onnittelut! Sinut on siirretty vapaaehtoistehtävän <strong>%(event)s</"
+"strong> jonotuslistalta osallistujaksi."
 
 #~ msgid "Admins"
 #~ msgstr "Ylläpitäjät"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-30 11:30+0300\n"
+"POT-Creation-Date: 2023-07-03 12:43+0300\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <jori@3d.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -739,7 +739,7 @@ msgstr "Mer information om vår kundtjänst"
 
 #: registrations/templates/message_to_signup.html:13
 #: registrations/templates/signup_confirmation.html:46
-#: registrations/templates/signup_confirmation_to_waiting_list.html:41
+#: registrations/templates/signup_confirmation_to_waiting_list.html:28
 #: registrations/templates/signup_transferred_as_participant.html:34
 msgid "Check your registration here"
 msgstr "Kontrollera din registrering här"
@@ -792,23 +792,7 @@ msgstr ""
 "Grattis! Du har framgångsrikt registrerat dig till volontärarbetet "
 "<strong>%(event)s</strong>."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:11
-#, python-format
-msgid "Registration for the event %(event)s waiting list has been saved."
-msgstr "Anmälan till evenemanget %(event)s väntelista har sparats."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:14
-#, python-format
-msgid "Registration for the course %(event)s waiting list has been saved."
-msgstr "Anmälan till kursen %(event)s väntelista har sparats."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:17
-#, python-format
-msgid ""
-"Registration for the volunteering %(event)s waiting list has been saved."
-msgstr "Anmälan till volontärarbetet %(event)s väntelista har sparats."
-
-#: registrations/templates/signup_confirmation_to_waiting_list.html:25
+#: registrations/templates/signup_confirmation_to_waiting_list.html:12
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event)s</strong> "
@@ -817,7 +801,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för evenemangets <strong>%(event)s</"
 "strong> väntelista."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:28
+#: registrations/templates/signup_confirmation_to_waiting_list.html:15
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event)s</strong> "
@@ -826,7 +810,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för kursen <strong>%(event)s</strong> "
 "väntelista."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:31
+#: registrations/templates/signup_confirmation_to_waiting_list.html:18
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering <strong>%(event)s</"
@@ -835,7 +819,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för volontärarbetets <strong>%(event)s</"
 "strong> väntelista."
 
-#: registrations/templates/signup_confirmation_to_waiting_list.html:35
+#: registrations/templates/signup_confirmation_to_waiting_list.html:22
 msgid ""
 "You will be transferred as a participant automatically when a seat becomes "
 "available."
@@ -844,26 +828,26 @@ msgstr "Du överförs automatiskt som deltagare när en plats blir ledig."
 #: registrations/templates/signup_transferred_as_participant.html:16
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the event "
-"<strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the event <strong>%(event)s</"
+"strong> to a participant."
 msgstr ""
-"Grattis! Du har flyttats från väntelistan för evenemanget <strong>%(event)s</"
-"strong> till en deltagare."
+"Du har flyttats från väntelistan för evenemanget <strong>%(event)s</strong> "
+"till en deltagare."
 
 #: registrations/templates/signup_transferred_as_participant.html:19
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the course "
-"<strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the course <strong>%(event)s</"
+"strong> to a participant."
 msgstr ""
-"Grattis! Du har flyttats från väntelistan för kursen <strong>%(event)s</"
-"strong> till en deltagare."
+"Du har flyttats från väntelistan för kursen <strong>%(event)s</strong> till "
+"en deltagare."
 
 #: registrations/templates/signup_transferred_as_participant.html:22
 #, python-format
 msgid ""
-"Congratulations! You have been moved from the waiting list of the "
-"volunteering <strong>%(event)s</strong> to a participant."
+"You have been moved from the waiting list of the volunteering "
+"<strong>%(event)s</strong> to a participant."
 msgstr ""
-"Grattis! Du har flyttats från väntelistan för volontärarbetet "
-"<strong>%(event)s</strong> till en deltagare."
+"Du har flyttats från väntelistan för volontärarbetet <strong>%(event)s</"
+"strong> till en deltagare."

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-26 10:19+0300\n"
+"POT-Creation-Date: 2023-06-30 11:30+0300\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <jori@3d.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,77 +18,434 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: events/admin.py:197
+msgid "Contact info"
+msgstr "Kontaktinformation"
+
 #: events/models.py:77 events/models.py:168 events/models.py:185
-#: events/models.py:299 events/models.py:348 events/models.py:359
-#: events/models.py:1187 events/models.py:1203 events/models.py:1253
-#: registrations/models.py:29 registrations/models.py:258
+#: events/models.py:299 events/models.py:348 events/models.py:362
+#: events/models.py:1190 events/models.py:1206 events/models.py:1256
+#: registrations/models.py:37 registrations/models.py:266
 #: venv/lib/python3.9/site-packages/munigeo/models.py:83
 #: venv/lib/python3.9/site-packages/munigeo/models.py:112
 #: venv/lib/python3.9/site-packages/munigeo/models.py:141
 msgid "Name"
 msgstr "Namn"
 
-#: events/models.py:566 events/models.py:1254 registrations/models.py:275
+#: events/models.py:87
+msgid "Resources may be edited by users"
+msgstr "Resurser kan redigeras av användare"
+
+#: events/models.py:90
+#: venv/lib/python3.9/site-packages/django_orghierarchy/models.py:20
+msgid "Organizations may be edited by users"
+msgstr "Organisationer kan redigeras av användare"
+
+#: events/models.py:93
+msgid "Past events may be edited using API"
+msgstr "Tidigare evenemang kan redigeras med API"
+
+#: events/models.py:96
+msgid "Past events may be created using API"
+msgstr "Tidigare evenemang kan skapas med API"
+
+#: events/models.py:100
+msgid "Do not show events created by this data_source by default."
+msgstr "Visa inte evenemang som skapats av denna datakälla som standard."
+
+#: events/models.py:169
+msgid "Url"
+msgstr "Url"
+
+#: events/models.py:172 events/models.py:230
+msgid "License"
+msgstr "Licens"
+
+#: events/models.py:173
+msgid "Licenses"
+msgstr "Licenser"
+
+#: events/models.py:198 events/models.py:393 events/models.py:556
+#: events/models.py:831
+msgid "Publisher"
+msgstr "Utgivare"
+
+#: events/models.py:224 events/models.py:280
+#: venv/lib/python3.9/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr "Bild"
+
+#: events/models.py:226
+msgid "Cropping"
+msgstr "Beskärning"
+
+#: events/models.py:236
+msgid "Photographer name"
+msgstr "Fotografens namn"
+
+#: events/models.py:239 events/models.py:1213
+msgid "Alt text"
+msgstr "Alt text"
+
+#: events/models.py:302
+msgid "Origin ID"
+msgstr "Ursprungs-ID"
+
+#: events/models.py:350
+msgid "Can be used as registration service language"
+msgstr "Kan användas som servicespråk för registrering"
+
+#: events/models.py:357
+msgid "language"
+msgstr "språk"
+
+#: events/models.py:358
+msgid "languages"
+msgstr "språk"
+
+#: events/models.py:406 events/models.py:611
+msgid "event count"
+msgstr "antal evenemang"
+
+#: events/models.py:407
+msgid "number of events with this keyword"
+msgstr "antal evenemang med detta sökord"
+
+#: events/models.py:498
+msgid "keyword"
+msgstr "nyckelord"
+
+#: events/models.py:499
+msgid "keywords"
+msgstr "nyckelord"
+
+#: events/models.py:525
+msgid "Intended keyword usage"
+msgstr "Avsedd nyckelordsanvändning"
+
+#: events/models.py:530
+msgid "Organization which uses this set"
+msgstr "Organisation som använder denna sökordsuppsättning"
+
+#: events/models.py:543
+msgid "KeywordSet can't have deprecated keywords"
+msgstr "Sökordsuppsättningen kan inte ha föråldrade sökord"
+
+#: events/models.py:560
+msgid "Place home page"
+msgstr "Placera hemsida"
+
+#: events/models.py:562 events/models.py:803
+msgid "Description"
+msgstr "Beskrivning"
+
+#: events/models.py:569 events/models.py:1257 registrations/models.py:283
 msgid "E-mail"
 msgstr "E-post"
 
-#: events/models.py:574 registrations/models.py:31 registrations/models.py:327
+#: events/models.py:571
+msgid "Telephone"
+msgstr "Telefon"
+
+#: events/models.py:574
+msgid "Contact type"
+msgstr "Kontakt typ"
+
+#: events/models.py:577 registrations/models.py:39 registrations/models.py:335
 msgid "Street address"
 msgstr "Gatuadress"
 
-#: events/models.py:879 registrations/models.py:72
+#: events/models.py:580
+msgid "Address locality"
+msgstr "Adressort"
+
+#: events/models.py:583
+#, fuzzy
+#| msgid "Address locality"
+msgid "Address region"
+msgstr "Adressort"
+
+#: events/models.py:586
+msgid "Postal code"
+msgstr "Postnummer"
+
+#: events/models.py:589
+msgid "PO BOX"
+msgstr "PO Box"
+
+#: events/models.py:592
+msgid "Country"
+msgstr "Land"
+
+#: events/models.py:595
+msgid "Deleted"
+msgstr "Raderade"
+
+#: events/models.py:612
+msgid "number of events in this location"
+msgstr "antal evenemang på denna plats"
+
+#: events/models.py:620
+msgid "place"
+msgstr "plats"
+
+#: events/models.py:621
+msgid "places"
+msgstr "platser"
+
+#: events/models.py:725
+msgid "opening hour specification"
+msgstr "specifikation för öppettider"
+
+#: events/models.py:726
+msgid "opening hour specifications"
+msgstr "specifikationer för öppettider"
+
+#: events/models.py:756
+msgid "Recurring"
+msgstr "Återkommande evenemang"
+
+#: events/models.py:757
+msgid "Umbrella event"
+msgstr "Paraplyevenemang"
+
+#: events/models.py:772
+msgid "Outdoors"
+msgstr "Utomhus"
+
+#: events/models.py:773
+msgid "Indoors"
+msgstr "Inomhus"
+
+#: events/models.py:777
+msgid "User name"
+msgstr "Användarens name"
+
+#: events/models.py:779
+msgid "User e-mail"
+msgstr "Användarens e-post"
+
+#: events/models.py:781
+msgid "User phone number"
+msgstr "Användarens telefonnummer"
+
+#: events/models.py:787
+msgid "User organization"
+msgstr "Användarens organisation"
+
+#: events/models.py:788
+msgid "Event organizer information."
+msgstr "Event arrangör information."
+
+#: events/models.py:794
+msgid "User consent"
+msgstr "Användarens samtycke"
+
+#: events/models.py:795
+msgid "I consent to the processing of my personal data?"
+msgstr "Jag samtycker till behandlingen av mina personuppgifter?"
+
+#: events/models.py:801
+msgid "Event home page"
+msgstr "Hemsidan för evenemanget"
+
+#: events/models.py:805
+msgid "Short description"
+msgstr "Kort beskrivning"
+
+#: events/models.py:810
+msgid "Date published"
+msgstr "Publiceringsdatum"
+
+#: events/models.py:820
+msgid "Headline"
+msgstr "Rubrik"
+
+#: events/models.py:823
+msgid "Secondary headline"
+msgstr "Sekundär rubrik"
+
+#: events/models.py:825
+msgid "Provider"
+msgstr "Leverantör"
+
+#: events/models.py:827
+msgid "Provider's contact info"
+msgstr "Leverantörens kontaktuppgifter"
+
+#: events/models.py:837
+msgid "Environmental certificate"
+msgstr "Miljöcertifikat"
+
+#: events/models.py:845
+msgid "Event status"
+msgstr "Evenemangstatus"
+
+#: events/models.py:852
+msgid "Event data publication status"
+msgstr "Publiceringsstatus för evenemangdata"
+
+#: events/models.py:861
+msgid "Location extra info"
+msgstr "Plats ytterligare info"
+
+#: events/models.py:864
+msgid "Event environment"
+msgstr "Evenemangmiljö"
+
+#: events/models.py:865
+msgid "Will the event be held outdoors?"
+msgstr "Kommer evenemanget att hållas utomhus?"
+
+#: events/models.py:873
+msgid "Start time"
+msgstr "Starttid"
+
+#: events/models.py:876
+msgid "End time"
+msgstr "Sluttid"
+
+#: events/models.py:882 registrations/models.py:80
 msgid "Minimum recommended age"
 msgstr "Rekommenderad lägsta ålder"
 
-#: events/models.py:882 registrations/models.py:75
+#: events/models.py:885 registrations/models.py:83
 msgid "Maximum recommended age"
 msgstr "Högsta rekommenderade ålder"
 
-#: events/models.py:928
+#: events/models.py:931
 msgid "maximum attendee capacity"
 msgstr "Maximal deltagarekapacitet"
 
-#: events/models.py:934
+#: events/models.py:937
 msgid "minimum attendee capacity"
 msgstr "Minsta deltagarekapacitet"
 
-#: events/models.py:937
+#: events/models.py:940
 msgid "enrolment start time"
 msgstr "Starttid för anmälan"
 
-#: events/models.py:940
+#: events/models.py:943
 msgid "enrolment end time"
 msgstr "Sluttid för anmälan"
 
-#: events/models.py:956
+#: events/models.py:959
 msgid "event"
 msgstr "evenemang"
 
-#: events/models.py:957
+#: events/models.py:960
 msgid "events"
 msgstr "evenemang"
+
+#: events/models.py:1008
+msgid "The event end time cannot be earlier than the start time."
+msgstr "Evenemangs sluttid kan inte vara tidigare än starttiden."
+
+#: events/models.py:1020
+msgid "Trying to save event with deprecated keywords "
+msgstr "Försöker spara evenemang med föråldrade sökord"
+
+#: events/models.py:1171
+msgid "Price"
+msgstr "Pris"
+
+#: events/models.py:1173
+msgid "Web link to offer"
+msgstr "Webblänk att erbjuda"
+
+#: events/models.py:1176
+msgid "Offer description"
+msgstr "Erbjudandebeskrivning"
+
+#: events/models.py:1180
+msgid "Is free"
+msgstr "Är gratis"
+
+#: events/models.py:1258 notifications/models.py:47
+msgid "Subject"
+msgstr "Ämne"
+
+#: events/models.py:1259 notifications/models.py:53
+msgid "Body"
+msgstr "Text"
+
+#: events/permissions.py:92 events/permissions.py:113
+msgid "Data source is not editable"
+msgstr "Datakällan kan inte redigeras"
+
+#: events/permissions.py:127
+msgid "Only admins of any organization are allowed to see the content."
+msgstr "Endast administratörer i någon organisation får se innehållet."
+
+#: events/utils.py:269
+msgid "Data source doesn't belong to any organization"
+msgstr "Datakällan tillhör inte någon organisation"
+
+#: notifications/apps.py:7
+msgid "Notifications"
+msgstr "Aviseringar"
+
+#: notifications/models.py:32
+msgid "Unpublished event deleted"
+msgstr "Opublicerad evenemang raderad"
+
+#: notifications/models.py:33
+msgid "Event published"
+msgstr "Evenemang publicerad"
+
+#: notifications/models.py:34
+msgid "Draft posted"
+msgstr "Utkast upplagt"
+
+#: notifications/models.py:35
+msgid "User created"
+msgstr "Användare skapad"
+
+#: notifications/models.py:39
+msgid "Type"
+msgstr "Typ"
+
+#: notifications/models.py:54
+msgid "Text body for email notifications"
+msgstr "Texttext för e-postmeddelanden"
+
+#: notifications/models.py:59
+msgid "HTML Body"
+msgstr "HTML Body"
+
+#: notifications/models.py:60
+msgid "HTML body for email notifications"
+msgstr "HTML Body för e-postmeddelanden"
+
+#: notifications/models.py:65
+msgid "Notification template"
+msgstr "Aviseringsmall"
+
+#: notifications/models.py:66
+msgid "Notification templates"
+msgstr "Aviseringsmallar"
 
 #: registrations/admin.py:10
 msgid "Event"
 msgstr "Evenemang"
 
-#: registrations/api.py:79
+#: registrations/api.py:84
 msgid "Registration with signups cannot be deleted"
 msgstr "Registrering med registreringar kan inte raderas"
 
-#: registrations/api.py:274
+#: registrations/api.py:282
 #, python-brace-format
 msgid "Registration with id {pk} doesn't exist."
 msgstr "Registrering med id {pk} finns inte."
 
-#: registrations/api.py:280
+#: registrations/api.py:288
 #, python-brace-format
 msgid "Only the admins of the organization {organization} have access rights."
 msgstr ""
 "Endast administratörerna för organisationen {organization} har "
 "åtkomsträttigheter."
 
-#: registrations/api.py:309
+#: registrations/api.py:317
 #, python-brace-format
 msgid "attendee_status can take following values: {statuses}, not {val}"
 msgstr "attendee_status kan ha följande värden: {statuses}, inte {val}"
@@ -97,141 +454,134 @@ msgstr "attendee_status kan ha följande värden: {statuses}, inte {val}"
 msgid "Request conflict with the current state of the target resource"
 msgstr "Begärkonflikt med målresursens aktuella tillstånd"
 
-#: registrations/models.py:28 registrations/models.py:268
+#: registrations/models.py:36 registrations/models.py:276
 msgid "City"
 msgstr "Stad"
 
-#: registrations/models.py:30 registrations/models.py:291
+#: registrations/models.py:38 registrations/models.py:299
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: registrations/models.py:32 registrations/models.py:334
+#: registrations/models.py:40 registrations/models.py:342
 msgid "ZIP code"
 msgstr "Postnummer"
 
-#: registrations/models.py:78
+#: registrations/models.py:86
 msgid "Created at"
 msgstr "Skapad kl"
 
-#: registrations/models.py:80
+#: registrations/models.py:88
 msgid "Modified at"
 msgstr "Ändrad kl"
 
-#: registrations/models.py:99
+#: registrations/models.py:107
 msgid "Enrollment start time"
 msgstr "Starttid för anmälan"
 
-#: registrations/models.py:102
+#: registrations/models.py:110
 msgid "Enrollment end time"
 msgstr "Sluttid för anmälan"
 
-#: registrations/models.py:106
+#: registrations/models.py:114
 msgid "Confirmation message"
 msgstr "Bekräftelsemeddelande"
 
-#: registrations/models.py:109
+#: registrations/models.py:117
 msgid "Instructions"
 msgstr "Instruktioner"
 
-#: registrations/models.py:113
+#: registrations/models.py:121
 msgid "Maximum attendee capacity"
 msgstr "Maximal deltagarekapacitet"
 
-#: registrations/models.py:116
+#: registrations/models.py:124
 msgid "Minimum attendee capacity"
 msgstr "Minsta deltagarekapacitet"
 
-#: registrations/models.py:119
+#: registrations/models.py:127
 msgid "Waiting list capacity"
 msgstr "Väntelistans kapacitet"
 
-#: registrations/models.py:122
+#: registrations/models.py:130
 msgid "Maximum group size"
 msgstr "Maximal gruppstorlek"
 
-#: registrations/models.py:136
+#: registrations/models.py:144
 msgid "Mandatory fields"
 msgstr "Obligatoriska fält"
 
-#: registrations/models.py:237
+#: registrations/models.py:245
 msgid "Waitlisted"
 msgstr "I kö"
 
-#: registrations/models.py:238
+#: registrations/models.py:246
 msgid "Attending"
 msgstr "Deltar"
 
-#: registrations/models.py:248
+#: registrations/models.py:256
 msgid "No Notification"
 msgstr "Ingen anmälan"
 
-#: registrations/models.py:249
+#: registrations/models.py:257
 msgid "SMS"
 msgstr "SMS"
 
-#: registrations/models.py:250
+#: registrations/models.py:258
 msgid "E-Mail"
 msgstr "E-post"
 
-#: registrations/models.py:251
+#: registrations/models.py:259
 msgid "Both SMS and email."
 msgstr "Både SMS och e-post."
 
-#: registrations/models.py:265
+#: registrations/models.py:273
 msgid "Date of birth"
 msgstr "Födelsedatum"
 
-#: registrations/models.py:278
+#: registrations/models.py:286
 msgid "Extra info"
 msgstr "Ytterligare info"
 
-#: registrations/models.py:284
+#: registrations/models.py:292
 msgid "Membership number"
 msgstr "Medlemsnummer"
 
-#: registrations/models.py:298
+#: registrations/models.py:306
 msgid "Notification type"
 msgstr "Aviseringstyp"
 
-#: registrations/models.py:304
+#: registrations/models.py:312
 msgid "Cancellation code"
 msgstr "Avbokningskod"
 
-#: registrations/models.py:307
+#: registrations/models.py:315
 msgid "Attendee status"
 msgstr "Deltagarstatus"
 
-#: registrations/models.py:391
-msgid "to event"
-msgstr "för evenemanget"
-
-#: registrations/models.py:392
-msgid "to course"
-msgstr "för kursen"
-
-#: registrations/models.py:393
-msgid "to volunteering"
-msgstr "för volontäruppdraget"
-
-#: registrations/models.py:404
-#, python-format
-msgid "Registration confirmation - %(event_name)s"
-msgstr "Bekräftelse av registrering - %(event_name)s"
-
-#: registrations/models.py:406
+#: registrations/models.py:413
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Registreringen avbruten - %(event_name)s"
 
-#: registrations/models.py:424
+#: registrations/models.py:417 registrations/models.py:425
+#, python-format
+msgid "Registration confirmation - %(event_name)s"
+msgstr "Bekräftelse av registrering - %(event_name)s"
+
+#: registrations/models.py:421
+#, python-format
+msgid "Waiting list seat reserved - %(event_name)s"
+msgstr "Väntelista plats reserverad - %(event_name)s"
+
+#: registrations/models.py:448
 msgid "Number of seats"
 msgstr "Antal platser"
 
-#: registrations/models.py:430
+#: registrations/models.py:454
 msgid "Seat reservation code"
 msgstr "Platsreservationskod"
 
-#: registrations/models.py:433
+#: registrations/models.py:457
 msgid "Timestamp"
 msgstr "Tidsstämpel"
 
@@ -243,32 +593,40 @@ msgstr "Parametern cancellation_code måste anges"
 msgid "Cancellation code did not match"
 msgstr "Avbokningskoden matchade inte"
 
-#: registrations/serializers.py:44
+#: registrations/serializers.py:29
+msgid "Enrolment is not yet open."
+msgstr "Anmälan är ännu inte öppen."
+
+#: registrations/serializers.py:31
+msgid "Enrolment is already closed."
+msgstr "Anmälan är redan stängd"
+
+#: registrations/serializers.py:69
 msgid "The waiting list is already full"
 msgstr "Väntelistan är redan full"
 
-#: registrations/serializers.py:54
+#: registrations/serializers.py:79
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Du får inte ändra attendee_status för ett befintligt objekt."
 
-#: registrations/serializers.py:61
+#: registrations/serializers.py:86
 msgid "You may not change the registration of an existing object."
 msgstr "Du får inte ändra registration för ett befintligt objekt."
 
-#: registrations/serializers.py:82 registrations/serializers.py:89
-#: registrations/serializers.py:293
+#: registrations/serializers.py:107 registrations/serializers.py:114
+#: registrations/serializers.py:322
 msgid "This field must be specified."
 msgstr "Detta fält måste anges."
 
-#: registrations/serializers.py:105
+#: registrations/serializers.py:130
 msgid "The participant is too young."
 msgstr "Deltagaren är för ung."
 
-#: registrations/serializers.py:110
+#: registrations/serializers.py:135
 msgid "The participant is too old."
 msgstr "Deltagaren är för gammal."
 
-#: registrations/serializers.py:168
+#: registrations/serializers.py:193
 #, python-brace-format
 msgid ""
 "Only the admins of the organization that published the event {event_id} have "
@@ -277,33 +635,33 @@ msgstr ""
 "Endast administratörerna för organisationen som publicerade händelsen "
 "{event_id} har åtkomsträttigheter."
 
-#: registrations/serializers.py:218
+#: registrations/serializers.py:247
 msgid "Reservation code doesn't exist."
 msgstr "Bokningskoden finns inte."
 
-#: registrations/serializers.py:240
+#: registrations/serializers.py:269
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Antalet registreringar är större än den maximala gruppstorleken: "
 "{max_group_size}."
 
-#: registrations/serializers.py:296
+#: registrations/serializers.py:325
 msgid "The value doesn't match."
 msgstr "Värdet stämmer inte överens."
 
-#: registrations/serializers.py:309
+#: registrations/serializers.py:343
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr "Antalet platser är större än maximal gruppstorlek: {max_group_size}."
 
-#: registrations/serializers.py:334
+#: registrations/serializers.py:368
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Inte tillräckligt med platser tillgängliga. Kapacitet kvar: {capacity_left}."
 
-#: registrations/serializers.py:350
+#: registrations/serializers.py:384
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -311,7 +669,7 @@ msgstr ""
 "Inte tillräckligt med kapacitet på väntelistan. Kapacitet kvar: "
 "{capacity_left}."
 
-#: registrations/serializers.py:364
+#: registrations/serializers.py:398
 msgid "Cannot update expired seats reservation."
 msgstr "Kan inte uppdatera utgångna platsreservationer."
 
@@ -331,45 +689,181 @@ msgstr "Helsingfors stad 2023"
 msgid "All rights reserved."
 msgstr "Alla rättigheter förbehållna."
 
-#: registrations/templates/cancellation_confirmation.html:8
+#: registrations/templates/cancellation_confirmation.html:9
 msgid "Registration cancelled"
 msgstr "Registreringen avbruten"
 
-#: registrations/templates/cancellation_confirmation.html:9
+#: registrations/templates/cancellation_confirmation.html:14
 #, python-format
-msgid "Registration %(to_event_type)s %(event)s has been cancelled."
-msgstr "Registreringen för %(to_event_type)s %(event)s har avbrutits."
+msgid "Registration to the event %(event)s has been cancelled."
+msgstr "Anmälan till evenemanget %(event)s har ställts in."
 
-#: registrations/templates/cancellation_confirmation.html:12
+#: registrations/templates/cancellation_confirmation.html:17
+#, python-format
+msgid "Registration to the course %(event)s has been cancelled."
+msgstr "Anmälan till kursen %(event)s har ställts in."
+
+#: registrations/templates/cancellation_confirmation.html:20
+#, python-format
+msgid "Registration to the volunteering %(event)s has been cancelled."
+msgstr "Anmälan till volontärarbetet %(event)s har ställts in."
+
+#: registrations/templates/cancellation_confirmation.html:28
 #, python-format
 msgid ""
-"You have successfully canceled your registration %(to_event_type)s %(event)s."
-msgstr "Du har avslutat prenumerationen %(to_event_type)s %(event)s."
+"You have successfully cancelled your registration to the event "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till evenemanget <strong>%(event)s</strong>."
 
-#: registrations/templates/cancellation_confirmation.html:15
+#: registrations/templates/cancellation_confirmation.html:31
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the course "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till kursen <strong>%(event)s</strong>."
+
+#: registrations/templates/cancellation_confirmation.html:34
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the volunteering "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till volontärarbetet <strong>%(event)s</"
+"strong>."
+
+#: registrations/templates/cancellation_confirmation.html:40
 msgid "More information from our customer service"
 msgstr "Mer information om vår kundtjänst"
 
 #: registrations/templates/message_to_signup.html:13
-#: registrations/templates/signup_confirmation.html:17
+#: registrations/templates/signup_confirmation.html:46
+#: registrations/templates/signup_confirmation_to_waiting_list.html:41
+#: registrations/templates/signup_transferred_as_participant.html:34
 msgid "Check your registration here"
 msgstr "Kontrollera din registrering här"
 
-#: registrations/templates/signup_confirmation.html:8
+#: registrations/templates/signup_confirmation.html:9
+#: registrations/templates/signup_transferred_as_participant.html:9
 #, python-format
 msgid "Welcome %(username)s"
 msgstr "Välkommen %(username)s"
 
-#: registrations/templates/signup_confirmation.html:9
-#, fuzzy, python-format
-msgid "Registration %(to_event_type)s %(event)s saved."
-msgstr "Registreringen %(event_type)s %(event)s sparad."
+#: registrations/templates/signup_confirmation.html:14
+#, python-format
+msgid "Registration to the event %(event)s has been saved."
+msgstr "Anmälan till evenemanget %(event)s väntelista har sparats."
 
-#: registrations/templates/signup_confirmation.html:12
+#: registrations/templates/signup_confirmation.html:17
+#, python-format
+msgid "Registration to the course %(event)s has been saved."
+msgstr "Anmälan till kursen %(event)s väntelista har sparats."
+
+#: registrations/templates/signup_confirmation.html:20
+#, python-format
+msgid "Registration to the volunteering %(event)s has been saved."
+msgstr "Anmälan till volontärarbetet %(event)s väntelista har sparats."
+
+#: registrations/templates/signup_confirmation.html:28
 #, python-format
 msgid ""
-"Congratulations! You have successfully registered %(to_event_type)s "
-"%(event)s."
+"Congratulations! You have successfully registered to the event "
+"<strong>%(event)s</strong>."
 msgstr ""
-"Klapp på ryggen! Du har framgångsrikt registrerat dig %(to_event_type)s "
-"%(event)s."
+"Grattis! Du har framgångsrikt registrerat dig till evenemanget "
+"<strong>%(event)s</strong>."
+
+#: registrations/templates/signup_confirmation.html:31
+#, python-format
+msgid ""
+"Congratulations! You have successfully registered to the course "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Grattis! Du har framgångsrikt registrerat dig till kursen <strong>%(event)s</"
+"strong>."
+
+#: registrations/templates/signup_confirmation.html:34
+#, python-format
+msgid ""
+"Congratulations! You have successfully registered to the volunteering "
+"<strong>%(event)s</strong>."
+msgstr ""
+"Grattis! Du har framgångsrikt registrerat dig till volontärarbetet "
+"<strong>%(event)s</strong>."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:11
+#, python-format
+msgid "Registration for the event %(event)s waiting list has been saved."
+msgstr "Anmälan till evenemanget %(event)s väntelista har sparats."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:14
+#, python-format
+msgid "Registration for the course %(event)s waiting list has been saved."
+msgstr "Anmälan till kursen %(event)s väntelista har sparats."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:17
+#, python-format
+msgid ""
+"Registration for the volunteering %(event)s waiting list has been saved."
+msgstr "Anmälan till volontärarbetet %(event)s väntelista har sparats."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:25
+#, python-format
+msgid ""
+"You have successfully registered for the event <strong>%(event)s</strong> "
+"waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för evenemangets <strong>%(event)s</"
+"strong> väntelista."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:28
+#, python-format
+msgid ""
+"You have successfully registered for the course <strong>%(event)s</strong> "
+"waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för kursen <strong>%(event)s</strong> "
+"väntelista."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:31
+#, python-format
+msgid ""
+"You have successfully registered for the volunteering <strong>%(event)s</"
+"strong> waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för volontärarbetets <strong>%(event)s</"
+"strong> väntelista."
+
+#: registrations/templates/signup_confirmation_to_waiting_list.html:35
+msgid ""
+"You will be transferred as a participant automatically when a seat becomes "
+"available."
+msgstr "Du överförs automatiskt som deltagare när en plats blir ledig."
+
+#: registrations/templates/signup_transferred_as_participant.html:16
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the event "
+"<strong>%(event)s</strong> to a participant."
+msgstr ""
+"Grattis! Du har flyttats från väntelistan för evenemanget <strong>%(event)s</"
+"strong> till en deltagare."
+
+#: registrations/templates/signup_transferred_as_participant.html:19
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the course "
+"<strong>%(event)s</strong> to a participant."
+msgstr ""
+"Grattis! Du har flyttats från väntelistan för kursen <strong>%(event)s</"
+"strong> till en deltagare."
+
+#: registrations/templates/signup_transferred_as_participant.html:22
+#, python-format
+msgid ""
+"Congratulations! You have been moved from the waiting list of the "
+"volunteering <strong>%(event)s</strong> to a participant."
+msgstr ""
+"Grattis! Du har flyttats från väntelistan för volontärarbetet "
+"<strong>%(event)s</strong> till en deltagare."

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -28,7 +28,12 @@ from events.permissions import (
 )
 from linkedevents.registry import register_view
 from registrations.exceptions import ConflictException
-from registrations.models import Registration, SeatReservationCode, SignUp
+from registrations.models import (
+    Registration,
+    SeatReservationCode,
+    SignUp,
+    SignUpNotificationType,
+)
 from registrations.permissions import AuthenticatedGet, AuthenticateWithCancellationCode
 from registrations.serializers import (
     CreateSignUpsSerializer,
@@ -244,7 +249,7 @@ class SignUpViewSet(
         instance = self.get_object()
         registration = instance.registration
 
-        instance.send_notification("cancellation")
+        instance.send_notification(SignUpNotificationType.CANCELLATION)
         response = super().destroy(request, *args, **kwargs)
 
         # Move first signup from waitlist to attending list
@@ -255,6 +260,9 @@ class SignUpViewSet(
             first_on_list = waitlisted[0]
             first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
             first_on_list.save()
+            first_on_list.send_notification(
+                SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT
+            )
         return response
 
     def filter_queryset(self, queryset):

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -11,7 +11,12 @@ from rest_framework.fields import DateTimeField
 
 from events.models import Language
 from registrations.exceptions import ConflictException
-from registrations.models import Registration, SeatReservationCode, SignUp
+from registrations.models import (
+    Registration,
+    SeatReservationCode,
+    SignUp,
+    SignUpNotificationType,
+)
 from registrations.utils import code_validity_duration
 
 
@@ -48,7 +53,7 @@ class SignUpSerializer(serializers.ModelSerializer):
 
         if (attendee_capacity is None) or (already_attending < attendee_capacity):
             signup = super().create(validated_data)
-            signup.send_notification("confirmation")
+            signup.send_notification(SignUpNotificationType.CONFIRMATION)
             return signup
         elif (waiting_list_capacity is None) or (
             already_waitlisted < waiting_list_capacity
@@ -56,6 +61,9 @@ class SignUpSerializer(serializers.ModelSerializer):
             signup = super().create(validated_data)
             signup.attendee_status = SignUp.AttendeeStatus.WAITING_LIST
             signup.save()
+            signup.send_notification(
+                SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST
+            )
             return signup
         else:
             raise DRFPermissionDenied(_("The waiting list is already full"))

--- a/registrations/templates/cancellation_confirmation.html
+++ b/registrations/templates/cancellation_confirmation.html
@@ -5,14 +5,41 @@
   <tr>
     <td class="content-cell" style="padding:0;margin:0;text-align:left;">
       <div class="content-container" style="padding:0 16px;">
-        <h1 style="color:#1a1a1a;font-size:36px;line-height:43px;font-weight:700;margin:0 0 12px;">{% blocktranslate %}Registration cancelled{% endblocktranslate %}</h1>
-        <h2 style="color:#1a1a1a;font-size:24px;font-weight:700;line-height:29px;margin:0;">{% blocktranslate %}Registration {{to_event_type}} {{event}} has been cancelled.{% endblocktranslate %}</h2>
+        <h1 style="color:#1a1a1a;font-size:36px;line-height:43px;font-weight:700;margin:0 0 12px;">
+          {% blocktranslate %}Registration cancelled{% endblocktranslate %}
+        </h1>
+        <h2 style="color:#1a1a1a;font-size:24px;font-weight:700;line-height:29px;margin:0;">
+          <!-- Event -->
+          {% if event_type_id == "1" %}
+          {% blocktranslate %}Registration to the event {{event}} has been cancelled.{% endblocktranslate %}
+          <!-- Course -->
+          {% elif event_type_id == "2" %}
+          {% blocktranslate %}Registration to the course {{event}} has been cancelled.{% endblocktranslate %}
+          <!-- Volunteering -->
+          {% elif event_type_id == "3" %}
+          {% blocktranslate %}Registration to the volunteering {{event}} has been cancelled.{% endblocktranslate %}
+          {% endif %}
+        </h2>
         <div class="divider" style="background:#0000bf;border-radius:0px;height:3px;width:100%;margin:24px 0;"></div>
         <div style="margin: 56px 0px 24px">
-          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">{% blocktranslate %}You have successfully canceled your registration {{to_event_type}} {{event}}.{% endblocktranslate %}</p>
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
+            <!-- Event -->
+            {% if event_type_id == "1" %}
+            {% blocktranslate %}You have successfully cancelled your registration to the event <strong>{{event}}</strong>.{% endblocktranslate %}
+            <!-- Course -->
+            {% elif event_type_id == "2" %}
+            {% blocktranslate %}You have successfully cancelled your registration to the course <strong>{{event}}</strong>.{% endblocktranslate %}
+            <!-- Volunteering -->
+            {% elif event_type_id == "3" %}
+            {% blocktranslate %}You have successfully cancelled your registration to the volunteering <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% endif %}
+          </p>
         </div>
         <div style="margin: 24px 0px 40px">
-          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">{% blocktranslate %}More information from our customer service{% endblocktranslate %} <a href="mailto:linkedevents@hel.fi" class="link" style="color:#0000bf;font-size:16px;font-weight:500;">linkedevents@hel.fi</a></p>
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
+            {% blocktranslate %}More information from our customer service{% endblocktranslate %} 
+            <a href="mailto:linkedevents@hel.fi" class="link" style="color:#0000bf;font-size:16px;font-weight:500;">linkedevents@hel.fi</a>
+          </p>
         </div>
       </div>
     </td>

--- a/registrations/templates/signup_confirmation_to_waiting_list.html
+++ b/registrations/templates/signup_confirmation_to_waiting_list.html
@@ -5,20 +5,7 @@
   <tr>
     <td class="content-cell" style="padding:0;margin:0;text-align:left;">
       <div class="content-container" style="padding:0 16px;">
-        <h2 style="color:#1a1a1a;font-size:24px;font-weight:700;line-height:29px;margin:0;">
-          <!-- Event -->
-          {% if event_type_id == "1" %}
-          {% blocktranslate %}Registration for the event {{event}} waiting list has been saved.{% endblocktranslate %}
-          <!-- Course -->
-          {% elif event_type_id == "2" %}
-          {% blocktranslate %}Registration for the course {{event}} waiting list has been saved.{% endblocktranslate %}
-          <!-- Volunteering -->
-          {% elif event_type_id == "3" %}
-          {% blocktranslate %}Registration for the volunteering {{event}} waiting list has been saved.{% endblocktranslate %}
-          {% endif %}
-        </h2>
-        <div class="divider" style="background:#0000bf;border-radius:0px;height:3px;width:100%;margin:24px 0;"></div>
-        <div style="margin: 56px 0px 40px">
+        <div style="margin: 16px 0px 40px">
           <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
             <!-- Event -->
             {% if event_type_id == "1" %}

--- a/registrations/templates/signup_confirmation_to_waiting_list.html
+++ b/registrations/templates/signup_confirmation_to_waiting_list.html
@@ -5,19 +5,16 @@
   <tr>
     <td class="content-cell" style="padding:0;margin:0;text-align:left;">
       <div class="content-container" style="padding:0 16px;">
-        <h1 style="color:#1a1a1a;font-size:36px;line-height:43px;font-weight:700;margin:0 0 12px;">
-          {% blocktranslate %}Welcome {{username}}{% endblocktranslate %}
-        </h1>
         <h2 style="color:#1a1a1a;font-size:24px;font-weight:700;line-height:29px;margin:0;">
           <!-- Event -->
           {% if event_type_id == "1" %}
-          {% blocktranslate %}Registration to the event {{event}} has been saved.{% endblocktranslate %}
+          {% blocktranslate %}Registration for the event {{event}} waiting list has been saved.{% endblocktranslate %}
           <!-- Course -->
           {% elif event_type_id == "2" %}
-          {% blocktranslate %}Registration to the course {{event}} has been saved.{% endblocktranslate %}
+          {% blocktranslate %}Registration for the course {{event}} waiting list has been saved.{% endblocktranslate %}
           <!-- Volunteering -->
           {% elif event_type_id == "3" %}
-          {% blocktranslate %}Registration to the volunteering {{event}} has been saved.{% endblocktranslate %}
+          {% blocktranslate %}Registration for the volunteering {{event}} waiting list has been saved.{% endblocktranslate %}
           {% endif %}
         </h2>
         <div class="divider" style="background:#0000bf;border-radius:0px;height:3px;width:100%;margin:24px 0;"></div>
@@ -25,20 +22,18 @@
           <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
             <!-- Event -->
             {% if event_type_id == "1" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the event <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}You have successfully registered for the event <strong>{{event}}</strong> waiting list.{% endblocktranslate %}
             <!-- Course -->
             {% elif event_type_id == "2" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the course <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}You have successfully registered for the course <strong>{{event}}</strong> waiting list.{% endblocktranslate %}
             <!-- Volunteering -->
             {% elif event_type_id == "3" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the volunteering <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}You have successfully registered for the volunteering <strong>{{event}}</strong> waiting list.{% endblocktranslate %}
             {% endif %}
           </p>
-          {% if confirmation_message %}
-            <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
-              {{confirmation_message}}
-            </p>
-          {% endif %}
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
+            {% blocktranslate %}You will be transferred as a participant automatically when a seat becomes available.{% endblocktranslate %}
+          </p>
         </div>
         <div class="cta-button-wrapper" style="margin: 0px 0px 40px">
           <a href="{{linked_registrations_ui_url}}/{{linked_registrations_ui_locale}}/registration/{{registration_id}}/enrolment/{{signup_id}}/{{cancellation_code}}/edit" target="_blank" rel="noopener" class="cta-button" style="background:#0000bf;border-radius:0px;border:none;height:56px;text-align:center;text-decoration:none;vertical-align:middle;padding:16px 24px;box-sizing:border-box;display:inline-block;">

--- a/registrations/templates/signup_transferred_as_participant.html
+++ b/registrations/templates/signup_transferred_as_participant.html
@@ -8,30 +8,18 @@
         <h1 style="color:#1a1a1a;font-size:36px;line-height:43px;font-weight:700;margin:0 0 12px;">
           {% blocktranslate %}Welcome {{username}}{% endblocktranslate %}
         </h1>
-        <h2 style="color:#1a1a1a;font-size:24px;font-weight:700;line-height:29px;margin:0;">
-          <!-- Event -->
-          {% if event_type_id == "1" %}
-          {% blocktranslate %}Registration to the event {{event}} has been saved.{% endblocktranslate %}
-          <!-- Course -->
-          {% elif event_type_id == "2" %}
-          {% blocktranslate %}Registration to the course {{event}} has been saved.{% endblocktranslate %}
-          <!-- Volunteering -->
-          {% elif event_type_id == "3" %}
-          {% blocktranslate %}Registration to the volunteering {{event}} has been saved.{% endblocktranslate %}
-          {% endif %}
-        </h2>
         <div class="divider" style="background:#0000bf;border-radius:0px;height:3px;width:100%;margin:24px 0;"></div>
         <div style="margin: 56px 0px 40px">
           <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
             <!-- Event -->
             {% if event_type_id == "1" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the event <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the event <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             <!-- Course -->
             {% elif event_type_id == "2" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the course <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the course <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             <!-- Volunteering -->
             {% elif event_type_id == "3" %}
-            {% blocktranslate %}Congratulations! You have successfully registered to the volunteering <strong>{{event}}</strong>.{% endblocktranslate %}
+            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the volunteering <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             {% endif %}
           </p>
           {% if confirmation_message %}

--- a/registrations/templates/signup_transferred_as_participant.html
+++ b/registrations/templates/signup_transferred_as_participant.html
@@ -13,13 +13,13 @@
           <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
             <!-- Event -->
             {% if event_type_id == "1" %}
-            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the event <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
+            {% blocktranslate %}You have been moved from the waiting list of the event <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             <!-- Course -->
             {% elif event_type_id == "2" %}
-            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the course <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
+            {% blocktranslate %}You have been moved from the waiting list of the course <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             <!-- Volunteering -->
             {% elif event_type_id == "3" %}
-            {% blocktranslate %}Congratulations! You have been moved from the waiting list of the volunteering <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
+            {% blocktranslate %}You have been moved from the waiting list of the volunteering <strong>{{event}}</strong> to a participant.{% endblocktranslate %}
             {% endif %}
           </p>
           {% if confirmation_message %}

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -325,17 +325,17 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
         (
             "en",
             "Registration confirmation",
-            "Congratulations! You have been moved from the waiting list of the event <strong>Foo</strong> to a participant.",
+            "You have been moved from the waiting list of the event <strong>Foo</strong> to a participant.",
         ),
         (
             "fi",
             "Vahvistus ilmoittautumisesta",
-            "Onnittelut! Sinut on siirretty tapahtuman <strong>Foo</strong> jonotuslistalta osallistujaksi.",
+            "Sinut on siirretty tapahtuman <strong>Foo</strong> jonotuslistalta osallistujaksi.",
         ),
         (
             "sv",
             "Bekräftelse av registrering",
-            "Grattis! Du har flyttats från väntelistan för evenemanget <strong>Foo</strong> till en deltagare.",
+            "Du har flyttats från väntelistan för evenemanget <strong>Foo</strong> till en deltagare.",
         ),
     ],
 )
@@ -386,17 +386,17 @@ def test_send_email_when_moving_participant_from_waitlist(
         (
             Event.TypeId.GENERAL,
             "Registration confirmation",
-            "Congratulations! You have been moved from the waiting list of the event <strong>Foo</strong> to a participant.",
+            "You have been moved from the waiting list of the event <strong>Foo</strong> to a participant.",
         ),
         (
             Event.TypeId.COURSE,
             "Registration confirmation",
-            "Congratulations! You have been moved from the waiting list of the course <strong>Foo</strong> to a participant.",
+            "You have been moved from the waiting list of the course <strong>Foo</strong> to a participant.",
         ),
         (
             Event.TypeId.VOLUNTEERING,
             "Registration confirmation",
-            "Congratulations! You have been moved from the waiting list of the volunteering <strong>Foo</strong> to a participant.",
+            "You have been moved from the waiting list of the volunteering <strong>Foo</strong> to a participant.",
         ),
     ],
 )

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -623,24 +623,21 @@ def test_confirmation_message_is_shown_in_service_language(
 
 
 @pytest.mark.parametrize(
-    "service_language,expected_subject,expected_heading,expected_text",
+    "service_language,expected_subject,expected_text",
     [
         (
             "en",
             "Waiting list seat reserved",
-            "Registration for the event Foo waiting list has been saved.",
             "You have successfully registered for the event <strong>Foo</strong> waiting list.",
         ),
         (
             "fi",
             "Paikka jonotuslistalla varattu",
-            "Ilmoittautuminen tapahtuman Foo jonotuslistaan on tallennettu.",
             "Olet onnistuneesti ilmoittautunut tapahtuman <strong>Foo</strong> jonotuslistalle.",
         ),
         (
             "sv",
             "Väntelista plats reserverad",
-            "Anmälan till evenemanget Foo väntelista har sparats.",
             "Du har framgångsrikt registrerat dig för evenemangets <strong>Foo</strong> väntelista.",
         ),
     ],
@@ -648,7 +645,6 @@ def test_confirmation_message_is_shown_in_service_language(
 @pytest.mark.django_db
 def test_different_email_sent_if_user_is_added_to_waiting_list(
     api_client,
-    expected_heading,
     expected_subject,
     expected_text,
     languages,
@@ -679,26 +675,22 @@ def test_different_email_sent_if_user_is_added_to_waiting_list(
         assert signup_data["name"] in response.data["waitlisted"]["people"][0]["name"]
         #  assert that the email was sent
         assert mail.outbox[0].subject.startswith(expected_subject)
-        assert expected_heading in str(mail.outbox[0].alternatives[0])
         assert expected_text in str(mail.outbox[0].alternatives[0])
 
 
 @pytest.mark.parametrize(
-    "event_type,expected_heading,expected_text",
+    "event_type,expected_text",
     [
         (
             Event.TypeId.GENERAL,
-            "Registration for the event Foo waiting list has been saved.",
             "You have successfully registered for the event <strong>Foo</strong> waiting list.",
         ),
         (
             Event.TypeId.COURSE,
-            "Registration for the course Foo waiting list has been saved.",
             "You have successfully registered for the course <strong>Foo</strong> waiting list.",
         ),
         (
             Event.TypeId.VOLUNTEERING,
-            "Registration for the volunteering Foo waiting list has been saved.",
             "You have successfully registered for the volunteering <strong>Foo</strong> waiting list.",
         ),
     ],
@@ -707,7 +699,6 @@ def test_different_email_sent_if_user_is_added_to_waiting_list(
 def test_confirmation_to_waiting_list_template_has_correct_text_per_event_type(
     api_client,
     event_type,
-    expected_heading,
     expected_text,
     languages,
     registration,
@@ -732,5 +723,4 @@ def test_confirmation_to_waiting_list_template_has_correct_text_per_event_type(
     response = assert_create_signups(api_client, signups_data)
     assert signup_data["name"] in response.data["waitlisted"]["people"][0]["name"]
     #  assert that the email was sent
-    assert expected_heading in str(mail.outbox[0].alternatives[0])
     assert expected_text in str(mail.outbox[0].alternatives[0])


### PR DESCRIPTION
## Description
- Send email to participant if he is added to waiting list or moved from waiting list as participant
- Translate some event texts to Finnish and Swedish
- Translating event type id texts breaks event creations so make them not-translatable

## Closes
[LINK-1370](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1370)

[LINK-1370]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ