### PR TITLE
Fix: build translations for production container

### DIFF
--- a/docker/django/.env.example
+++ b/docker/django/.env.example
@@ -1,5 +1,6 @@
 ALLOWED_HOSTS=*
 APPLY_MIGRATIONS=true
+COMPILE_TRANSLATIONS=true
 CREATE_SUPERUSER=true
 DATABASE_URL=postgis://linkedevents:linkedevents@linkedevents-db/linkedevents
 DEBUG=true

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -44,8 +44,6 @@ COPY --chown=appuser:appuser . /app/
 # This is required by osoite importer (by underlying munigeo importers)
 RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod g+w -R /app/data
 
-RUN django-admin compilemessages
-
 USER appuser
 
 EXPOSE 8000/tcp
@@ -65,6 +63,9 @@ FROM appbase AS production
 COPY --from=staticbuilder --chown=appuser:appuser /app/static /app/static
 COPY --chown=appuser:appuser . /app/
 
+RUN django-admin compilemessages
+
+# This is needed to install preferred templates here.
 RUN chgrp -R 0 /app/templates/rest_framework/ && chmod g+w -R /app/templates/rest_framework/
 
 # This is required by osoite importer (by underlying munigeo importers)

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -24,6 +24,11 @@ if [[ -n "$INSTALL_TEMPLATE" ]]; then
     ./manage.py install_templates "${INSTALL_TEMPLATE}"
 fi
 
+if [[ "$COMPILE_TRANSLATIONS" = "true" ]]; then
+    echo "Compile translations..."
+    django-admin compilemessages
+fi
+
 # Start server
 if [[ -n "$@" ]]; then
     "$@"


### PR DESCRIPTION
This change builds the translations for the production container in `Dockerfile`. Translations were previously only built for the local development container, which has some issues since the `docker-compose.yml` mounts over the ` /app` folder gets. For compiling translations in development container a `COMPILE_TRANSLATIONS` variable was added.