### PR TITLE
LINK-1451 | Add env variable for noreply email address

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -28,7 +28,6 @@ from django.contrib.gis.db import models
 from django.contrib.postgres.fields import HStoreField
 from django.contrib.postgres.indexes import Index
 from django.contrib.postgres.search import SearchVectorField
-from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.db import transaction
 from django.db.models import Q
@@ -48,6 +47,7 @@ from notifications.models import (
     NotificationType,
     render_notification_template,
 )
+from registrations.utils import get_email_noreply_address
 
 logger = logging.getLogger(__name__)
 
@@ -1142,7 +1142,7 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
             send_mail(
                 rendered_notification["subject"],
                 rendered_notification["body"],
-                "noreply@%s" % Site.objects.get_current().domain,
+                get_email_noreply_address(),
                 recipient_list,
                 html_message=rendered_notification["html_body"],
             )

--- a/events/signals.py
+++ b/events/signals.py
@@ -2,7 +2,6 @@ import logging
 from smtplib import SMTPException
 
 from django.contrib.auth import get_user_model
-from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -12,6 +11,7 @@ from notifications.models import (
     NotificationType,
     render_notification_template,
 )
+from registrations.utils import get_email_noreply_address
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ def user_created_notification(sender, instance, created, **kwargs):
             send_mail(
                 rendered_notification["subject"],
                 rendered_notification["body"],
-                "noreply@%s" % Site.objects.get_current().domain,
+                get_email_noreply_address(),
                 recipient_list,
                 html_message=rendered_notification["html_body"],
             )

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -52,6 +52,7 @@ env = environ.Env(
     COOKIE_PREFIX=(str, "linkedevents"),
     DATABASE_URL=(str, "postgis:///linkedevents"),
     DEBUG=(bool, False),
+    DEFAULT_FROM_EMAIL=(str, "noreply@linkedevents.hel.fi"),
     ELASTICSEARCH_URL=(str, None),
     ELIS_EVENT_API_URL=(
         str,
@@ -591,6 +592,9 @@ FULLTEXT_SEARCH_LANGUAGES = {"fi": "finnish", "sv": "swedish", "en": "english"}
 
 # Email address used to send feedback forms
 SUPPORT_EMAIL = env("SUPPORT_EMAIL")
+
+# Email address used as default "from" email
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -65,4 +65,6 @@ def send_mass_html_mail(
 
 
 def get_email_noreply_address():
-    return "noreply@%s" % Site.objects.get_current().domain
+    return (
+        settings.DEFAULT_FROM_EMAIL or "noreply@%s" % Site.objects.get_current().domain
+    )


### PR DESCRIPTION
### Description
- Makes it possible to define the `DEFAULT_FROM_EMAIL` using an environment variable. The main purpose of the variable will be to define a "noreply" address.
- Makes code where the noreply address has been determined individually use a common utility function for getting the address.
- The utility function will fall back to `Site.objects.get_current().domain` if `settings` do not have an address value.
### Closes
[LINK-1451](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1451)

[LINK-1451]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ