### PR TITLE
Fix user_created_notification failing on empty emails

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -40,10 +40,10 @@ def user_created_notification(sender, instance, created, **kwargs):
     if created:
         user_model = get_user_model()
         recipient_list = [
-            item[0]
-            for item in user_model.objects.filter(is_superuser=True).values_list(
-                "email"
-            )
+            item
+            for item in user_model.objects.filter(is_superuser=True)
+            .exclude(email__exact="")
+            .values_list("email", flat=True)
         ]
         notification_type = NotificationType.USER_CREATED
         context = {"user": instance}

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -4,9 +4,7 @@ from rest_framework import status
 
 from events.models import Event
 from events.tests.utils import versioned_reverse as reverse
-from registrations.tests.test_registration_user_access_invitation import (
-    assert_invitation_email_is_sent,
-)
+from registrations.tests.utils import assert_invitation_email_is_sent
 
 email = "user@email.com"
 event_name = "Foo"

--- a/registrations/tests/test_registration_put.py
+++ b/registrations/tests/test_registration_put.py
@@ -10,9 +10,7 @@ from registrations.tests.test_registration_post import (
     create_registration,
     get_event_url,
 )
-from registrations.tests.test_registration_user_access_invitation import (
-    assert_invitation_email_is_sent,
-)
+from registrations.tests.utils import assert_invitation_email_is_sent
 
 email = "user@email.com"
 edited_email = "edited@email.com"

--- a/registrations/tests/test_registration_user_access_invitation.py
+++ b/registrations/tests/test_registration_user_access_invitation.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from events.models import Event, Language
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import RegistrationUserAccess
+from registrations.tests.utils import assert_invitation_email_is_sent
 
 email = "user@email.com"
 event_name = "Foo"
@@ -27,15 +28,6 @@ def assert_send_invitation(api_client, pk):
     response = send_invitation(api_client, pk)
 
     assert response.status_code == status.HTTP_200_OK
-
-
-def assert_invitation_email_is_sent(email, event_name):
-    assert mail.outbox[0].to[0] == email
-    assert mail.outbox[0].subject.startswith("Oikeudet myönnetty osallistujalistaan")
-    assert (
-        f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty oikeudet lukea tapahtuman <strong>{event_name}</strong> osallistujalista."
-        in str(mail.outbox[0].alternatives[0])
-    )
 
 
 # === tests ===
@@ -90,17 +82,20 @@ def test_regular_user_cannot_send_invitation_to_registration_user_access(
         (
             "en",
             "Rights granted to the participant list",
-            f"The e-mail address <strong>{email}</strong> has been granted the rights to read the participant list of the event <strong>{event_name}</strong>.",
+            f"The e-mail address <strong>{email}</strong> has been granted the rights "
+            f"to read the participant list of the event <strong>{event_name}</strong>.",
         ),
         (
             "fi",
             "Oikeudet myönnetty osallistujalistaan",
-            f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty oikeudet lukea tapahtuman <strong>{event_name}</strong> osallistujalista.",
+            f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty oikeudet "
+            f"lukea tapahtuman <strong>{event_name}</strong> osallistujalista.",
         ),
         (
             "sv",
             "Rättigheter tilldelade deltagarlistan",
-            f"E-postadressen <strong>{email}</strong> har beviljats rättigheter att läsa deltagarlistan för evenemanget <strong>{event_name}</strong>.",
+            f"E-postadressen <strong>{email}</strong> har beviljats rättigheter att "
+            f"läsa deltagarlistan för evenemanget <strong>{event_name}</strong>.",
         ),
     ],
 )

--- a/registrations/tests/utils.py
+++ b/registrations/tests/utils.py
@@ -1,0 +1,11 @@
+from django.core import mail
+
+
+def assert_invitation_email_is_sent(email, event_name):
+    assert mail.outbox[0].to[0] == email
+    assert mail.outbox[0].subject.startswith("Oikeudet myönnetty osallistujalistaan")
+    assert (
+        f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty oikeudet lukea "
+        f"tapahtuman <strong>{event_name}</strong> osallistujalista."
+        in str(mail.outbox[0].alternatives[0])
+    )


### PR DESCRIPTION
If a superuser with an empty exists. `user_created_notification` will fail with `AnymailInvalidAddress`.