### PR TITLE
LINK-1394 | User doing AD authentication is never considered to be an external user

### DIFF
--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -94,7 +94,9 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
     ],
 )
 @pytest.mark.django_db
-def test_is_external_user(is_admin, is_regular_user, expected):
+def test_user_is_external_based_on_group_membership(
+    is_admin, is_regular_user, expected
+):
     with (
         patch.object(
             UserModelPermissionMixin, "organization_memberships", new_callable=MagicMock

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -77,6 +77,8 @@ env = environ.Env(
     MAILGUN_API_KEY=(str, ""),
     MEDIA_ROOT=(environ.Path(), root("media")),
     MEDIA_URL=(str, "/media/"),
+    # "helsinkiazuread" = Tunnistamo auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2
+    NON_EXTERNAL_AUTHENTICATION_METHODS=(list, ["helsinkiazuread"]),
     REDIS_SENTINELS=(list, []),
     REDIS_URL=(str, None),
     REDIS_PASSWORD=(str, None),
@@ -304,6 +306,9 @@ ENABLE_EXTERNAL_USER_EVENTS = env("ENABLE_EXTERNAL_USER_EVENTS")
 # Publisher used for events created by users without organization (i.e. external users)
 EXTERNAL_USER_PUBLISHER_ID = env("EXTERNAL_USER_PUBLISHER_ID")
 
+# Which OIDC authentication methods are never considered as external users
+NON_EXTERNAL_AUTHENTICATION_METHODS = env("NON_EXTERNAL_AUTHENTICATION_METHODS")
+
 #
 # REST Framework
 #
@@ -328,7 +333,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "events.auth.ApiKeyAuthentication",
-        "helusers.oidc.ApiTokenAuthentication",
+        "events.auth.ApiTokenAuthentication",
     ),
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     "VIEW_NAME_FUNCTION": "linkedevents.utils.get_view_name",


### PR DESCRIPTION
User.is_external checks the AMR claim value and and returns False if AD authentication is used.

AMR (Authentication Method Reference) should be a list of string that are identifiers for authentication methods used in the authentication. Tunnistamo however sets a simple string here, which is assumed in this implementation also.

Refs LINK-1394