### PR TITLE
LINK-1495: Fix organization edit permission

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1611,7 +1611,9 @@ class OrganizationViewSet(
     viewsets.ModelViewSet,
 ):
     queryset = Organization.objects.all()
-    permission_classes = (DataSourceOrganizationEditPermission,)
+    permission_classes = [
+        DataSourceResourceEditPermission & DataSourceOrganizationEditPermission
+    ]
 
     def get_serializer_class(self, *args, **kwargs):
         if self.action in ["create", "retrieve", "update"]:

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -145,22 +145,25 @@ class DataSourceResourceEditPermission(
                 )
         else:
             # without api key, the user will have to be admin
-            if not obj.is_user_editable_resources():
+            if (
+                hasattr(obj, "is_user_editable_resources")
+                and not obj.is_user_editable_resources()
+            ):
                 raise PermissionDenied(_("Data source is not editable"))
 
         return True
 
 
-class DataSourceOrganizationEditPermission(DataSourceResourceEditPermission):
+class DataSourceOrganizationEditPermission(BasePermission):
     def has_permission(self, request, view):
         if request.method == "POST":
             if request.user.admin_organizations.exists():
-                return super().has_permission(request, view)
+                return True
 
             logging.info("User must be an admin to create an organization")
             return False
 
-        return super().has_permission(request, view)
+        return True
 
     def has_object_permission(self, request: Request, view, obj):
         if request.method in permissions.SAFE_METHODS:

--- a/events/permissions.py
+++ b/events/permissions.py
@@ -157,7 +157,10 @@ class DataSourceResourceEditPermission(
 class DataSourceOrganizationEditPermission(BasePermission):
     def has_permission(self, request, view):
         if request.method == "POST":
-            if request.user.admin_organizations.exists():
+            if (
+                request.user.is_authenticated
+                and request.user.admin_organizations.exists()
+            ):
                 return True
 
             logging.info("User must be an admin to create an organization")

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -492,3 +492,10 @@ def test_permissions_destroy_organization(
     api_client.force_authenticate(user2_with_user_type)
     response = delete_organization(api_client, organization.pk)
     assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+def test_get_organization_list_html_renders(api_client, event):
+    url = reverse("organization-list", version="v1")
+    response = api_client.get(url, data=None, HTTP_ACCEPT="text/html")
+    assert response.status_code == status.HTTP_200_OK, str(response.content)


### PR DESCRIPTION
DataSourceOrganizationEditPermission raised an error for anonymous users (no `admin_organizations` attribute in `AnonymousUser`). Changed it to check for authentication before doing anything else.

Also decoupled `DataSourceOrganizationEditPermission` from `DataSourceResourceEditPermission` to remove potential spaghetti code.

Refs [LINK-1495](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1495)

[LINK-1495]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ