### PR TITLE
LINK-1080: Miscellaneous importer changes

### DIFF
--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from collections import namedtuple
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -98,14 +97,11 @@ class HarrastushakuImporter(Importer):
         for location in locations:
             try:
                 self.handle_location(location)
+            except HarrastushakuException as e:
+                logger.exception(f"Error handling location {location.get('id')}: {e}")
             except Exception as e:  # noqa
-                message = (
-                    e
-                    if isinstance(e, HarrastushakuException)
-                    else traceback.format_exc()
-                )
-                logger.error(
-                    "Error handling location {}: {}".format(location.get("id"), message)
+                logger.exception(
+                    f"An unexpected error occurred while handling location {location.get('id')}: {e}"
                 )
 
     def map_harrastushaku_location_ids_to_tprek_ids(self, harrastushaku_locations):
@@ -235,14 +231,11 @@ class HarrastushakuImporter(Importer):
         for i, activity in enumerate(activities, 1):
             try:
                 self.handle_activity(activity)
+            except HarrastushakuException as e:
+                logger.exception(f"Error handling activity {activity.get('id')}: {e}")
             except Exception as e:  # noqa
-                message = (
-                    e
-                    if isinstance(e, HarrastushakuException)
-                    else traceback.format_exc()
-                )
-                logger.error(
-                    "Error handling activity {}: {}".format(activity.get("id"), message)
+                logger.exception(
+                    f"An unexpected error occurred while handling activity {activity.get('id')}: {e}"
                 )
 
             if not i % 10:

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -704,7 +704,7 @@ class KulkeImporter(Importer):
                     kulke_keyword = Keyword.objects.get(pk=kulke_id)
                     event_keywords.add(kulke_keyword)
                 except Keyword.DoesNotExist:
-                    logger.error("Could not find {}".format(kulke_id))
+                    logger.exception("Could not find {}".format(kulke_id))
 
             if is_course:
                 event_keywords.update(self.course_keywords)

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -22,6 +22,7 @@ URL = "http://finto.fi/rest/v1/yso/data"
 YSO_DEPRECATED_MAPS = {
     "yso:p12262": "yso:p4354",  # lapset (kooste) -> lapset (ikään liittyvä rooli), missing YSO replacement
     "yso:p21160": "yso:p8113",  # kirjallisuus (erikoisala) -> kirjallisuus (taidelajit), wrong YSO replacement
+    "yso:p27158": "yso:p508707",  # Suvilahti -> Suvilahti (Helsinki), missing YSO replacement
 }
 
 # yso keywords for the importers to automatically include in the audience field as well


### PR DESCRIPTION
- Add exception information in some of the kulke/harrastushaku importer error logs
  - Also change the error messages for harrastushaku error loggers.
  - These both are mostly for making Sentry more helpful.
  - I also considered making `HarrastushakuException` related log messages into warnings, since they are essentially warnings, but wasn't quite sure how Sentry handles warnings, so left them as errors.
- Add YSO replacement for Suvilahti (deprecated: [Suvilahti](https://finto.fi/yso/fi/page/p27158), replaced by: [Suvilahti (Helsinki)](https://finto.fi/yso-paikat/fi/page/p508707))
  - Due to this error: `Exception: Deprecating YSO keyword Suvilahti that is referenced in events <MultilingualBaseTreeQuerySet [<Event: D-A-D & Melrose (helsinki:af25a6ji4u) 2022-08-25 15:00:00+00:00>]>. No replacement keyword was found in YSO. Please manually map the keyword to a new keyword in YSO_DEPRECATED_MAPS.`
  - Not sure why the importer can't find the replacement by itself since it's very apparent in the website at least, but then again, I didn't really take a stab at the API side of things

Probably doesn't fix everything, but should give more info in Sentry and hopefully resolve at least one hurdle for the YSO importer.