### PR TITLE
LINK-1351, part 2 | Registration admin permissions

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -260,9 +260,11 @@ class Registration(CreatedModifiedBaseModel):
 
     def can_be_edited_by(self, user):
         """Check if current registration can be edited by the given user"""
-        if user.is_superuser:
-            return True
-        return user.is_admin_of(self.event.publisher)
+        return (
+            user.is_superuser
+            or user.is_admin_of(self.event.publisher)
+            or user.is_registration_admin_of(self.event.publisher)
+        )
 
     def is_user_editable_resources(self):
         return bool(
@@ -283,7 +285,19 @@ class SignUpMixin:
         """Check if the current signup can be edited by the given user"""
         return (
             user.is_superuser
-            or user.is_admin_of(self.publisher)
+            or user.is_registration_admin_of(self.publisher)
+            or user.is_strongly_identificated
+            and self.registration.registration_user_accesses.filter(
+                email=user.email
+            ).exists()
+            or user.id == self.created_by_id
+        )
+
+    def can_be_deleted_by(self, user):
+        """Check if current signup can be deleted by the given user"""
+        return (
+            user.is_superuser
+            or user.is_registration_admin_of(self.publisher)
             or user.id == self.created_by_id
         )
 

--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -1,25 +1,80 @@
-from django.utils.translation import gettext as _
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from events.auth import ApiKeyUser
-from registrations.models import SignUp
+from events.permissions import UserDataFromRequestMixin
+from registrations.models import Registration, SignUp
 
 
-class CanCreateEditDeleteSignup(permissions.BasePermission):
-    message: str = _(
-        "Only authenticated users are able to access sign-ups. Viewing, editing and deleting are"
-        "allowed only for admins of the publishing organization and for users that have created "
-        "the sign-up."
-    )
-
+class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission):
     def has_permission(self, request: Request, view: APIView) -> bool:
-        return (
-            request.method
-            in permissions.SAFE_METHODS + ("POST", "PUT", "PATCH", "DELETE")
-            and request.user.is_authenticated
-        )
+        if not request.user.is_authenticated:
+            return False
+
+        if request.method == "POST":
+            (
+                __,
+                user_organization,
+            ) = self.user_data_source_and_organization_from_request(request)
+            return (
+                request.user.is_superuser
+                or request.user.is_admin_of(user_organization)
+                or request.user.is_registration_admin_of(user_organization)
+            )
+
+        if request.method in ("PUT", "PATCH", "DELETE"):
+            (
+                __,
+                user_organization,
+            ) = self.user_data_source_and_organization_from_request(request)
+            return bool(user_organization)
+
+        return request.method in permissions.SAFE_METHODS
+
+    def has_object_permission(
+        self, request: Request, view: APIView, obj: Registration
+    ) -> bool:
+        if isinstance(request.user, ApiKeyUser):
+            user_data_source, _ = view.user_data_source_and_organization
+            # allow only if the api key matches instance data source
+            if obj.data_source != user_data_source:
+                return False
+
+        if request.method == "GET":
+            return (
+                obj.can_be_edited_by(request.user)
+                and obj.registration_user_accesses.filter(
+                    email=request.user.email
+                ).exists()
+                or obj.created_by_id == request.user.id
+            )
+
+        return obj.can_be_edited_by(request.user)
+
+
+class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if not request.user.is_authenticated:
+            return False
+
+        if request.method == "POST":
+            (
+                __,
+                user_organization,
+            ) = self.user_data_source_and_organization_from_request(request)
+            return request.user.is_superuser or request.user.is_registration_admin_of(
+                user_organization
+            )
+
+        if request.method in ("PATCH", "PUT", "DELETE"):
+            (
+                __,
+                user_organization,
+            ) = self.user_data_source_and_organization_from_request(request)
+            return bool(user_organization)
+
+        return request.method in permissions.SAFE_METHODS
 
     def has_object_permission(
         self, request: Request, view: APIView, obj: SignUp
@@ -30,20 +85,7 @@ class CanCreateEditDeleteSignup(permissions.BasePermission):
             if obj.data_source != user_data_source:
                 return False
 
+        if request.method == "DELETE":
+            return obj.can_be_deleted_by(request.user)
+
         return obj.can_be_edited_by(request.user)
-
-
-class RegistrationUserAccessRetrievePermission(permissions.BasePermission):
-    def has_permission(self, request, view):
-        # Only authenticated users can get object
-        return view.action == "retrieve" and request.user.is_authenticated
-
-    def has_object_permission(self, request: Request, view, obj):
-        user = request.user
-
-        return (
-            user.is_strongly_identificated
-            and obj.registration.registration_user_accesses.filter(
-                email=user.email
-            ).exists()
-        )

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -57,6 +57,12 @@ class TestRegistration(TestCase):
         can_be_edited = self.registration.can_be_edited_by(self.user)
         self.assertTrue(can_be_edited)
 
+    def test_can_be_edited_by_registration_admin_user(self):
+        self.org.registration_admin_users.add(self.user)
+
+        can_be_edited = self.registration.can_be_edited_by(self.user)
+        self.assertTrue(can_be_edited)
+
 
 class TestRegistrationUserAccess(TestCase):
     def setUp(self):
@@ -124,8 +130,14 @@ class TestSignUpGroup(TestCase):
         can_be_edited = self.signup_group.can_be_edited_by(self.user)
         self.assertTrue(can_be_edited)
 
-    def test_can_be_edited_by_admin_user(self):
+    def test_cannot_be_edited_by_admin_user(self):
         self.org.admin_users.add(self.user)
+
+        can_be_edited = self.signup_group.can_be_edited_by(self.user)
+        self.assertFalse(can_be_edited)
+
+    def test_can_be_edited_by_registration_admin_user(self):
+        self.org.registration_admin_users.add(self.user)
 
         can_be_edited = self.signup_group.can_be_edited_by(self.user)
         self.assertTrue(can_be_edited)
@@ -191,8 +203,14 @@ class TestSignUp(TestCase):
         can_be_edited = self.signup.can_be_edited_by(self.user)
         self.assertFalse(can_be_edited)
 
-    def test_can_be_edited_by_admin_user(self):
+    def test_cannot_be_edited_by_admin_user(self):
         self.org.admin_users.add(self.user)
+
+        can_be_edited = self.signup.can_be_edited_by(self.user)
+        self.assertFalse(can_be_edited)
+
+    def test_can_be_edited_by_registration_admin_user(self):
+        self.org.registration_admin_users.add(self.user)
 
         can_be_edited = self.signup.can_be_edited_by(self.user)
         self.assertTrue(can_be_edited)

--- a/registrations/tests/test_signup_group_get.py
+++ b/registrations/tests/test_signup_group_get.py
@@ -46,7 +46,11 @@ def assert_signup_group_fields_exist(data):
 
 
 @pytest.mark.django_db
-def test_admin_user_can_get_signup_group_with_signups(user_api_client, registration):
+def test_registration_admin_user_can_get_signup_group(
+    user_api_client, registration, organization, user
+):
+    organization.registration_admin_users.add(user)
+
     signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(registration=registration, signup_group=signup_group)
     SignUpFactory(registration=registration, signup_group=signup_group)
@@ -135,7 +139,7 @@ def test_user_from_other_organization_cannot_get_signup_group(
 
 
 @pytest.mark.django_db
-def test_api_key_with_organization_can_get_signup(
+def test_api_key_with_organization_and_registration_permissions_can_get_signup_group(
     api_client, data_source, organization
 ):
     signup_group = SignUpGroupFactory(
@@ -146,7 +150,8 @@ def test_api_key_with_organization_can_get_signup(
     SignUpFactory(registration=signup_group.registration, signup_group=signup_group)
 
     data_source.owner = organization
-    data_source.save()
+    data_source.user_editable_registrations = True
+    data_source.save(update_fields=["owner", "user_editable_registrations"])
     api_client.credentials(apikey=data_source.api_key)
 
     response = assert_get_detail(api_client, signup_group.id)

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -30,6 +30,8 @@ def assert_patch_signup(api_client, signup_pk, signup_data):
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
 def test__patch_presence_status_of_signup(api_client, registration, signup, user):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.audience_min_age = 10
     registration.mandatory_fields = [
         MandatoryFields.PHONE_NUMBER,

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -34,6 +34,8 @@ def assert_create_signups(api_client, signups_data):
 
 @pytest.mark.django_db
 def test_successful_signup(user_api_client, languages, registration, user):
+    user.get_default_organization().registration_admin_users.add(user)
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
@@ -76,6 +78,31 @@ def test_successful_signup(user_api_client, languages, registration, user):
 
 
 @pytest.mark.django_db
+def test_cannot_signup_if_not_registration_admin(user_api_client, event, registration):
+    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    signups_data = {
+        "registration": registration.id,
+        "reservation_code": reservation.code,
+        "signups": [
+            {
+                "name": "Michael Jackson",
+                "date_of_birth": "2011-04-07",
+                "email": "test@test.com",
+                "phone_number": "0441111111",
+                "notifications": "sms",
+                "service_language": "fi",
+                "native_language": "fi",
+                "street_address": "my street",
+                "zipcode": "myzip1",
+            }
+        ],
+    }
+
+    response = create_signups(user_api_client, signups_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
 def test_cannot_signup_if_not_authenticated(api_client, event, registration, user):
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     signups_data = {
@@ -101,7 +128,10 @@ def test_cannot_signup_if_not_authenticated(api_client, event, registration, use
 
 
 @pytest.mark.django_db
-def test_cannot_signup_if_enrolment_is_not_opened(user_api_client, event, registration):
+def test_cannot_signup_if_enrolment_is_not_opened(
+    user_api_client, event, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
 
     registration.enrolment_start_time = localtime() + timedelta(days=1)
     registration.enrolment_end_time = localtime() + timedelta(days=2)
@@ -125,7 +155,11 @@ def test_cannot_signup_if_enrolment_is_not_opened(user_api_client, event, regist
 
 
 @pytest.mark.django_db
-def test_cannot_signup_if_enrolment_is_closed(user_api_client, event, registration):
+def test_cannot_signup_if_enrolment_is_closed(
+    user_api_client, event, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.enrolment_start_time = localtime() - timedelta(days=2)
     registration.enrolment_end_time = localtime() - timedelta(days=1)
     registration.save()
@@ -148,7 +182,11 @@ def test_cannot_signup_if_enrolment_is_closed(user_api_client, event, registrati
 
 
 @pytest.mark.django_db
-def test_cannot_signup_if_reservation_code_is_missing(user_api_client, registration):
+def test_cannot_signup_if_reservation_code_is_missing(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
     signups_payload = {
         "registration": registration.id,
         "signups": [],
@@ -161,8 +199,10 @@ def test_cannot_signup_if_reservation_code_is_missing(user_api_client, registrat
 
 @pytest.mark.django_db
 def test_amount_if_signups_cannot_be_greater_than_maximum_group_size(
-    user_api_client, event, registration
+    user_api_client, event, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.audience_min_age = None
     registration.audience_max_age = None
     registration.maximum_attendee_capacity = None
@@ -187,7 +227,11 @@ def test_amount_if_signups_cannot_be_greater_than_maximum_group_size(
 
 
 @pytest.mark.django_db
-def test_cannot_signup_if_reservation_code_is_invalid(user_api_client, registration):
+def test_cannot_signup_if_reservation_code_is_invalid(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
     signups_payload = {
         "registration": registration.id,
         "reservation_code": "c5e7d3ba-e48d-447c-b24d-c779950b2acb",
@@ -201,8 +245,10 @@ def test_cannot_signup_if_reservation_code_is_invalid(user_api_client, registrat
 
 @pytest.mark.django_db
 def test_cannot_signup_if_reservation_code_is_for_different_registration(
-    user_api_client, registration, registration2
+    user_api_client, registration, registration2, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     reservation = SeatReservationCode.objects.create(
         registration=registration2, seats=2
     )
@@ -220,8 +266,10 @@ def test_cannot_signup_if_reservation_code_is_for_different_registration(
 
 @pytest.mark.django_db
 def test_cannot_signup_if_number_of_signups_exceeds_number_reserved_seats(
-    user_api_client, registration
+    user_api_client, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
 
     signups_data = {
@@ -249,7 +297,11 @@ def test_cannot_signup_if_number_of_signups_exceeds_number_reserved_seats(
 
 
 @pytest.mark.django_db
-def test_cannot_signup_if_reservation_code_is_expired(user_api_client, registration):
+def test_cannot_signup_if_reservation_code_is_expired(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     reservation.timestamp = reservation.timestamp - timedelta(days=1)
     reservation.save()
@@ -272,7 +324,9 @@ def test_cannot_signup_if_reservation_code_is_expired(user_api_client, registrat
 
 
 @pytest.mark.django_db
-def test_can_signup_twice_with_same_phone_or_email(user_api_client, registration):
+def test_can_signup_twice_with_same_phone_or_email(user_api_client, registration, user):
+    user.get_default_organization().registration_admin_users.add(user)
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=3)
     signup_data = {
         "first_name": "Michael",
@@ -301,8 +355,10 @@ def test_can_signup_twice_with_same_phone_or_email(user_api_client, registration
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
 def test_date_of_birth_is_mandatory_if_audience_min_or_max_age_specified(
-    user_api_client, date_of_birth, min_age, max_age, registration
+    user_api_client, date_of_birth, min_age, max_age, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     falsy_values = ("", None)
 
     # Update registration
@@ -361,8 +417,10 @@ def test_date_of_birth_is_mandatory_if_audience_min_or_max_age_specified(
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
 def test_signup_age_has_to_match_the_audience_min_max_age(
-    user_api_client, date_of_birth, expected_error, expected_status, registration
+    user_api_client, date_of_birth, expected_error, expected_status, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.audience_max_age = 40
     registration.audience_min_age = 20
     registration.enrolment_start_time = localtime()
@@ -405,8 +463,10 @@ def test_signup_age_has_to_match_the_audience_min_max_age(
 )
 @pytest.mark.django_db
 def test_signup_mandatory_fields_has_to_be_filled(
-    user_api_client, mandatory_field_id, registration
+    user_api_client, mandatory_field_id, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.mandatory_fields = [mandatory_field_id]
     registration.save()
 
@@ -419,8 +479,8 @@ def test_signup_mandatory_fields_has_to_be_filled(
         "city": "Helsinki",
         "zipcode": "00100",
         "notifications": "sms",
+        mandatory_field_id: "",
     }
-    signup_data[mandatory_field_id] = ""
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
@@ -439,8 +499,10 @@ def test_signup_mandatory_fields_has_to_be_filled(
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
 def test_cannot_signup_with_not_allowed_service_language(
-    user_api_client, languages, registration
+    user_api_client, languages, registration, user
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     languages[0].service_language = False
     languages[0].save()
 
@@ -465,7 +527,9 @@ def test_cannot_signup_with_not_allowed_service_language(
 
 
 @pytest.mark.django_db
-def test_group_signup_successful_with_waitlist(user_api_client, registration):
+def test_group_signup_successful_with_waitlist(user_api_client, registration, user):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = 2
     registration.save()
@@ -557,7 +621,10 @@ def test_email_sent_on_successful_signup(
     languages,
     registration,
     service_language,
+    user,
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     with translation.override(service_language):
         registration.event.type_id = Event.TypeId.GENERAL
         registration.event.name = "Foo"
@@ -619,10 +686,14 @@ def test_confirmation_template_has_correct_text_per_event_type(
     expected_text,
     languages,
     registration,
+    user,
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.event.type_id = event_type
     registration.event.name = "Foo"
     registration.event.save()
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
@@ -663,10 +734,14 @@ def test_confirmation_message_is_shown_in_service_language(
     languages,
     registration,
     service_language,
+    user,
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     Language.objects.get_or_create(
         id=service_language, defaults={"name": service_language}
     )
+
     registration.confirmation_message_en = "Confirmation message"
     registration.confirmation_message_fi = "Vahvistusviesti"
     registration.save()
@@ -717,7 +792,10 @@ def test_different_email_sent_if_user_is_added_to_waiting_list(
     registration,
     service_language,
     signup,
+    user,
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     with translation.override(service_language):
         registration.event.type_id = Event.TypeId.GENERAL
         registration.event.name = "Foo"
@@ -775,12 +853,16 @@ def test_confirmation_to_waiting_list_template_has_correct_text_per_event_type(
     languages,
     registration,
     signup,
+    user,
 ):
+    user.get_default_organization().registration_admin_users.add(user)
+
     registration.event.type_id = event_type
     registration.event.name = "Foo"
     registration.event.save()
     registration.maximum_attendee_capacity = 1
     registration.save()
+
     reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",


### PR DESCRIPTION
### Description
Makes the following changes to registration permissions:
* Only a registration admin, a superuser or the "created user" is able to perform all CRUD operations on the endpoint `signup`.
* In addition to a regular admin, the registration admin will be able to perform all CRUD operations on the endpoint `registration`.
* A registration user (`RegistrationUserAccess`) is allowed to get a `registration`, but not allowed to do any other CRUD operations on that endpoint.
* A registration user (`RegistrationUserAccess`) is allowed to get or update a `signup`, but not allowed to do any other CRUD operations on that endpoint (updating will be limited to patching just `presence_status` in LINK-1429).

This PR is the second one of two PRs - the first PR (part 1) will bring the Django admin and organization API endpoint changes described in the Jira task.
### Partially closes
[LINK-1351](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1351)

[LINK-1351]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ