### PR TITLE
LINK-1384 | Expose User.is_external property in the API

### DIFF
--- a/helevents/serializers.py
+++ b/helevents/serializers.py
@@ -28,5 +28,6 @@ class UserSerializer(serializers.ModelSerializer):
             "department_name",
             "is_staff",
             "display_name",
+            "is_external",
         ]
         model = get_user_model()

--- a/helevents/tests/test_user_get.py
+++ b/helevents/tests/test_user_get.py
@@ -32,6 +32,7 @@ def assert_user_fields_exist(data, version="v1"):
         "display_name",
         "admin_organizations",
         "organization_memberships",
+        "is_external",
     )
     assert_fields_exist(data, fields)
 


### PR DESCRIPTION
This adds the is_external flag to the API.