### PR TITLE
TILA-1071 | Add filters for event max- and min_attendee_capacity

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3229,6 +3229,22 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         method="filter_dwithin", widget=DistanceWithinWidget()
     )
 
+    max_attendee_capacity_gte = django_filters.NumberFilter(
+        field_name="maximum_attendee_capacity", lookup_expr="gte"
+    )
+
+    min_attendee_capacity_gte = django_filters.NumberFilter(
+        field_name="minimum_attendee_capacity", lookup_expr="gte"
+    )
+
+    max_attendee_capacity_lte = django_filters.NumberFilter(
+        field_name="maximum_attendee_capacity", lookup_expr="lte"
+    )
+
+    min_attendee_capacity_lte = django_filters.NumberFilter(
+        field_name="minimum_attendee_capacity", lookup_expr="lte"
+    )
+
     class Meta:
         model = Event
         fields = ("division", "super_event_type", "super_event")
@@ -3300,6 +3316,8 @@ class EventViewSet(
         "duration",
         "last_modified_time",
         "name",
+        "maximum_attendee_capacity",
+        "minimum_attendee_capacity",
     )
     ordering = ("-last_modified_time",)
     renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [DOCXRenderer]

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1155,3 +1155,179 @@ def test_get_event_list_verify_registration_filter(
     event3.save()
     get_list_and_assert_events("registration=true", [event, event2])
     get_list_and_assert_events("registration=false", [event3])
+
+
+@pytest.mark.django_db
+def test_get_event_list_max_attendee_capacity_filter_gte(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.maximum_attendee_capacity = 10
+    event.save()
+    event2.maximum_attendee_capacity = 9
+    event2.save()
+    event3.maximum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("max_attendee_capacity_gte=9", [event, event2])
+
+
+@pytest.mark.django_db
+def test_get_event_list_max_attendee_capacity_filter_gte_when_equal(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.maximum_attendee_capacity = 10
+    event.save()
+    event2.maximum_attendee_capacity = 9
+    event2.save()
+    event3.maximum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("max_attendee_capacity_gte=10", [event])
+
+
+@pytest.mark.django_db
+def test_get_event_list_max_attendee_capacity_filter_lte(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.maximum_attendee_capacity = 10
+    event.save()
+    event2.maximum_attendee_capacity = 9
+    event2.save()
+    event3.maximum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("max_attendee_capacity_lte=9", [event2, event3])
+
+
+@pytest.mark.django_db
+def test_get_event_list_max_attendee_capacity_filter_lte_when_equal(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.maximum_attendee_capacity = 10
+    event.save()
+    event2.maximum_attendee_capacity = 9
+    event2.save()
+    event3.maximum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("max_attendee_capacity_lte=8", [event3])
+
+
+@pytest.mark.django_db
+def test_get_event_list_min_attendee_capacity_filter_gte(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.minimum_attendee_capacity = 10
+    event.save()
+    event2.minimum_attendee_capacity = 9
+    event2.save()
+    event3.minimum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("min_attendee_capacity_gte=9", [event, event2])
+
+
+@pytest.mark.django_db
+def test_get_event_list_min_attendee_capacity_filter_gte_when_equal(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.minimum_attendee_capacity = 10
+    event.save()
+    event2.minimum_attendee_capacity = 9
+    event2.save()
+    event3.minimum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("min_attendee_capacity_gte=10", [event])
+
+
+@pytest.mark.django_db
+def test_get_event_list_min_attendee_capacity_filter_lte(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.minimum_attendee_capacity = 10
+    event.save()
+    event2.minimum_attendee_capacity = 9
+    event2.save()
+    event3.minimum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("min_attendee_capacity_lte=9", [event2, event3])
+
+
+@pytest.mark.django_db
+def test_get_event_list_min_attendee_capacity_filter_lte_when_equal(
+    api_client,
+    event,
+    event2,
+    event3,
+):
+    event.minimum_attendee_capacity = 10
+    event.save()
+    event2.minimum_attendee_capacity = 9
+    event2.save()
+    event3.minimum_attendee_capacity = 8
+    event3.save()
+
+    get_list_and_assert_events("min_attendee_capacity_lte=8", [event3])
+
+
+@pytest.mark.django_db
+def test_sort_events_by_maximum_attendee_capacity(api_client, event, event2, event3):
+    event.maximum_attendee_capacity = 10
+    event.save()
+    event2.maximum_attendee_capacity = 9
+    event2.save()
+    event3.maximum_attendee_capacity = 8
+    event3.save()
+
+    response = get_list(
+        api_client=api_client, query_string="sort=-maximum_attendee_capacity"
+    )
+
+    results = response.data["data"]
+    assert len(results) == 3
+    assert results[0]["id"] == event.id
+    assert results[1]["id"] == event2.id
+    assert results[2]["id"] == event3.id
+
+
+@pytest.mark.django_db
+def test_sort_events_by_minimum_attendee_capacity(api_client, event, event2, event3):
+    event.minimum_attendee_capacity = 10
+    event.save()
+    event2.minimum_attendee_capacity = 9
+    event2.save()
+    event3.minimum_attendee_capacity = 8
+    event3.save()
+
+    response = get_list(
+        api_client=api_client, query_string="sort=minimum_attendee_capacity"
+    )
+
+    results = response.data["data"]
+    assert len(results) == 3
+    assert results[0]["id"] == event3.id
+    assert results[1]["id"] == event2.id
+    assert results[2]["id"] == event.id


### PR DESCRIPTION
Adds possibility to filter max- and min_attendee_capacity fields through gte, lte lookups. Such as `?max_attendee_capacity__gte=12`.

Also adds ordering capabilities for those fields

Refs LINK-1071