### PR TITLE
LINK-1527 | uWSGI: Add harakiri-graceful-queue-thershold

### DIFF
--- a/.prod/uwsgi_configuration.ini
+++ b/.prod/uwsgi_configuration.ini
@@ -17,9 +17,10 @@ master = 1
 # by default uwsgi reloads on SIGTERM instead of terminating
 # this makes container slow to stop, so we change it here
 die-on-term = true
-http-timeout = 60
-harakiri = 55
+harakiri = 20
 harakiri-graceful-timeout = 5
+# Default listen queue is 100
+harakiri-queue-threshold = 80
 buffer-size = 65535
 
 # Reload workers regularly to keep memory fresh


### PR DESCRIPTION
Lower the default harakiri time. If listen queue is not looking too bad, we can allow processing to continue with the `harakiri-graceful-queue-threshold`.

- harakiri-graceful-queue-threshold only triggers a harakiri if/when the listen queue crosses a threshold. Harakiri continues to be checked until the conditions are met.
- This configuration option was added in [uWSGI 2.0.22](https://github.com/unbit/uwsgi/compare/2.0.21...2.0.22) 
