### PR TITLE
Bump pyjwt, cryptography, social-auth-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -211,7 +211,7 @@ pygments==2.15.1
     # via ipython
 pyjwkest==1.4.2
     # via drf-oidc-auth
-pyjwt==1.7.1
+pyjwt==2.8.0
     # via social-auth-core
 pyparsing==3.0.9
     # via rdflib
@@ -274,11 +274,10 @@ six==1.16.0
     #   pyjwkest
     #   python-dateutil
     #   social-auth-app-django
-    #   social-auth-core
     #   url-normalize
 social-auth-app-django==4.0.0
     # via -r requirements.in
-social-auth-core==4.0.2
+social-auth-core==4.0.3
     # via
     #   -r requirements.in
     #   social-auth-app-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==41.0.2
+cryptography==41.0.3
     # via social-auth-core
 decorator==5.1.1
     # via ipython


### PR DESCRIPTION
Needed to bump social-auth-core (🤞 ) to get latest pyjwt. Previously used version of pyjwt had some security issues.

Refs RAT-18