### PR TITLE
LINK-1471 | Fix signup_confimation template translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -791,18 +791,18 @@ msgstr "Tervetuloa %(username)s"
 #: registrations/templates/signup_confirmation.html:14
 #, python-format
 msgid "Registration to the event %(event)s has been saved."
-msgstr "Ilmoittautuminen tapahtuman %(event)s jonotuslistaan on tallennettu."
+msgstr "Ilmoittautuminen tapahtumaan %(event)s on tallennettu."
 
 #: registrations/templates/signup_confirmation.html:17
 #, python-format
 msgid "Registration to the course %(event)s has been saved."
-msgstr "Ilmoittautuminen kurssin %(event)s jonotuslistaan on tallennettu."
+msgstr "Ilmoittautuminen kurssille %(event)s on tallennettu."
 
 #: registrations/templates/signup_confirmation.html:20
 #, python-format
 msgid "Registration to the volunteering %(event)s has been saved."
 msgstr ""
-"Ilmoittautuminen vapaaehtoistehtävän %(event)s jonotuslistaan on tallennettu."
+"Ilmoittautuminen vapaaehtoistehtävään %(event)s on tallennettu."
 
 #: registrations/templates/signup_confirmation.html:28
 #, python-format

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -791,17 +791,17 @@ msgstr "Välkommen %(username)s"
 #: registrations/templates/signup_confirmation.html:14
 #, python-format
 msgid "Registration to the event %(event)s has been saved."
-msgstr "Anmälan till evenemanget %(event)s väntelista har sparats."
+msgstr "Anmälan till evenemanget %(event)s har sparats."
 
 #: registrations/templates/signup_confirmation.html:17
 #, python-format
 msgid "Registration to the course %(event)s has been saved."
-msgstr "Anmälan till kursen %(event)s väntelista har sparats."
+msgstr "Anmälan till kursen %(event)s har sparats."
 
 #: registrations/templates/signup_confirmation.html:20
 #, python-format
 msgid "Registration to the volunteering %(event)s has been saved."
-msgstr "Anmälan till volontärarbetet %(event)s väntelista har sparats."
+msgstr "Anmälan till volontärarbetet %(event)s har sparats."
 
 #: registrations/templates/signup_confirmation.html:28
 #, python-format

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -537,13 +537,13 @@ def test_group_signup_successful_with_waitlist(user_api_client, registration):
         (
             "fi",
             "Vahvistus ilmoittautumisesta",
-            "Ilmoittautuminen tapahtuman Foo jonotuslistaan on tallennettu.",
+            "Ilmoittautuminen tapahtumaan Foo on tallennettu.",
             "Onnittelut! Olet onnistuneesti ilmoittautunut tapahtumaan <strong>Foo</strong>.",
         ),
         (
             "sv",
             "Bekräftelse av registrering",
-            "Anmälan till evenemanget Foo väntelista har sparats.",
+            "Anmälan till evenemanget Foo har sparats.",
             "Grattis! Du har framgångsrikt registrerat dig till evenemanget <strong>Foo</strong>.",
         ),
     ],


### PR DESCRIPTION
## Description
Current Finnish and Swedish translations of signup_confirmation.html template are incorrect.
They tell that the user is added to the waiting list, even though she already has a place in the event.

Fix translation in this PR.

## Closes
[LINK-1471](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1471)

[LINK-1471]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ