### PR TITLE
Support changing the URL prefix used by Django

### DIFF
--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -3,7 +3,10 @@
 
 http-socket = :8000
 chdir = /app
-module = linkedevents.wsgi
+mount = $(DJANGO_URL_PREFIX)=linkedevents/wsgi.py
+# causes uwsgi to change SCRIPT_NAME & PATH_INFO based on mount directive
+# see: https://wsgi.readthedocs.io/en/latest/definitions.html#envvar-SCRIPT_NAME
+manage-script-name = true
 if-env = MEDIA_ROOT
 static-map = /media=$(MEDIA_ROOT)
 end-if =
@@ -11,6 +14,9 @@ uid = nobody
 gid = nogroup
 enable-threads = true
 master = 1
+# by default uwsgi reloads on SIGTERM instead of terminating
+# this makes container slow to stop, so we change it here
+die-on-term = true
 socket-timeout = 60
 buffer-size = 65535
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -8,6 +8,9 @@ RUN mkdir /entrypoint
 
 ENV PYTHONDONTWRITEBYTECODE=true
 ENV PYTHONUNBUFFERED=true
+# Default for URL prefix, handled by uwsgi, ignored by devserver
+# Works like this: "/example" -> http://hostname.domain.name/example
+ENV DJANGO_URL_PREFIX=/
 
 ## Setting the permissions beforehand makes the mounted volume inherit the permission
 ## in docker compose. Useful for development with non-root user and named volume.

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -29,14 +29,14 @@ if [[ "$COMPILE_TRANSLATIONS" = "true" ]]; then
     django-admin compilemessages
 fi
 
-# Start server
+# Allow running arbitrary commands instead of the servers
 if [[ -n "$@" ]]; then
     "$@"
 elif [[ "$DEV_SERVER" = "true" ]]; then
-    python -Wd ./manage.py runserver_plus 0.0.0.0:8000
+    exec python -Wd ./manage.py runserver_plus 0.0.0.0:8000
 else
-    uwsgi \
-    --ini .prod/uwsgi_configuration.ini \
-    --processes ${UWSGI_PROCESSES-2} \
-    --threads ${UWSGI_THREADS-2}
+    exec uwsgi \
+         --ini .prod/uwsgi_configuration.ini \
+         --processes ${UWSGI_PROCESSES-2} \
+         --threads ${UWSGI_THREADS-2}
 fi


### PR DESCRIPTION
Support changing the URL prefix for Django by the way of the "mount" and "manage-script-name" directives in uwsgi

URL prefix is read from environment with default being "/".

Also includes a slight optimization for container shutdown speed