### PR TITLE
LINK-1490 | Add possibility to send emails to specific registration signup groups

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -127,7 +127,7 @@ class RegistrationViewSet(
             responsible_signups = (
                 signup_group.responsible_signups or signup_group.signups.all()
             )
-            for signup in responsible_signups:
+            for signup in responsible_signups.exclude(email=None):
                 message = signup.get_registration_message(
                     subject, cleaned_body, plain_text_body
                 )
@@ -169,7 +169,7 @@ class RegistrationViewSet(
         signup_groups = serializer.validated_data.get("signup_groups", [])
         signups = serializer.validated_data.get("signups", [])
         if not (signup_groups or signups):
-            signup_groups = registration.signup_groups.exclude(signups__email=None)
+            signup_groups = registration.signup_groups.all()
             signups = registration.signups.exclude(email=None)
         messages = self._get_messages(
             subject,

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -500,6 +500,13 @@ class SeatReservationCodeSerializer(serializers.ModelSerializer):
         model = SeatReservationCode
 
 
+class MassEmailSignupGroupsField(serializers.PrimaryKeyRelatedField):
+    def get_queryset(self):
+        registration = self.context["request"].data["registration"]
+
+        return registration.signup_groups.exclude(signups__email=None)
+
+
 class MassEmailSignupsField(serializers.PrimaryKeyRelatedField):
     def get_queryset(self):
         registration = self.context["request"].data["registration"]
@@ -510,6 +517,10 @@ class MassEmailSignupsField(serializers.PrimaryKeyRelatedField):
 class MassEmailSerializer(serializers.Serializer):
     subject = serializers.CharField()
     body = serializers.CharField()
+    signup_groups = MassEmailSignupGroupsField(
+        many=True,
+        required=False,
+    )
     signups = MassEmailSignupsField(
         many=True,
         required=False,

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -504,7 +504,7 @@ class MassEmailSignupGroupsField(serializers.PrimaryKeyRelatedField):
     def get_queryset(self):
         registration = self.context["request"].data["registration"]
 
-        return registration.signup_groups.exclude(signups__email=None)
+        return registration.signup_groups.all()
 
 
 class MassEmailSignupsField(serializers.PrimaryKeyRelatedField):

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -66,7 +66,7 @@ def test_email_is_sent_to_all_if_no_groups_or_signups_given(
 
     # Individual
     third_signup = SignUpFactory(registration=registration, email="test3@test.com")
-    fourth_signup = SignUpFactory(registration=registration, email="test3@test.com")
+    fourth_signup = SignUpFactory(registration=registration, email="test4@test.com")
 
     api_client.force_authenticate(user)
     send_message_data = {"subject": "Message subject", "body": "Message body"}
@@ -88,33 +88,37 @@ def test_email_is_sent_to_all_if_no_groups_or_signups_given(
 
 @pytest.mark.django_db
 def test_email_is_sent_to_selected_signup_groups_only(api_client, registration, user):
-    signup_group0 = SignUpGroupFactory(registration=registration)
+    first_signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(
-        signup_group=signup_group0, registration=registration, email="test@test.com"
+        signup_group=first_signup_group,
+        registration=registration,
+        email="test@test.com",
     )
     SignUpFactory(
-        signup_group=signup_group0,
+        signup_group=first_signup_group,
         registration=registration,
         responsible_for_group=True,
         email="test2@test.com",
     )
 
-    signup_group1 = SignUpGroupFactory(registration=registration)
+    second_signup_group = SignUpGroupFactory(registration=registration)
     third_signup = SignUpFactory(
-        signup_group=signup_group1,
+        signup_group=second_signup_group,
         registration=registration,
         responsible_for_group=True,
         email="test3@test.com",
     )
     SignUpFactory(
-        signup_group=signup_group1, registration=registration, email="test4@test.com"
+        signup_group=second_signup_group,
+        registration=registration,
+        email="test4@test.com",
     )
 
     api_client.force_authenticate(user)
     send_message_data = {
         "subject": "Message subject",
         "body": "Message body",
-        "signup_groups": [signup_group1.pk],
+        "signup_groups": [second_signup_group.pk],
     }
 
     assert_send_message(
@@ -126,26 +130,30 @@ def test_email_is_sent_to_selected_signup_groups_only(api_client, registration, 
 
 @pytest.mark.django_db
 def test_email_is_sent_to_selected_signups_only(api_client, registration, user):
-    signup_group0 = SignUpGroupFactory(registration=registration)
+    first_signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(
-        signup_group=signup_group0, registration=registration, email="test@test.com"
+        signup_group=first_signup_group,
+        registration=registration,
+        email="test@test.com",
     )
     responsible_signup = SignUpFactory(
-        signup_group=signup_group0,
+        signup_group=first_signup_group,
         registration=registration,
         responsible_for_group=True,
         email="test2@test.com",
     )
 
-    signup_group1 = SignUpGroupFactory(registration=registration)
+    second_signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(
-        signup_group=signup_group1,
+        signup_group=second_signup_group,
         registration=registration,
         responsible_for_group=True,
         email="test3@test.com",
     )
     non_responsible_signup = SignUpFactory(
-        signup_group=signup_group1, registration=registration, email="test4@test.com"
+        signup_group=second_signup_group,
+        registration=registration,
+        email="test4@test.com",
     )
 
     individual_signup = SignUpFactory(registration=registration, email="test5@test.com")

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -87,7 +87,9 @@ def test_email_is_sent_to_all_if_no_groups_or_signups_given(
 
 
 @pytest.mark.django_db
-def test_email_is_sent_to_selected_signup_groups_only(api_client, registration, user):
+def test_email_is_sent_to_selected_signup_groups_responsible_signup_only(
+    api_client, registration, user
+):
     first_signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(
         signup_group=first_signup_group,


### PR DESCRIPTION
### Description
Makes it possible to send messages to specific signup groups (to their responsible signups).

Also changes the individual signup messaging so that if any individual signups - that is, signups that don't belong to any group - are given to the endpoint, messages will be sent to them regardless of if they are responsible for a group or not (unless they were already processed through the group messaging).
### Closes
[LINK-1490](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1490)

[LINK-1490]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ