### PR TITLE
LINK-1527 | Log uWSGI errors to sentry

### DIFF
--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -17,7 +17,8 @@ master = 1
 # by default uwsgi reloads on SIGTERM instead of terminating
 # this makes container slow to stop, so we change it here
 die-on-term = true
-socket-timeout = 60
+http-timeout = 60
+harakiri = 60
 buffer-size = 65535
 
 # Reload workers regularly to keep memory fresh

--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -18,7 +18,8 @@ master = 1
 # this makes container slow to stop, so we change it here
 die-on-term = true
 http-timeout = 60
-harakiri = 60
+harakiri = 55
+harakiri-graceful-timeout = 5
 buffer-size = 65535
 
 # Reload workers regularly to keep memory fresh

--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -32,3 +32,13 @@ worker-reload-mercy = 60  # How long to wait before forcefully killing workers (
 ignore-sigpipe = true
 ignore-write-errors = true
 disable-write-exception = true
+
+if-env = SENTRY_DSN
+print = Enabled sentry logging for uWSGI
+plugin = sentry
+alarm = logsentry sentry:dsn=$(SENTRY_DSN),logger=uwsgi.sentry
+# Log full queue, segfault and harakiri errors to sentry
+alarm-backlog = logsentry
+alarm-segfault = logsentry
+alarm-log = logsentry HARAKIRI \[core.*\]
+endif =

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -25,9 +25,11 @@ RUN apt-install.sh \
     gdal-bin \
     gettext \
     postgresql-client \
+    libcurl4-openssl-dev \
     && pip install --upgrade pip \
     && pip install --no-cache-dir -r /app/requirements.txt \
     && pip install --no-cache-dir -r /app/requirements-prod.txt \
+    && uwsgi --build-plugin https://github.com/City-of-Helsinki/uwsgi-sentry \
     && apt-cleanup.sh build-essential
 
 COPY --chown=appuser:appuser ./docker/django/docker-entrypoint.sh /entrypoint/docker-entrypoint.sh


### PR DESCRIPTION
This PR adds uwsgi-sentry plugin for uWSGI so that errors from uWSGI can be logged into sentry. This PR also adds `harakiri` to uWSGI configuration, which should take care of actually killing a long running uWSGI process.