### PR TITLE
LINK-1503 | Azure pipeline: use production pool for production

### DIFF
--- a/azure-pipelines-prod.yml
+++ b/azure-pipelines-prod.yml
@@ -3,7 +3,7 @@
 
 trigger: none
 pr: none
-pool: Default
+pool: Production
 
 parameters:
   - name: buildenv


### PR DESCRIPTION
Changing to production pool should take care of some resources not being available in the pipeline.