### PR TITLE
LINK-1548 | Log registrations exceptions to Sentry

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from smtplib import SMTPException
 from uuid import uuid4
@@ -25,6 +26,8 @@ from registrations.utils import (
 )
 
 User = settings.AUTH_USER_MODEL
+
+logger = logging.getLogger(__name__)
 
 
 class SignUpNotificationType:
@@ -373,7 +376,7 @@ class RegistrationUserAccess(models.Model):
                 html_message=rendered_body,
             )
         except SMTPException:
-            pass
+            logger.exception("Couldn't send registration user access invitation email.")
 
     class Meta:
         unique_together = ("email", "registration")
@@ -621,7 +624,7 @@ class SignUp(CreatedModifiedBaseModel, SignUpMixin):
                 html_message=rendered_body,
             )
         except SMTPException:
-            pass
+            logger.exception("Couldn't send signup notification email.")
 
 
 class SeatReservationCode(models.Model):


### PR DESCRIPTION
### Description
Ensures that some caught exceptions in the `registrations` app are logged into Sentry.
### Closes
[LINK-1548](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1548)

[LINK-1548]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ