### PR TITLE
LINK-1449 | Signups require strong identification from registration users

### DIFF
--- a/helevents/models.py
+++ b/helevents/models.py
@@ -34,6 +34,14 @@ class UserModelPermissionMixin:
     def token_amr_claim(self, value: str):
         self._token_amr_claim = value
 
+    @property
+    def is_strongly_identificated(self):
+        """Check if the user is strongly identificated"""
+        return (
+            self.token_amr_claim
+            in settings.STRONG_IDENTIFICATION_AUTHENTICATION_METHODS
+        )
+
     @cached_property
     def is_external(self):
         """Check if the user is an external user"""

--- a/helevents/serializers.py
+++ b/helevents/serializers.py
@@ -29,5 +29,6 @@ class UserSerializer(serializers.ModelSerializer):
             "is_staff",
             "display_name",
             "is_external",
+            "is_strongly_identificated",
         ]
         model = get_user_model()

--- a/helevents/tests/test_user_get.py
+++ b/helevents/tests/test_user_get.py
@@ -33,6 +33,7 @@ def assert_user_fields_exist(data, version="v1"):
         "admin_organizations",
         "organization_memberships",
         "is_external",
+        "is_strongly_identificated",
     )
     assert_fields_exist(data, fields)
 

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -79,6 +79,7 @@ env = environ.Env(
     MEDIA_URL=(str, "/media/"),
     # "helsinkiazuread" = Tunnistamo auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2
     NON_EXTERNAL_AUTHENTICATION_METHODS=(list, ["helsinkiazuread"]),
+    STRONG_IDENTIFICATION_AUTHENTICATION_METHODS=(list, ["heltunnistussuomifi"]),
     REDIS_SENTINELS=(list, []),
     REDIS_URL=(str, None),
     REDIS_PASSWORD=(str, None),
@@ -310,6 +311,11 @@ EXTERNAL_USER_PUBLISHER_ID = env("EXTERNAL_USER_PUBLISHER_ID")
 
 # Which OIDC authentication methods are never considered as external users
 NON_EXTERNAL_AUTHENTICATION_METHODS = env("NON_EXTERNAL_AUTHENTICATION_METHODS")
+
+# Which OIDC authentication methods are considered as strong identification methods
+STRONG_IDENTIFICATION_AUTHENTICATION_METHODS = env(
+    "STRONG_IDENTIFICATION_AUTHENTICATION_METHODS"
+)
 
 #
 # REST Framework

--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -41,6 +41,9 @@ class RegistrationUserAccessRetrievePermission(permissions.BasePermission):
     def has_object_permission(self, request: Request, view, obj):
         user = request.user
 
-        return obj.registration.registration_user_accesses.filter(
-            email=user.email
-        ).exists()
+        return (
+            user.is_strongly_identificated
+            and obj.registration.registration_user_accesses.filter(
+                email=user.email
+            ).exists()
+        )

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -229,7 +229,8 @@ class RegistrationBaseSerializer(serializers.ModelSerializer):
             user = self.context["user"]
             if not user.is_anonymous and (
                 user.is_admin_of(obj.event.publisher)
-                or obj.registration_user_accesses.filter(email=user.email).exists()
+                or user.is_strongly_identificated
+                and obj.registration_user_accesses.filter(email=user.email).exists()
             ):
                 signups = obj.signups.all()
                 return SignUpSerializer(signups, many=True, read_only=True).data


### PR DESCRIPTION
### Description
After these changes, the "suomifi" identification will be required for registration users (`RegistrationUserAccess`) to access signup data.
### Closes
[LINK-1449](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1449)

[LINK-1449]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ