### PR TITLE
LINK-1075, part 3 | Update signup group

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -380,6 +380,7 @@ class SignUpGroupSerializer(serializers.ModelSerializer):
 
         if (
             "registration" in validated_data
+            and self.instance
             and self.instance.registration != validated_data["registration"]
         ):
             errors["registration"] = _(

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -34,6 +34,7 @@ def validate_registration_enrolment_times(registration):
 
 class SignUpSerializer(serializers.ModelSerializer):
     view_name = "signup"
+    id = serializers.IntegerField(required=False)
     service_language = serializers.PrimaryKeyRelatedField(
         queryset=Language.objects.filter(service_language=True),
         many=False,
@@ -330,6 +331,12 @@ class CreateSignUpsSerializer(serializers.Serializer):
 class SignUpGroupCreateSerializer(serializers.ModelSerializer, CreateSignUpsSerializer):
     reservation_code = serializers.CharField(write_only=True)
 
+    def _create_signups(self, instance, validated_signups_data):
+        for signup_data in validated_signups_data:
+            signup_data["signup_group"] = instance
+            signup_serializer = SignUpSerializer(data=signup_data, context=self.context)
+            signup_serializer.create(signup_data)
+
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user
         validated_data["last_modified_by"] = self.context["request"].user
@@ -339,11 +346,7 @@ class SignUpGroupCreateSerializer(serializers.ModelSerializer, CreateSignUpsSeri
         signups_data = validated_data.pop("signups")
 
         instance = super().create(validated_data)
-
-        for signup_data in signups_data:
-            signup_data["signup_group"] = instance
-            signup_serializer = SignUpSerializer(data=signup_data, context=self.context)
-            signup_serializer.create(signup_data)
+        self._create_signups(instance, signups_data)
 
         reservation.delete()
 
@@ -362,7 +365,57 @@ class SignUpGroupCreateSerializer(serializers.ModelSerializer, CreateSignUpsSeri
 
 class SignUpGroupSerializer(serializers.ModelSerializer):
     view_name = "signupgroup-detail"
-    signups = SignUpSerializer(many=True)
+
+    def get_fields(self):
+        fields = super().get_fields()
+        fields["signups"] = SignUpSerializer(
+            many=True, required=False, partial=self.partial
+        )
+        return fields
+
+    def validate(self, data):
+        validated_data = super().validate(data)
+
+        errors = {}
+
+        if (
+            "registration" in validated_data
+            and self.instance.registration != validated_data["registration"]
+        ):
+            errors["registration"] = _(
+                "You may not change the registration of an existing object."
+            )
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return validated_data
+
+    def _update_signups(self, instance, validated_signups_data):
+        for signup_data in validated_signups_data:
+            if not signup_data.get("id"):
+                continue
+
+            if not self.partial:
+                signup_data["signup_group"] = instance
+
+            signup = SignUp.objects.get(pk=signup_data["id"])
+            signup_serializer = SignUpSerializer(
+                instance=signup,
+                data=signup_data,
+                context=self.context,
+                partial=self.partial,
+            )
+            signup_serializer.update(signup_serializer.instance, signup_data)
+
+    def update(self, instance, validated_data):
+        signups_data = validated_data.pop("signups", [])
+        validated_data["last_modified_by"] = self.context["request"].user
+
+        super().update(instance, validated_data)
+        self._update_signups(instance, signups_data)
+
+        return instance
 
     class Meta:
         fields = ("id", "registration", "signups", "extra_info")

--- a/registrations/tests/test_signup_group_patch.py
+++ b/registrations/tests/test_signup_group_patch.py
@@ -1,0 +1,234 @@
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+
+from events.tests.utils import versioned_reverse as reverse
+from registrations.models import SignUp
+from registrations.tests.factories import SignUpFactory, SignUpGroupFactory
+
+# === util methods ===
+
+
+def patch_signup_group(api_client, signup_group_pk, signup_group_data):
+    signup_group_url = reverse(
+        "signupgroup-detail",
+        kwargs={"pk": signup_group_pk},
+    )
+
+    response = api_client.patch(signup_group_url, signup_group_data, format="json")
+    return response
+
+
+def assert_patch_signup_group(api_client, signup_group_pk, signup_group_data):
+    response = patch_signup_group(api_client, signup_group_pk, signup_group_data)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == signup_group_pk
+
+    return response
+
+
+# === tests ===
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_registration_admin_can_patch_signup_group_extra_info(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup0 extra info",
+    )
+    signup1 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup1 extra info",
+    )
+
+    signup_group_data = {"extra_info": "signup group extra info"}
+
+    assert signup_group.extra_info is None
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+    response = assert_patch_signup_group(
+        user_api_client, signup_group.id, signup_group_data
+    )
+    assert response.data["extra_info"] == signup_group_data["extra_info"]
+
+    signup_group.refresh_from_db()
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup_group.extra_info == signup_group_data["extra_info"]
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_admin_cannot_patch_signup_group_extra_info(user_api_client, registration):
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup0 extra info",
+    )
+    signup1 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup1 extra info",
+    )
+
+    signup_group_data = {"extra_info": "signup group extra info"}
+
+    assert signup_group.extra_info is None
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+    response = patch_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup_group.refresh_from_db()
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup_group.extra_info is None
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_regular_user_cannot_patch_signup_group_extra_info(
+    user_api_client, registration, user
+):
+    default_org = user.get_default_organization()
+    default_org.regular_users.add(user)
+    default_org.admin_users.remove(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup0 extra info",
+    )
+    signup1 = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        extra_info="signup1 extra info",
+    )
+
+    signup_group_data = {"extra_info": "signup group extra info"}
+
+    assert signup_group.extra_info is None
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+    response = patch_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup_group.refresh_from_db()
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup_group.extra_info is None
+    assert signup0.extra_info == "signup0 extra info"
+    assert signup1.extra_info == "signup1 extra info"
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_registration_admin_can_patch_signups_data(user_api_client, registration, user):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(signup_group=signup_group, registration=registration)
+    signup1 = SignUpFactory(signup_group=signup_group, registration=registration)
+
+    signup_group_data = {
+        "signups": [
+            {"id": signup0.pk, "presence_status": SignUp.PresenceStatus.PRESENT},
+            {"id": signup1.pk, "extra_info": "signup1 extra info"},
+        ]
+    }
+
+    assert signup0.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info is None
+
+    assert_patch_signup_group(user_api_client, signup_group.id, signup_group_data)
+
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup0.presence_status == SignUp.PresenceStatus.PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info == "signup1 extra info"
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_admin_cannot_patch_signups_data(user_api_client, registration):
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(signup_group=signup_group, registration=registration)
+    signup1 = SignUpFactory(signup_group=signup_group, registration=registration)
+
+    signup_group_data = {
+        "signups": [
+            {"id": signup0.pk, "presence_status": SignUp.PresenceStatus.PRESENT},
+            {"id": signup1.pk, "extra_info": "signup1 extra info"},
+        ]
+    }
+
+    assert signup0.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info is None
+
+    response = patch_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup0.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info is None
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_regular_user_cannot_patch_signups_data(user_api_client, registration, user):
+    default_org = user.get_default_organization()
+    default_org.regular_users.add(user)
+    default_org.admin_users.remove(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(signup_group=signup_group, registration=registration)
+    signup1 = SignUpFactory(signup_group=signup_group, registration=registration)
+
+    signup_group_data = {
+        "signups": [
+            {"id": signup0.pk, "presence_status": SignUp.PresenceStatus.PRESENT},
+            {"id": signup1.pk, "extra_info": "signup1 extra info"},
+        ]
+    }
+
+    assert signup0.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info is None
+
+    response = patch_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup0.refresh_from_db()
+    signup1.refresh_from_db()
+    assert signup0.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup1.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+    assert signup0.extra_info is None
+    assert signup1.extra_info is None

--- a/registrations/tests/test_signup_group_put.py
+++ b/registrations/tests/test_signup_group_put.py
@@ -1,0 +1,362 @@
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+
+from events.tests.utils import versioned_reverse as reverse
+from registrations.models import SignUp, SignUpGroup
+from registrations.tests.factories import (
+    RegistrationUserAccessFactory,
+    SignUpFactory,
+    SignUpGroupFactory,
+)
+
+# === util methods ===
+
+
+def update_signup_group(
+    api_client, signup_group_pk, signup_group_data, query_string=None
+):
+    signup_group_url = reverse(
+        "signupgroup-detail",
+        kwargs={"pk": signup_group_pk},
+    )
+
+    if query_string:
+        signup_group_url = "%s?%s" % (signup_group_url, query_string)
+
+    response = api_client.put(signup_group_url, signup_group_data, format="json")
+    return response
+
+
+def assert_update_signup_group(
+    api_client, signup_group_pk, signup_group_data, query_string=None
+):
+    response = update_signup_group(
+        api_client, signup_group_pk, signup_group_data, query_string
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["id"] == signup_group_pk
+
+    return response
+
+
+# === tests ===
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_registration_admin_can_update_signup_group(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup0 = SignUpFactory(signup_group=signup_group, registration=registration)
+    signup1 = SignUpFactory(signup_group=signup_group, registration=registration)
+
+    new_signup_group_extra_info = "Edited extra info"
+    new_signup_name = "Edited name"
+
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+    db_signup_group = SignUpGroup.objects.get(pk=signup_group.id)
+    assert db_signup_group.extra_info != new_signup_group_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+    db_signup0 = SignUp.objects.get(pk=signup0.id)
+    assert db_signup0.first_name != new_signup_name
+    assert db_signup0.last_modified_by_id is None
+
+    db_signup1 = SignUp.objects.get(pk=signup1.id)
+    assert db_signup1.first_name != new_signup_name
+    assert db_signup1.last_modified_by_id is None
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": new_signup_group_extra_info,
+        "signups": [
+            {"id": signup0.id, "first_name": new_signup_name},
+            {"extra_info": "This sign-up does not exist"},
+        ],
+    }
+
+    assert_update_signup_group(user_api_client, signup_group.id, signup_group_data)
+
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+    db_signup_group.refresh_from_db()
+    assert db_signup_group.extra_info == new_signup_group_extra_info
+    assert db_signup_group.last_modified_by_id == user.id
+
+    db_signup0.refresh_from_db()
+    assert db_signup0.first_name == new_signup_name
+    assert db_signup0.last_modified_by_id == user.id
+
+    db_signup1.refresh_from_db()
+    assert db_signup1.first_name != new_signup_name
+    assert db_signup1.last_modified_by_id is None
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_created_regular_user_can_update_signup_group(
+    user_api_client, registration, user
+):
+    signup_group = SignUpGroupFactory(registration=registration, created_by=user)
+
+    default_org = user.get_default_organization()
+    default_org.regular_users.add(user)
+    default_org.admin_users.remove(user)
+
+    new_extra_info = "Edited extra info"
+
+    db_signup_group = SignUpGroup.objects.get(pk=signup_group.id)
+    assert db_signup_group.extra_info != new_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": new_extra_info,
+    }
+
+    assert_update_signup_group(user_api_client, signup_group.id, signup_group_data)
+
+    db_signup_group.refresh_from_db()
+    assert db_signup_group.extra_info == new_extra_info
+    assert db_signup_group.last_modified_by_id == user.id
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_non_created_regular_user_cannot_update_signup_group(
+    user_api_client, registration, user
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    default_org = user.get_default_organization()
+    default_org.regular_users.add(user)
+    default_org.admin_users.remove(user)
+
+    new_extra_info = "Edited extra info"
+
+    db_signup_group = SignUpGroup.objects.get(pk=signup_group.id)
+    assert db_signup_group.extra_info != new_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": new_extra_info,
+    }
+
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    db_signup_group.refresh_from_db()
+    assert db_signup_group.extra_info != new_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_admin_cannot_update_signup_group(user_api_client, registration, user):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    new_extra_info = "Edited extra info"
+
+    db_signup_group = SignUpGroup.objects.get(pk=signup_group.id)
+    assert db_signup_group.extra_info != new_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": new_extra_info,
+    }
+
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    db_signup_group.refresh_from_db()
+    assert db_signup_group.extra_info != new_extra_info
+    assert db_signup_group.last_modified_by_id is None
+
+
+@pytest.mark.django_db
+def test_registration_user_access_cannot_update_signup_group(
+    registration, user, user_api_client
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    user.get_default_organization().admin_users.remove(user)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_cannot_update_attendee_status_of_signup_in_group(
+    user_api_client, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup = SignUpFactory(
+        signup_group=signup_group,
+        registration=registration,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+    )
+
+    signup_group_data = {
+        "registration": registration.id,
+        "signups": [
+            {"id": signup.id, "attendee_status": SignUp.AttendeeStatus.WAITING_LIST}
+        ],
+    }
+
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.data["attendee_status"]
+        == "You may not change the attendee_status of an existing object."
+    )
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_cannot_update_registration_of_signup_group(
+    user_api_client, registration, registration2, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    signup_group_data = {
+        "registration": registration2.id,
+    }
+
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.data["registration"][0]
+        == "You may not change the registration of an existing object."
+    )
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_api_key_with_organization_and_user_editable_registrations_can_update_signup_group(
+    api_client, data_source, organization, registration
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    data_source.owner = organization
+    data_source.user_editable_registrations = True
+    data_source.save(update_fields=["owner", "user_editable_registrations"])
+    api_client.credentials(apikey=data_source.api_key)
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+    assert_update_signup_group(api_client, signup_group.id, signup_group_data)
+
+
+@pytest.mark.django_db
+def test_api_key_of_other_organization_with_user_editable_registrations_cannot_update_signup_group(
+    api_client, data_source, organization2, registration
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    data_source.owner = organization2
+    data_source.user_editable_registrations = True
+    data_source.save(update_fields=["owner", "user_editable_registrations"])
+    api_client.credentials(apikey=data_source.api_key)
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+    response = update_signup_group(api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_api_key_from_wrong_data_source_with_user_editable_registrations_cannot_update_signup_group(
+    api_client, organization, other_data_source, registration
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    other_data_source.owner = organization
+    other_data_source.user_editable_registrations = True
+    other_data_source.save(update_fields=["owner", "user_editable_registrations"])
+    api_client.credentials(apikey=other_data_source.api_key)
+
+    signup_group_data = {
+        "registration": registration.id,
+        "name": "Edited extra_info",
+    }
+    response = update_signup_group(api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_unknown_api_key_cannot_update_signup_group(api_client, registration):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    api_client.credentials(apikey="unknown")
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+
+    response = update_signup_group(api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_user_editable_resources_can_update_signup_group(
+    user_api_client, data_source, organization, registration, user
+):
+    user.get_default_organization().registration_admin_users.add(user)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    data_source.owner = organization
+    data_source.user_editable_resources = True
+    data_source.save(update_fields=["owner", "user_editable_resources"])
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+
+    assert_update_signup_group(user_api_client, signup_group.id, signup_group_data)
+
+
+@pytest.mark.django_db
+def test_non_user_editable_resources_cannot_update_signup_group(
+    user_api_client, data_source, organization, registration
+):
+    signup_group = SignUpGroupFactory(registration=registration)
+
+    data_source.owner = organization
+    data_source.user_editable_resources = False
+    data_source.save(update_fields=["owner", "user_editable_resources"])
+
+    signup_group_data = {
+        "registration": registration.id,
+        "extra_info": "Edited extra_info",
+    }
+
+    response = update_signup_group(user_api_client, signup_group.id, signup_group_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
### Description
Adds the possibility to update `SignUpGroup` instances and `SignUp` instances belonging to the groups. It is only allowed to edit the related `SignUp` instances' data - adding new sign-ups or deleting existing ones from groups needs to be done through the `signup` endpoint.
### Partially closes
[LINK-1075](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1075)

[LINK-1075]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ