### PR TITLE
LINK-1429 | Permissions for signup presence status

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -42,7 +42,6 @@ from registrations.serializers import (
     SignUpGroupCreateSerializer,
     SignUpGroupSerializer,
     SignUpSerializer,
-    SignUpSerializerForRegistrationUser,
 )
 from registrations.utils import send_mass_html_mail
 
@@ -381,15 +380,6 @@ class SignUpViewSet(
     filter_backends = [SignUpFilterBackend]
     filterset_class = SignUpFilter
     permission_classes = [CanAccessSignup]
-
-    def get_serializer_class(self):
-        if (
-            self.action in ("update", "partial_update")
-            and self.request.user.id == self.get_object().created_by_id
-        ):
-            # Allow the "registration user" to only update some of the signup data.
-            return SignUpSerializerForRegistrationUser
-        return super().get_serializer_class()
 
     def create(self, request, *args, **kwargs):
         context = super().get_serializer_context()

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -33,7 +33,11 @@ from registrations.models import (
     SignUp,
     SignUpGroup,
 )
-from registrations.permissions import CanAccessRegistration, CanAccessSignup
+from registrations.permissions import (
+    CanAccessRegistration,
+    CanAccessSignup,
+    CanAccessSignupGroup,
+)
 from registrations.serializers import (
     CreateSignUpsSerializer,
     MassEmailSerializer,
@@ -432,7 +436,7 @@ class SignUpGroupViewSet(
     queryset = SignUpGroup.objects.all()
     filter_backends = [SignUpFilterBackend]
     filterset_class = SignUpGroupFilter
-    permission_classes = [CanAccessSignup]
+    permission_classes = [CanAccessSignupGroup]
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -42,6 +42,7 @@ from registrations.serializers import (
     SignUpGroupCreateSerializer,
     SignUpGroupSerializer,
     SignUpSerializer,
+    SignUpSerializerForRegistrationUser,
 )
 from registrations.utils import send_mass_html_mail
 
@@ -380,6 +381,15 @@ class SignUpViewSet(
     filter_backends = [SignUpFilterBackend]
     filterset_class = SignUpFilter
     permission_classes = [CanAccessSignup]
+
+    def get_serializer_class(self):
+        if (
+            self.action in ("update", "partial_update")
+            and self.request.user.id == self.get_object().created_by_id
+        ):
+            # Allow the "registration user" to only update some of the signup data.
+            return SignUpSerializerForRegistrationUser
+        return super().get_serializer_class()
 
     def create(self, request, *args, **kwargs):
         context = super().get_serializer_context()

--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 
 from events.auth import ApiKeyUser
 from events.permissions import UserDataFromRequestMixin
-from registrations.models import Registration, SignUp
+from registrations.models import Registration, SignUp, SignUpGroup
 
 
 class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission):
@@ -15,16 +15,17 @@ class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission
         if not request.user.is_authenticated:
             return False
 
+        if request.user.is_superuser:
+            return True
+
         if request.method == "POST":
             (
                 __,
                 user_organization,
             ) = self.user_data_source_and_organization_from_request(request)
-            return (
-                request.user.is_superuser
-                or request.user.is_admin_of(user_organization)
-                or request.user.is_registration_admin_of(user_organization)
-            )
+            return request.user.is_admin_of(
+                user_organization
+            ) or request.user.is_registration_admin_of(user_organization)
 
         if request.method in ("PUT", "PATCH", "DELETE"):
             (
@@ -54,6 +55,30 @@ class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
     def has_permission(self, request: Request, view: APIView) -> bool:
         return request.user.is_authenticated
 
+    @staticmethod
+    def _has_object_update_permission(request: Request, obj: SignUp) -> bool:
+        if request.user.is_superuser or request.user.is_registration_admin_of(
+            obj.publisher
+        ):
+            return True
+
+        if obj.registration.registration_user_accesses.filter(
+            email=request.user.email
+        ).exists():
+            # Registration user can only change presence_status and nothing else,
+            # and they need to be strongly identified.
+            data_keys = set(request.data.keys())
+            return request.user.is_strongly_identified and (
+                data_keys == {"id", "presence_status"}
+                or data_keys == {"presence_status"}
+            )
+        elif obj.created_by_id == request.user.id:
+            # User who created the signup, and is not one of the signup admins,
+            # is allowed to change all other data except presence_status.
+            return "presence_status" not in request.data.keys()
+
+        return False
+
     def has_object_permission(
         self, request: Request, view: APIView, obj: SignUp
     ) -> bool:
@@ -67,25 +92,42 @@ class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
             return obj.can_be_deleted_by(request.user)
 
         if request.method in ("PUT", "PATCH"):
-            if obj.registration.registration_user_accesses.filter(
-                email=request.user.email
-            ).exists():
-                # Registration user can only change presence_status and nothing else,
-                # and they need to be strongly identified.
-                data_keys = request.data.keys()
-                data_keys_length = len(data_keys)
-                return (
-                    request.user.is_strongly_identificated
-                    and data_keys_length == 1
-                    and "presence_status" in data_keys
-                )
-            elif (
-                obj.created_by_id == request.user.id
-                and not request.user.is_superuser
-                and not request.user.is_registration_admin_of(obj.publisher)
-            ):
-                # User who created the signup, and is not one of the signup admins,
-                # is allowed to change all other data except presence_status.
-                return "presence_status" not in request.data.keys()
+            return self._has_object_update_permission(request, obj)
 
         return obj.can_be_edited_by(request.user)
+
+
+class CanAccessSignupGroup(CanAccessSignup):
+    @staticmethod
+    def _has_object_update_permission(request: Request, obj: SignUpGroup) -> bool:
+        if not request.data.get("signups"):
+            return obj.can_be_edited_by(request.user)
+
+        if request.user.is_superuser or request.user.is_registration_admin_of(
+            obj.publisher
+        ):
+            return True
+
+        def get_signups_keys():
+            keys = set()
+            for signup in request.data.get("signups", []):
+                keys |= set(signup.keys())
+            return keys
+
+        if obj.registration.registration_user_accesses.filter(
+            email=request.user.email
+        ).exists():
+            # Registration user can only change presence_status and nothing else,
+            # and they need to be strongly identified.
+            data_keys = get_signups_keys()
+            return request.user.is_strongly_identified and (
+                data_keys == {"id", "registration", "presence_status"}
+                or data_keys == {"id", "presence_status"}
+            )
+        elif obj.created_by_id == request.user.id:
+            # User who created the signup, and is not one of the signup admins,
+            # is allowed to change all other data except presence_status.
+            data_keys = get_signups_keys()
+            return "presence_status" not in data_keys
+
+        return False

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -57,6 +57,12 @@ class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
         return instance
 
 
+class SignUpSerializerForRegistrationUser(serializers.ModelSerializer):
+    class Meta:
+        fields = (("presence_status",),)
+        model = SignUp
+
+
 class SignUpSerializer(CreatedModifiedBaseSerializer):
     view_name = "signup"
     id = serializers.IntegerField(required=False)

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -57,12 +57,6 @@ class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
         return instance
 
 
-class SignUpSerializerForRegistrationUser(serializers.ModelSerializer):
-    class Meta:
-        fields = (("presence_status",),)
-        model = SignUp
-
-
 class SignUpSerializer(CreatedModifiedBaseSerializer):
     view_name = "signup"
     id = serializers.IntegerField(required=False)

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -4,6 +4,7 @@ from rest_framework import status
 
 from events.models import Event
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.tests.utils import assert_invitation_email_is_sent
 
 email = "user@email.com"
@@ -41,6 +42,15 @@ def test_create_registration(user, api_client, event):
     api_client.force_authenticate(user)
     registration_data = {"event": {"@id": get_event_url(event.id)}}
 
+    assert_create_registration(api_client, registration_data)
+
+
+@pytest.mark.django_db
+def test_superuser_can_create_registration(api_client, event):
+    user = UserFactory(is_superuser=True)
+    api_client.force_authenticate(user)
+
+    registration_data = {"event": {"@id": get_event_url(event.id)}}
     assert_create_registration(api_client, registration_data)
 
 

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -1,10 +1,17 @@
+from unittest.mock import patch, PropertyMock
+
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
 
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.models import MandatoryFields, SignUp
-from registrations.tests.factories import RegistrationUserAccessFactory
+from registrations.tests.factories import (
+    RegistrationFactory,
+    RegistrationUserAccessFactory,
+    SignUpFactory,
+)
 
 # === util methods ===
 
@@ -28,111 +35,166 @@ def assert_patch_signup(api_client, signup_pk, signup_data):
     return response
 
 
-@freeze_time("2023-03-14 03:30:00+02:00")
-@pytest.mark.django_db
-def test__registration_admin_can_patch_presence_status_of_signup(
-    api_client, registration, signup, user
-):
-    user.get_default_organization().registration_admin_users.add(user)
-
-    registration.audience_min_age = 10
-    registration.mandatory_fields = [
-        MandatoryFields.PHONE_NUMBER,
-        MandatoryFields.STREET_ADDRESS,
-    ]
-    registration.save()
-    signup.date_of_birth = "2011-01-01"
-    signup.phone_number = "0441234567"
-    signup.street_address = "Street address"
-    signup.save()
-    api_client.force_authenticate(user)
-
-    signup_data = {
-        "presence_status": SignUp.PresenceStatus.PRESENT,
-    }
-
-    response = assert_patch_signup(api_client, signup.id, signup_data)
-    assert response.data["presence_status"] == SignUp.PresenceStatus.PRESENT
+# === tests ===
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__registration_user_can_patch_presence_status_of_signup(
-    api_client, registration, signup, user
-):
-    RegistrationUserAccessFactory(registration=registration, email=user.email)
+def test_registration_admin_can_patch_presence_status_of_signup(api_client, event):
+    user = UserFactory()
+    user.registration_admin_organizations.add(event.publisher)
 
-    registration.audience_min_age = 10
-    registration.mandatory_fields = [
-        MandatoryFields.PHONE_NUMBER,
-        MandatoryFields.STREET_ADDRESS,
-    ]
-    registration.save()
-
-    signup.date_of_birth = "2011-01-01"
-    signup.phone_number = "0441234567"
-    signup.street_address = "Street address"
-    signup.save(update_fields=["date_of_birth", "phone_number", "street_address"])
-
-    api_client.force_authenticate(user)
-
-    signup_data = {
-        "presence_status": SignUp.PresenceStatus.PRESENT,
-    }
-
-    response = assert_patch_signup(api_client, signup.id, signup_data)
-    assert response.data["presence_status"] == SignUp.PresenceStatus.PRESENT
-
-
-@freeze_time("2023-03-14 03:30:00+02:00")
-@pytest.mark.django_db
-def test__admin_cannot_patch_presence_status_of_signup(
-    api_client, registration, signup, user
-):
-    user.get_default_organization().admin_users.add(user)
-
-    registration.audience_min_age = 10
-    registration.mandatory_fields = [
-        MandatoryFields.PHONE_NUMBER,
-        MandatoryFields.STREET_ADDRESS,
-    ]
-    registration.save()
-
-    signup.date_of_birth = "2011-01-01"
-    signup.phone_number = "0441234567"
-    signup.street_address = "Street address"
-    signup.save()
-
-    api_client.force_authenticate(user)
-
-    signup_data = {
-        "presence_status": SignUp.PresenceStatus.PRESENT,
-    }
-
-    response = patch_signup(api_client, signup.id, signup_data)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-@freeze_time("2023-03-14 03:30:00+02:00")
-@pytest.mark.django_db
-def test__created_user_cannot_patch_presence_status_of_signup(
-    api_client, registration, signup, user
-):
-    registration.audience_min_age = 10
-    registration.mandatory_fields = [
-        MandatoryFields.PHONE_NUMBER,
-        MandatoryFields.STREET_ADDRESS,
-    ]
-    registration.save()
-
-    signup.date_of_birth = "2011-01-01"
-    signup.phone_number = "0441234567"
-    signup.street_address = "Street address"
-    signup.created_by = user
-    signup.save(
-        update_fields=["date_of_birth", "phone_number", "street_address", "created_by"]
+    registration = RegistrationFactory(
+        event=event,
+        audience_min_age=10,
+        mandatory_fields=[MandatoryFields.PHONE_NUMBER, MandatoryFields.STREET_ADDRESS],
     )
 
+    signup = SignUpFactory(
+        registration=registration,
+        date_of_birth="2011-01-01",
+        phone_number="0441234567",
+        street_address="Street address",
+    )
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    assert_patch_signup(api_client, signup.id, signup_data)
+
+    signup.refresh_from_db()
+    assert signup.presence_status == SignUp.PresenceStatus.PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_registration_user_can_patch_signup_presence_status_signup_if_strongly_identified(
+    api_client, event, user
+):
+    registration = RegistrationFactory(
+        event=event,
+        audience_min_age=10,
+        mandatory_fields=[MandatoryFields.PHONE_NUMBER, MandatoryFields.STREET_ADDRESS],
+    )
+
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
+
+    signup = SignUpFactory(
+        registration=registration,
+        date_of_birth="2011-01-01",
+        phone_number="0441234567",
+        street_address="Street address",
+    )
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    with patch(
+        "helevents.models.UserModelPermissionMixin.token_amr_claim",
+        new_callable=PropertyMock,
+        return_value="heltunnistussuomifi",
+    ) as mocked:
+        assert_patch_signup(api_client, signup.id, signup_data)
+        assert mocked.called is True
+
+    signup.refresh_from_db()
+    assert signup.presence_status == SignUp.PresenceStatus.PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_registration_user_cannot_patch_signup_presence_status_signup_if_not_strongly_identified(
+    api_client, event, user
+):
+    registration = RegistrationFactory(
+        event=event,
+        audience_min_age=10,
+        mandatory_fields=[MandatoryFields.PHONE_NUMBER, MandatoryFields.STREET_ADDRESS],
+    )
+
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
+
+    signup = SignUpFactory(
+        registration=registration,
+        date_of_birth="2011-01-01",
+        phone_number="0441234567",
+        street_address="Street address",
+    )
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    with patch(
+        "helevents.models.UserModelPermissionMixin.token_amr_claim",
+        new_callable=PropertyMock,
+        return_value=None,
+    ) as mocked:
+        response = patch_signup(api_client, signup.id, signup_data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert mocked.called is True
+
+    signup.refresh_from_db()
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_admin_cannot_patch_presence_status_of_signup(user_api_client, event, signup):
+    registration = RegistrationFactory(
+        event=event,
+        audience_min_age=10,
+        mandatory_fields=[MandatoryFields.PHONE_NUMBER, MandatoryFields.STREET_ADDRESS],
+    )
+
+    signup = SignUpFactory(
+        registration=registration,
+        date_of_birth="2011-01-01",
+        phone_number="0441234567",
+        street_address="Street address",
+    )
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    response = patch_signup(user_api_client, signup.id, signup_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup.refresh_from_db()
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_created_user_cannot_patch_presence_status_of_signup(api_client, event, user):
+    registration = RegistrationFactory(
+        event=event,
+        audience_min_age=10,
+        mandatory_fields=[MandatoryFields.PHONE_NUMBER, MandatoryFields.STREET_ADDRESS],
+    )
+
+    signup = SignUpFactory(
+        registration=registration,
+        date_of_birth="2011-01-01",
+        phone_number="0441234567",
+        street_address="Street address",
+        created_by=user,
+    )
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
+
     api_client.force_authenticate(user)
 
     signup_data = {
@@ -141,3 +203,6 @@ def test__created_user_cannot_patch_presence_status_of_signup(
 
     response = patch_signup(api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    signup.refresh_from_db()
+    assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -4,6 +4,7 @@ from rest_framework import status
 
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import MandatoryFields, SignUp
+from registrations.tests.factories import RegistrationUserAccessFactory
 
 # === util methods ===
 
@@ -29,7 +30,9 @@ def assert_patch_signup(api_client, signup_pk, signup_data):
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__patch_presence_status_of_signup(api_client, registration, signup, user):
+def test__registration_admin_can_patch_presence_status_of_signup(
+    api_client, registration, signup, user
+):
     user.get_default_organization().registration_admin_users.add(user)
 
     registration.audience_min_age = 10
@@ -50,3 +53,91 @@ def test__patch_presence_status_of_signup(api_client, registration, signup, user
 
     response = assert_patch_signup(api_client, signup.id, signup_data)
     assert response.data["presence_status"] == SignUp.PresenceStatus.PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test__registration_user_can_patch_presence_status_of_signup(
+    api_client, registration, signup, user
+):
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
+
+    registration.audience_min_age = 10
+    registration.mandatory_fields = [
+        MandatoryFields.PHONE_NUMBER,
+        MandatoryFields.STREET_ADDRESS,
+    ]
+    registration.save()
+
+    signup.date_of_birth = "2011-01-01"
+    signup.phone_number = "0441234567"
+    signup.street_address = "Street address"
+    signup.save(update_fields=["date_of_birth", "phone_number", "street_address"])
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    response = assert_patch_signup(api_client, signup.id, signup_data)
+    assert response.data["presence_status"] == SignUp.PresenceStatus.PRESENT
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test__admin_cannot_patch_presence_status_of_signup(
+    api_client, registration, signup, user
+):
+    user.get_default_organization().admin_users.add(user)
+
+    registration.audience_min_age = 10
+    registration.mandatory_fields = [
+        MandatoryFields.PHONE_NUMBER,
+        MandatoryFields.STREET_ADDRESS,
+    ]
+    registration.save()
+
+    signup.date_of_birth = "2011-01-01"
+    signup.phone_number = "0441234567"
+    signup.street_address = "Street address"
+    signup.save()
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    response = patch_signup(api_client, signup.id, signup_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test__created_user_cannot_patch_presence_status_of_signup(
+    api_client, registration, signup, user
+):
+    registration.audience_min_age = 10
+    registration.mandatory_fields = [
+        MandatoryFields.PHONE_NUMBER,
+        MandatoryFields.STREET_ADDRESS,
+    ]
+    registration.save()
+
+    signup.date_of_birth = "2011-01-01"
+    signup.phone_number = "0441234567"
+    signup.street_address = "Street address"
+    signup.created_by = user
+    signup.save(
+        update_fields=["date_of_birth", "phone_number", "street_address", "created_by"]
+    )
+
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    response = patch_signup(api_client, signup.id, signup_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
### Description
Makes the following changes for updating sign-ups:

- A registration user (`RegistrationUserAccess`) is only allowed to update the `presence_status` field and nothing else.
- The user who created the sign-up is allowed to update all other data except `presence_status`.

A superuser or a registration admin is still allowed to update all data of a sign-up.

### Closes
[LINK-1429](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1429)

[LINK-1429]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ