### PR TITLE
LINK-1531: Optimize place and keyword listings

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -922,8 +922,8 @@ class KeywordListViewSet(
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
 ):
-    queryset = Keyword.objects.all()
-    queryset = queryset.select_related("publisher").prefetch_related("alt_labels__name")
+    # publisher relation performs better with prefetch than selected
+    queryset = Keyword.objects.all().prefetch_related("publisher", "alt_labels")
     serializer_class = KeywordSerializer
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ("n_events", "id", "name", "data_source")
@@ -946,7 +946,8 @@ class KeywordListViewSet(
         show_all_keywords (keywords without events are included)
         show_deprecated (deprecated keywords are included)
         """
-        queryset = Keyword.objects.all()
+
+        queryset = self.queryset
         data_source = self.request.query_params.get("data_source")
         # Filter by data source, multiple sources separated by comma
         if data_source:

--- a/events/tests/test_keyword_get.py
+++ b/events/tests/test_keyword_get.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_django.asserts import assertNumQueries
 
 from events.models import Keyword
 
@@ -140,3 +141,17 @@ def test_get_keyword_free_search(api_client, keyword, keyword2, keyword3):
     response = get_list(api_client, data={"free_text": "cheeese"})
     ids = [entry["id"] for entry in response.data["data"]]
     assert ids == [keyword.id, keyword2.id, keyword3.id]
+
+
+@pytest.mark.django_db
+def test_list_keyword_query_counts(api_client, keyword, keyword2, keyword3):
+    """
+    Expect 5 queries when listing keywords
+    1) COUNT
+    2) SELECT keywords
+    3) SELECT related organizations
+    4) SELECT related keyword labels
+    5) SELECT system data source
+    """
+    with assertNumQueries(5):
+        get_list(api_client, data={"show_all_keywords": True})

--- a/events/tests/test_place_get.py
+++ b/events/tests/test_place_get.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.management import call_command
+from pytest_django.asserts import assertNumQueries
 
 from events.models import Place
 
@@ -197,3 +198,19 @@ def test_get_place_with_upcoming_events(api_client, place, place2, event, past_e
     ids = [entry["id"] for entry in response.data["data"]]
     assert place.id in ids
     assert place2.id in ids
+
+
+@pytest.mark.django_db
+def test_list_place_query_counts(api_client, place, place2, place3):
+    """
+    Expect 7 queries when listing places
+    1) COUNT
+    2) SELECT places
+    3) SELECT related publishers
+    4) SELECT related division, join type and municipality
+    5) SELECT related division municipality translations
+    6) SELECT related division translations
+    7) SELECT system data source
+    """
+    with assertNumQueries(7):
+        get_list(api_client, data={"show_all_places": True})


### PR DESCRIPTION
Fix duplicate queries for both place and keyword endpoints, move multiple select_related fields to prefetch_related because they are mostly null rows anyway, so joining is inefficient (especially with large page offsets), and add tests to keep an eye on the query numbers for default listings.

Ref https://helsinkisolutionoffice.atlassian.net/browse/LINK-1531