### PR TITLE
LINK-1550 | Excplicitly define fields for signup and registration serializers

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -165,7 +165,31 @@ class SignUpSerializer(serializers.ModelSerializer):
         return data
 
     class Meta:
-        fields = "__all__"
+        fields = (
+            "id",
+            "service_language",
+            "created_at",
+            "last_modified_at",
+            "created_by",
+            "last_modified_by",
+            "responsible_for_group",
+            "first_name",
+            "last_name",
+            "date_of_birth",
+            "city",
+            "email",
+            "extra_info",
+            "membership_number",
+            "phone_number",
+            "notifications",
+            "attendee_status",
+            "street_address",
+            "zipcode",
+            "presence_status",
+            "registration",
+            "signup_group",
+            "native_language",
+        )
         model = SignUp
 
 
@@ -261,7 +285,36 @@ class RegistrationBaseSerializer(serializers.ModelSerializer):
         return obj.publisher.id
 
     class Meta:
-        fields = "__all__"
+        fields = (
+            "id",
+            "signups",
+            "current_attendee_count",
+            "current_waiting_list_count",
+            "remaining_attendee_capacity",
+            "remaining_waiting_list_capacity",
+            "data_source",
+            "publisher",
+            "registration_user_accesses",
+            "created_time",
+            "last_modified_time",
+            "created_by",
+            "last_modified_by",
+            "event",
+            "created_at",
+            "last_modified_at",
+            "attendee_registration",
+            "audience_min_age",
+            "audience_max_age",
+            "enrolment_start_time",
+            "enrolment_end_time",
+            "maximum_attendee_capacity",
+            "minimum_attendee_capacity",
+            "waiting_list_capacity",
+            "maximum_group_size",
+            "mandatory_fields",
+            "confirmation_message",
+            "instructions",
+        )
         model = Registration
 
 

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -7,6 +7,7 @@ from events.models import Event
 from events.tests.conftest import APIClient
 from events.tests.factories import EventFactory
 from events.tests.test_event_get import get_list_and_assert_events
+from events.tests.utils import assert_fields_exist
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import RegistrationUserAccess, SeatReservationCode
 from registrations.tests.factories import RegistrationFactory
@@ -65,6 +66,46 @@ def get_detail_and_assert_registration(
     return response
 
 
+def assert_registration_fields_exist(data, is_admin_user=False):
+    fields = (
+        "id",
+        "signups",
+        "current_attendee_count",
+        "current_waiting_list_count",
+        "remaining_attendee_capacity",
+        "remaining_waiting_list_capacity",
+        "data_source",
+        "publisher",
+        "created_time",
+        "last_modified_time",
+        "event",
+        "created_at",
+        "last_modified_at",
+        "attendee_registration",
+        "audience_min_age",
+        "audience_max_age",
+        "enrolment_start_time",
+        "enrolment_end_time",
+        "maximum_attendee_capacity",
+        "minimum_attendee_capacity",
+        "waiting_list_capacity",
+        "maximum_group_size",
+        "mandatory_fields",
+        "confirmation_message",
+        "instructions",
+        "@id",
+        "@context",
+        "@type",
+    )
+    if is_admin_user:
+        fields += (
+            "created_by",
+            "last_modified_by",
+            "registration_user_accesses",
+        )
+    assert_fields_exist(data, fields)
+
+
 # === tests ===
 
 
@@ -97,7 +138,8 @@ def test_admin_can_get_registration_not_created_by_self(
 
     assert registration.created_by_id != user.id
 
-    get_detail_and_assert_registration(user_api_client, registration.id)
+    response = get_detail_and_assert_registration(user_api_client, registration.id)
+    assert_registration_fields_exist(response.data)
 
 
 @pytest.mark.django_db
@@ -106,6 +148,7 @@ def test_admin_user_can_see_registration_user_accesses(registration, user_api_cl
     response = get_detail_and_assert_registration(user_api_client, registration.id)
     response_registration_user_accesses = response.data["registration_user_accesses"]
     assert len(response_registration_user_accesses) == 1
+    assert_registration_fields_exist(response.data, is_admin_user=True)
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -139,7 +139,7 @@ def test_admin_can_get_registration_not_created_by_self(
     assert registration.created_by_id != user.id
 
     response = get_detail_and_assert_registration(user_api_client, registration.id)
-    assert_registration_fields_exist(response.data)
+    assert_registration_fields_exist(response.data, is_admin_user=True)
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_signup_get.py
+++ b/registrations/tests/test_signup_get.py
@@ -4,6 +4,7 @@ import pytest
 from rest_framework import status
 
 from events.tests.conftest import APIClient
+from events.tests.utils import assert_fields_exist
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import RegistrationUserAccess, SignUp
 
@@ -52,6 +53,35 @@ def assert_get_detail(api_client: APIClient, signup_pk: str, query: str = None):
     return response
 
 
+def assert_signup_fields_exist(data):
+    fields = (
+        "id",
+        "service_language",
+        "created_at",
+        "last_modified_at",
+        "created_by",
+        "last_modified_by",
+        "responsible_for_group",
+        "first_name",
+        "last_name",
+        "date_of_birth",
+        "city",
+        "email",
+        "extra_info",
+        "membership_number",
+        "phone_number",
+        "notifications",
+        "attendee_status",
+        "street_address",
+        "zipcode",
+        "presence_status",
+        "registration",
+        "signup_group",
+        "native_language",
+    )
+    assert_fields_exist(data, fields)
+
+
 # === tests ===
 
 
@@ -84,8 +114,9 @@ def test_registration_user_access_can_get_signup_when_strongly_identified(
         new_callable=PropertyMock,
         return_value="heltunnistussuomifi",
     ) as mocked:
-        assert_get_detail(user_api_client, signup.id)
+        response = assert_get_detail(user_api_client, signup.id)
         assert mocked.called is True
+    assert_signup_fields_exist(response.data)
 
 
 @pytest.mark.django_db
@@ -128,6 +159,7 @@ def test_regular_created_user_can_get_signup(
 
     response = get_detail(user_api_client, signup.id)
     assert response.status_code == status.HTTP_200_OK
+    assert_signup_fields_exist(response.data)
 
 
 @pytest.mark.django_db
@@ -149,7 +181,8 @@ def test__api_key_with_organization_and_registration_permission_can_get_signup(
     data_source.save(update_fields=["owner", "user_editable_registrations"])
     api_client.credentials(apikey=data_source.api_key)
 
-    assert_get_detail(api_client, signup.id)
+    response = assert_get_detail(api_client, signup.id)
+    assert_signup_fields_exist(response.data)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
To avoid showing all fields by default because of the use of `fields = "__all__"`, the fields have been explicitly defined for `SignUpSerializer` and `RegistrationBaseSerializer`. Tests have also been added for the serializers' fields.
### Closes
[LINK-1550](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1550)



[LINK-1550]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ