### PR TITLE
LINK-1392 | Free used memory from uWSGI processes

### DIFF
--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -13,6 +13,15 @@ master = 1
 processes = 2
 threads = 2
 socket-timeout = 60
+
+# Reload workers regularly to keep memory fresh
+# and ease potential memory leaks
+max-requests = 1000       # Restart workers after this many requests
+reload-on-rss = 300       # Restart workers after this much resident memory
+worker-reload-mercy = 60  # How long to wait before forcefully killing workers (default is 60)
+
+# Suppress errors about clients closing sockets, happens with nginx as the ingress when
+# http pipes are closed before workers has had the time to serve content to the pipe
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true


### PR DESCRIPTION
Reload workers regularly to keep memory fresh and ease potential memory leaks.