### PR TITLE
Tweak azure pipelines for prod/staging builds and deployments

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -6,6 +6,7 @@ trigger:
     include:
       - develop
       - refs/tags/staging-*
+      - refs/tags/release-*
       # other examples:
       #- release/*
       #- refs/tags/*
@@ -48,7 +49,9 @@ extends:
   #parameters:
   #imagetag: ${{ parameters.imagetag }}
   parameters:
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/staging-') }}:
+    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/release-') }}:
+      buildenv: -prod
+    ${{ elseif startsWith(variables['Build.SourceBranch'], 'refs/tags/staging-') }}:
       buildenv: -staging
     ${{ else }}:
       buildenv: -dev

--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -30,7 +30,6 @@ parameters:
     default: "-prod"
     values:
       - "-prod"
-      - "-dev"
 
 
 # Image tag name for Fuse projects

--- a/azure-pipelines-stage.yml
+++ b/azure-pipelines-stage.yml
@@ -6,9 +6,10 @@ parameters:
   - name: buildenv
     displayName: Build environment
     type: string
-    default: "-prod"
+    default: "-staging"
     values:
       - "-prod"
+      - "-staging"
       - "-dev"
 
 


### PR DESCRIPTION
1) Trigger build on releasing a tag that starts with `release-`
2) set buildenv for release builds as PROD
3) Allow deploying only prod builds to production
4) Allow deploying all builds to staging

Ref [LINK-1407](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1407)

[LINK-1407]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ