### PR TITLE
LINK-1547 | Require authentication in SeatReservationViewSet

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -12,6 +12,7 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from events.api import (
@@ -366,7 +367,7 @@ class SeatReservationViewSet(
 ):
     serializer_class = SeatReservationCodeSerializer
     queryset = SeatReservationCode.objects.all()
-    permission_classes = []
+    permission_classes = [IsAuthenticated]
 
 
 register_view(SeatReservationViewSet, "seats_reservation")

--- a/registrations/tests/test_seatsreservation_post.py
+++ b/registrations/tests/test_seatsreservation_post.py
@@ -23,136 +23,173 @@ def assert_reserve_seats(api_client, reservation_data):
 
 
 @pytest.mark.django_db
-def test_create_seats_reservation(api_client, event, registration):
+def test_authenticated_admin_user_can_create_seats_reservation(
+    user_api_client, event, registration
+):
     registration.maximum_attendee_capacity = 2
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
     reservation_data = {"seats": 1, "registration": registration.id}
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == False
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is False
+
+
+@pytest.mark.django_db
+def test_authenticated_regular_user_can_create_seats_reservation(
+    user_api_client, event, registration, user
+):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+
+    registration.maximum_attendee_capacity = 2
+    registration.save(update_fields=["maximum_attendee_capacity"])
+
+    reservation_data = {"seats": 1, "registration": registration.id}
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is False
+
+
+@pytest.mark.django_db
+def test_anonymous_user_cannot_create_seats_reservation(
+    api_client, event, registration
+):
+    registration.maximum_attendee_capacity = 2
+    registration.save(update_fields=["maximum_attendee_capacity"])
+
+    reservation_data = {"seats": 1, "registration": registration.id}
+    response = reserve_seats(api_client, reservation_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.django_db
 def test_seats_amount_has_not_limit_if_maximum_attendee_capacity_is_none(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.maximum_attendee_capacity = None
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
     reservation_data = {"seats": 10000, "registration": registration.id}
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == False
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is False
 
 
 @pytest.mark.django_db
-def test_seats_value_is_required(api_client, event, registration):
+def test_seats_value_is_required(user_api_client, event, registration):
     registration.maximum_attendee_capacity = 2
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
     reservation_data = {"registration": registration.id}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0].code == "required"
 
 
 @pytest.mark.django_db
 def test_seats_cannot_be_greater_than_maximum_group_size(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.maximum_attendee_capacity = None
     registration.maximum_group_size = 5
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity", "maximum_group_size"])
 
     reservation_data = {"registration": registration.id, "seats": 6}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0].code == "max_group_size"
 
 
 @pytest.mark.django_db
 def test_cannot_reserve_seats_if_enrolment_is_not_opened(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.enrolment_start_time = localtime() + timedelta(days=1)
     registration.enrolment_end_time = localtime() + timedelta(days=2)
-    registration.save()
+    registration.save(update_fields=["enrolment_start_time", "enrolment_end_time"])
 
     reservation_data = {"seats": 1, "registration": registration.id}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.data["detail"] == "Enrolment is not yet open."
 
 
 @pytest.mark.django_db
-def test_cannot_reserve_seats_if_enrolment_is_closed(api_client, event, registration):
+def test_cannot_reserve_seats_if_enrolment_is_closed(
+    user_api_client, event, registration
+):
     registration.enrolment_start_time = localtime() - timedelta(days=2)
     registration.enrolment_end_time = localtime() - timedelta(days=1)
-    registration.save()
+    registration.save(update_fields=["enrolment_start_time", "enrolment_end_time"])
 
     reservation_data = {"seats": 1, "registration": registration.id}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.data["detail"] == "Enrolment is already closed."
 
 
 @pytest.mark.django_db
 def test_cannot_reserve_seats_if_there_are_not_enough_seats_available(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.maximum_attendee_capacity = 2
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
     reservation_data = {"seats": 3, "registration": registration.id}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0] == "Not enough seats available. Capacity left: 2."
 
     reservation_data["seats"] = 1
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == False
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is False
 
     reservation_data["seats"] = 2
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0] == "Not enough seats available. Capacity left: 1."
 
 
 @pytest.mark.django_db
 def test_reserve_seats_to_waiting_list(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = 2
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
     reservation_data = {"seats": 1, "registration": registration.id}
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == True
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is True
 
 
 @pytest.mark.django_db
 def test_waiting_list_seats_amount_has_not_limit_if_waiting_list_capacity_is_none(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = None
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
     reservation_data = {"seats": 10000, "registration": registration.id}
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == True
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is True
 
 
 @pytest.mark.django_db
 def test_cannot_reserve_seats_waiting_list_if_there_are_not_enough_seats_available(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = 2
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
     reservation_data = {"seats": 3, "registration": registration.id}
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.data["seats"][0]
@@ -160,11 +197,11 @@ def test_cannot_reserve_seats_waiting_list_if_there_are_not_enough_seats_availab
     )
 
     reservation_data["seats"] = 1
-    response = assert_reserve_seats(api_client, reservation_data)
-    assert response.data["in_waitlist"] == True
+    response = assert_reserve_seats(user_api_client, reservation_data)
+    assert response.data["in_waitlist"] is True
 
     reservation_data["seats"] = 2
-    response = reserve_seats(api_client, reservation_data)
+    response = reserve_seats(user_api_client, reservation_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.data["seats"][0]

--- a/registrations/tests/test_seatsreservation_put.py
+++ b/registrations/tests/test_seatsreservation_put.py
@@ -5,7 +5,7 @@ from django.utils.timezone import localtime
 from rest_framework import status
 
 from events.tests.utils import versioned_reverse as reverse
-from registrations.models import SeatReservationCode
+from registrations.tests.factories import SeatReservationCodeFactory
 from registrations.tests.test_seatsreservation_post import assert_reserve_seats
 
 
@@ -26,110 +26,160 @@ def assert_update_seats_reservation(api_client, pk, reservation_data):
 
 
 @pytest.mark.django_db
-def test_update_seats_reservation(api_client, event, registration):
+def test_authenticated_admin_user_can_update_seats_reservation(
+    user_api_client, event, registration
+):
     registration.maximum_attendee_capacity = 2
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     reservation_data = {
         "seats": 2,
         "registration": registration.id,
         "code": reservation.code,
     }
-    assert_update_seats_reservation(api_client, reservation.id, reservation_data)
+    assert_update_seats_reservation(user_api_client, reservation.id, reservation_data)
+
+
+@pytest.mark.django_db
+def test_authenticated_regular_user_can_update_seats_reservation(
+    user_api_client, event, registration, user
+):
+    user.get_default_organization().regular_users.add(user)
+    user.get_default_organization().admin_users.remove(user)
+
+    registration.maximum_attendee_capacity = 2
+    registration.save(update_fields=["maximum_attendee_capacity"])
+
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    reservation_data = {
+        "seats": 2,
+        "registration": registration.id,
+        "code": reservation.code,
+    }
+    assert_update_seats_reservation(user_api_client, reservation.id, reservation_data)
+
+
+@pytest.mark.django_db
+def test_anonymous_user_cannot_update_seats_reservation(
+    api_client, event, registration
+):
+    registration.maximum_attendee_capacity = 2
+    registration.save(update_fields=["maximum_attendee_capacity"])
+
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    reservation_data = {
+        "seats": 2,
+        "registration": registration.id,
+        "code": reservation.code,
+    }
+    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.django_db
 def test_seats_amount_has_not_limit_if_maximum_attendee_capacity_is_none(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.maximum_attendee_capacity = None
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "seats": 10000,
         "registration": registration.id,
         "code": reservation.code,
     }
-    assert_update_seats_reservation(api_client, reservation.id, reservation_data)
+    assert_update_seats_reservation(user_api_client, reservation.id, reservation_data)
 
 
 @pytest.mark.django_db
-def test_seats_value_is_required(api_client, event, registration):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_seats_value_is_required(user_api_client, event, registration):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "registration": registration.id,
         "code": reservation.code,
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0].code == "required"
 
 
 @pytest.mark.django_db
-def test_code_value_is_required(api_client, event, registration):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_code_value_is_required(user_api_client, event, registration):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "seats": 1,
         "registration": registration.id,
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["code"][0].code == "required"
 
 
 @pytest.mark.django_db
-def test_code_value_must_match(api_client, event, registration):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_code_value_must_match(user_api_client, event, registration):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "seats": 1,
         "registration": registration.id,
         "code": "invalid_code",
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["code"][0] == "The value doesn't match."
 
 
 @pytest.mark.django_db
-def test_cannot_update_registration(api_client, event, registration, registration2):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_cannot_update_registration(
+    user_api_client, event, registration, registration2
+):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "seats": 1,
         "code": reservation.code,
         "registration": registration2.id,
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.data["registration"] == registration.id
 
 
 @pytest.mark.django_db
-def test_cannot_update_expired_reservation(api_client, event, registration):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_cannot_update_expired_reservation(user_api_client, event, registration):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     reservation.timestamp = localtime() - timedelta(days=1)
-    reservation.save()
+    reservation.save(update_fields=["timestamp"])
 
     reservation_data = {
         "seats": 1,
         "registration": registration.id,
         "code": reservation.code,
     }
-    response = assert_reserve_seats(api_client, reservation_data)
+    assert_reserve_seats(user_api_client, reservation_data)
 
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.data["detail"] == "Cannot update expired seats reservation."
 
 
 @pytest.mark.django_db
-def test_cannot_update_timestamp(api_client, event, registration):
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+def test_cannot_update_timestamp(user_api_client, event, registration):
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     timestamp = reservation.timestamp
 
     reservation_data = {
@@ -138,87 +188,97 @@ def test_cannot_update_timestamp(api_client, event, registration):
         "code": reservation.code,
         "timestamp": localtime() + timedelta(minutes=15),
     }
-    assert_update_seats_reservation(api_client, reservation.id, reservation_data)
+    assert_update_seats_reservation(user_api_client, reservation.id, reservation_data)
 
-    updated_reservation = SeatReservationCode.objects.get(id=reservation.id)
-    assert updated_reservation.seats == 2
-    assert updated_reservation.timestamp == timestamp
+    reservation.refresh_from_db()
+    assert reservation.seats == 2
+    assert reservation.timestamp == timestamp
 
 
 @pytest.mark.django_db
 def test_cannot_reserve_seats_if_there_are_not_enough_seats_available(
-    api_client, event, registration
+    user_api_client, event, registration
 ):
     registration.maximum_attendee_capacity = 2
-    registration.save()
+    registration.save(update_fields=["maximum_attendee_capacity"])
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
 
     reservation_data = {
         "seats": 3,
         "registration": registration.id,
         "code": reservation.code,
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["seats"][0] == "Not enough seats available. Capacity left: 2."
 
 
 @pytest.mark.django_db
 def test_update_seats_reservation_in_waiting_list(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = 2
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     reservation_data = {
         "seats": 2,
         "registration": registration.id,
         "code": reservation.code,
     }
     response = assert_update_seats_reservation(
-        api_client, reservation.id, reservation_data
+        user_api_client, reservation.id, reservation_data
     )
-    assert response.data["in_waitlist"] == True
+    assert response.data["in_waitlist"] is True
 
 
 @pytest.mark.django_db
 def test_waiting_list_seats_amount_has_not_limit_if_waiting_list_capacity_is_none(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = None
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     reservation_data = {
         "seats": 10000,
         "registration": registration.id,
         "code": reservation.code,
     }
     response = assert_update_seats_reservation(
-        api_client, reservation.id, reservation_data
+        user_api_client, reservation.id, reservation_data
     )
-    assert response.data["in_waitlist"] == True
+    assert response.data["in_waitlist"] is True
 
 
 @pytest.mark.django_db
 def test_cannot_reserve_seats_waiting_list_if_there_are_not_enough_seats_available(
-    api_client, event, registration, signup, signup2
+    user_api_client, event, registration, signup, signup2
 ):
     registration.maximum_attendee_capacity = 2
     registration.waiting_list_capacity = 2
-    registration.save()
+    registration.save(
+        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+    )
 
-    reservation = SeatReservationCode.objects.create(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     reservation_data = {
         "seats": 3,
         "registration": registration.id,
         "code": reservation.code,
     }
-    response = update_seats_reservation(api_client, reservation.id, reservation_data)
+    response = update_seats_reservation(
+        user_api_client, reservation.id, reservation_data
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert (
         response.data["seats"][0]


### PR DESCRIPTION
### Description
Makes the `seat_reservation` endpoint require the user to be authenticated for all requests.
### Closes
[LINK-1547](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1547)

[LINK-1547]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ