### PR TITLE
LINK-1080: Add missing imports (kulke keywords, harrastushaku places)

### DIFF
--- a/helevents/service_tasks/daily_tasks.sh
+++ b/helevents/service_tasks/daily_tasks.sh
@@ -9,9 +9,14 @@ if [ $? -ne 0 ]; then
     echo "YSO update signaled failure"
 fi
 
+timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --places
+if [ $? -ne 0 ]; then
+    echo "Harrastushaku places update signaled failure"
+fi
+
 timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --courses
 if [ $? -ne 0 ]; then
-    echo "Harrastushaku update signaled failure"
+    echo "Harrastushaku courses update signaled failure"
 fi
 
 

--- a/helevents/service_tasks/hourly_tasks.sh
+++ b/helevents/service_tasks/hourly_tasks.sh
@@ -11,9 +11,14 @@ fi
 
 echo "--- Starting kulke importer ---"
 
+timeout --preserve-status -s INT 30m python manage.py event_import kulke --keywords
+if [ $? -ne 0 ]; then
+    echo "kulke importer keyword import signaled failure"
+fi
+
 timeout --preserve-status -s INT 30m python manage.py event_import kulke --events
 if [ $? -ne 0 ]; then
-    echo "kulke importer signaled failure"
+    echo "kulke importer event import signaled failure"
 fi
 
 echo "--- Starting lippupiste importer ---"


### PR DESCRIPTION
Add kulke keywords import and harrastushaku places import in `hourly_tasks.sh` and `daily_tasks.sh`.

Some of the kulke/harrastushaku events (or at least Harrastushaku) require these. Causes `Keyword.DoesNotExist` in kulke & `Place.DoesNotExist` in HH otherwise. Tested with Harrastushaku importer locally; Kulke importer doesn't seem to work locally for me, but the error seems to have a similar root cause.

These weren't in the old production environment's crontab, so makes me wonder whether there's a good reason for it or not.