### PR TITLE
Fix api root view name

### DIFF
--- a/linkedevents/api.py
+++ b/linkedevents/api.py
@@ -11,6 +11,8 @@ from linkedevents.registry import all_views
 
 
 class CustomAPIRootView(APIRootView):
+    name = "Linked Events"
+
     def get(self, request, *args, **kwargs):
         # Return a plain {"name": "hyperlink"} response.
         ret = OrderedDict()

--- a/linkedevents/tests/test_api_root_view.py
+++ b/linkedevents/tests/test_api_root_view.py
@@ -31,3 +31,8 @@ def test_return_correct_routes(api_client):
     assert response.data.get("organization_class") == None
     assert response.data.get("feedback") == None
     assert response.data.get("guest-feedback") == None
+
+
+def test_has_correct_name(api_client):
+    response = api_client.get(reverse("api-root"), HTTP_ACCEPT="text/html")
+    assert "<h1>Linked Events</h1>" in str(response.content)

--- a/linkedevents/tests/test_api_root_view.py
+++ b/linkedevents/tests/test_api_root_view.py
@@ -27,10 +27,10 @@ def test_return_correct_routes(api_client):
     )
     assert response.data["signup"] == "http://testserver/v1/signup/"
     assert len(response.data) == 12
-    assert response.data.get("data_source") == None
-    assert response.data.get("organization_class") == None
-    assert response.data.get("feedback") == None
-    assert response.data.get("guest-feedback") == None
+    assert response.data.get("data_source") is None
+    assert response.data.get("organization_class") is None
+    assert response.data.get("feedback") is None
+    assert response.data.get("guest-feedback") is None
 
 
 def test_has_correct_name(api_client):


### PR DESCRIPTION
Fixed API root view name which was erroneous "Custom Api Root" due to a regression introduced in 8ac8ec78c34aba7ee90159f64b7797a2a5dadd91.

Spotted by @charn 🦅 👁️

<img width="1317" alt="Screenshot 2023-08-21 at 0 20 52" src="https://github.com/City-of-Helsinki/linkedevents/assets/1314604/d93fd343-59a2-4ed8-8d1e-db0bf3c164f4">

<img width="1310" alt="Screenshot 2023-08-21 at 0 26 48" src="https://github.com/City-of-Helsinki/linkedevents/assets/1314604/547377a0-7361-448e-aa76-b6d123c871b0">
