### PR TITLE
LINK-1071 | Changes to attendee capacity filters

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3355,19 +3355,19 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         method="filter_dwithin", widget=DistanceWithinWidget()
     )
 
-    max_attendee_capacity_gte = django_filters.NumberFilter(
+    maximum_attendee_capacity_gte = django_filters.NumberFilter(
         field_name="maximum_attendee_capacity", lookup_expr="gte"
     )
 
-    min_attendee_capacity_gte = django_filters.NumberFilter(
+    minimum_attendee_capacity_gte = django_filters.NumberFilter(
         field_name="minimum_attendee_capacity", lookup_expr="gte"
     )
 
-    max_attendee_capacity_lte = django_filters.NumberFilter(
+    maximum_attendee_capacity_lte = django_filters.NumberFilter(
         field_name="maximum_attendee_capacity", lookup_expr="lte"
     )
 
-    min_attendee_capacity_lte = django_filters.NumberFilter(
+    minimum_attendee_capacity_lte = django_filters.NumberFilter(
         field_name="minimum_attendee_capacity", lookup_expr="lte"
     )
 

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1158,7 +1158,7 @@ def test_get_event_list_verify_registration_filter(
 
 
 @pytest.mark.django_db
-def test_get_event_list_max_attendee_capacity_filter_gte(
+def test_get_event_list_maximum_attendee_capacity_filter_gte(
     api_client,
     event,
     event2,
@@ -1171,11 +1171,11 @@ def test_get_event_list_max_attendee_capacity_filter_gte(
     event3.maximum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("max_attendee_capacity_gte=9", [event, event2])
+    get_list_and_assert_events("maximum_attendee_capacity_gte=9", [event, event2])
 
 
 @pytest.mark.django_db
-def test_get_event_list_max_attendee_capacity_filter_gte_when_equal(
+def test_get_event_list_maximum_attendee_capacity_filter_gte_when_equal(
     api_client,
     event,
     event2,
@@ -1188,11 +1188,11 @@ def test_get_event_list_max_attendee_capacity_filter_gte_when_equal(
     event3.maximum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("max_attendee_capacity_gte=10", [event])
+    get_list_and_assert_events("maximum_attendee_capacity_gte=10", [event])
 
 
 @pytest.mark.django_db
-def test_get_event_list_max_attendee_capacity_filter_lte(
+def test_get_event_list_maximum_attendee_capacity_filter_lte(
     api_client,
     event,
     event2,
@@ -1205,11 +1205,11 @@ def test_get_event_list_max_attendee_capacity_filter_lte(
     event3.maximum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("max_attendee_capacity_lte=9", [event2, event3])
+    get_list_and_assert_events("maximum_attendee_capacity_lte=9", [event2, event3])
 
 
 @pytest.mark.django_db
-def test_get_event_list_max_attendee_capacity_filter_lte_when_equal(
+def test_get_event_list_maximum_attendee_capacity_filter_lte_when_equal(
     api_client,
     event,
     event2,
@@ -1222,11 +1222,11 @@ def test_get_event_list_max_attendee_capacity_filter_lte_when_equal(
     event3.maximum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("max_attendee_capacity_lte=8", [event3])
+    get_list_and_assert_events("maximum_attendee_capacity_lte=8", [event3])
 
 
 @pytest.mark.django_db
-def test_get_event_list_min_attendee_capacity_filter_gte(
+def test_get_event_list_minimum_attendee_capacity_filter_gte(
     api_client,
     event,
     event2,
@@ -1239,11 +1239,11 @@ def test_get_event_list_min_attendee_capacity_filter_gte(
     event3.minimum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("min_attendee_capacity_gte=9", [event, event2])
+    get_list_and_assert_events("minimum_attendee_capacity_gte=9", [event, event2])
 
 
 @pytest.mark.django_db
-def test_get_event_list_min_attendee_capacity_filter_gte_when_equal(
+def test_get_event_list_minimum_attendee_capacity_filter_gte_when_equal(
     api_client,
     event,
     event2,
@@ -1256,11 +1256,11 @@ def test_get_event_list_min_attendee_capacity_filter_gte_when_equal(
     event3.minimum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("min_attendee_capacity_gte=10", [event])
+    get_list_and_assert_events("minimum_attendee_capacity_gte=10", [event])
 
 
 @pytest.mark.django_db
-def test_get_event_list_min_attendee_capacity_filter_lte(
+def test_get_event_list_minimum_attendee_capacity_filter_lte(
     api_client,
     event,
     event2,
@@ -1273,11 +1273,11 @@ def test_get_event_list_min_attendee_capacity_filter_lte(
     event3.minimum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("min_attendee_capacity_lte=9", [event2, event3])
+    get_list_and_assert_events("minimum_attendee_capacity_lte=9", [event2, event3])
 
 
 @pytest.mark.django_db
-def test_get_event_list_min_attendee_capacity_filter_lte_when_equal(
+def test_get_event_list_minimum_attendee_capacity_filter_lte_when_equal(
     api_client,
     event,
     event2,
@@ -1290,7 +1290,7 @@ def test_get_event_list_min_attendee_capacity_filter_lte_when_equal(
     event3.minimum_attendee_capacity = 8
     event3.save()
 
-    get_list_and_assert_events("min_attendee_capacity_lte=8", [event3])
+    get_list_and_assert_events("minimum_attendee_capacity_lte=8", [event3])
 
 
 @pytest.mark.django_db

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -354,6 +354,39 @@
         <pre><code>event/?enrolment_open_waitilist=true</code></pre>
         <p><a href="?enrolment_open_waitilist=true" title="json">See the result</a></p>
 
+        <h3 id="attendee-capacity">Attendee capacity</h3>
+        <p>Filters for filtering by event maximum_attendee_capacity and minimum_attendee_capacity:</p>
+
+        <h4 id="">Filtering for maximum_attendee_capacity</h4>
+        <p>It is possible to filter by maximum_attendee_capacity using gte (>) or lte (<) filters.</p>
+
+        <p><code>maximum_attendee_capacity_gte</code> parameter displays events with maximum attendee capacity greater than
+            or equal the applied parameter (integer value)</p>
+        <p>Example:</p>
+        <pre><code>event/?maximum_attendee_capacity_gte=10</code></pre>
+        <p><a href="?maximum_attendee_capacity_gte=10" title="json">See the result</a></p>
+
+        <p><code>maximum_attendee_capacity_lte</code> parameter displays events with maximum attendee capacity less than
+            or equal the applied parameter (integer value)</p>
+        <p>Example:</p>
+        <pre><code>event/?maximum_attendee_capacity_lte=10</code></pre>
+        <p><a href="?maximum_attendee_capacity_lte=10" title="json">See the result</a></p>
+
+        <h4 id="">Filtering for minimum_attendee_capacity</h4>
+        <p>It is possible to filter by minimum_attendee_capacity using gte (>) or lte (<) filters.</p>
+
+        <p><code>minimum_attendee_capacity_gte</code> parameter displays events with minimum attendee capacity greater than
+            or equal the applied parameter (integer value)</p>
+        <p>Example:</p>
+        <pre><code>event/?minimum_attendee_capacity_gte=10</code></pre>
+        <p><a href="?minimum_attendee_capacity_gte=10" title="json">See the result</a></p>
+
+        <p><code>minimum_attendee_capacity_lte</code> parameter displays events with minimum attendee capacity less than
+            or equal the applied parameter (integer value)</p>
+        <p>Example:</p>
+        <pre><code>event/?minimum_attendee_capacity_lte=10</code></pre>
+        <p><a href="?minimum_attendee_capacity_lte=10" title="json">See the result</a></p>
+
         <h3 id="event-for-authenticated-users">Filtering for authenticated users</h3>
         <p>By default, only public events are shown in the event list. However, certain query parameters allow 
             customizing the listing for authenticated users</p>

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -351,8 +351,8 @@
             have open spots at the event itself. Null values are regarded as unlimited number of spots at 
             the event or in the waiting list.</p>
         <p>For example:</p>
-        <pre><code>event/?enrolment_open_waitilist=true</code></pre>
-        <p><a href="?enrolment_open_waitilist=true" title="json">See the result</a></p>
+        <pre><code>event/?enrolment_open_waitlist=true</code></pre>
+        <p><a href="?enrolment_open_waitlist=true" title="json">See the result</a></p>
 
         <h3 id="attendee-capacity">Attendee capacity</h3>
         <p>Filters for filtering by event maximum_attendee_capacity and minimum_attendee_capacity:</p>


### PR DESCRIPTION
### Changes:

 - Renames the newly introduced `max_attendee_capacity` and `min_attendee_capacity` filters to `maximum_attendee_capacity` and `minimum_attendee_capacity` to stay consistent with the model field names. 
 - Adds documentation for the above filters
 - Fix discovered typo in event_list.html 

Refs LINK-1071