### PR TITLE
Increase the buffer-size for uWSGI

### DIFF
--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -12,6 +12,7 @@ gid = nogroup
 enable-threads = true
 master = 1
 socket-timeout = 60
+buffer-size = 65535
 
 # Reload workers regularly to keep memory fresh
 # and ease potential memory leaks


### PR DESCRIPTION
Increasing the buffer-size will allow bigger requests which will allow e.g. to include big lists of AD-group memberships in a authentication token.

Refs LINK-1448