### PR TITLE
Don't use DataSourceResourceEditPermission in the registrations API

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -23,10 +23,7 @@ from events.api import (
     UserDataSourceAndOrganizationMixin,
 )
 from events.models import Event
-from events.permissions import (
-    DataSourceResourceEditPermission,
-    OrganizationUserEditPermission,
-)
+from events.permissions import OrganizationUserEditPermission
 from linkedevents.registry import register_view
 from registrations.exceptions import ConflictException
 from registrations.models import (
@@ -64,7 +61,7 @@ class RegistrationViewSet(
     serializer_class = RegistrationSerializer
     queryset = Registration.objects.all()
 
-    permission_classes = [CanAccessRegistration & DataSourceResourceEditPermission]
+    permission_classes = [CanAccessRegistration]
 
     def perform_create(self, serializer):
         # Check object level permissions for event which has the relevant data_source.
@@ -151,7 +148,7 @@ class RegistrationViewSet(
     @action(
         methods=["post"],
         detail=True,
-        permission_classes=[CanAccessRegistration & DataSourceResourceEditPermission],
+        permission_classes=[CanAccessRegistration],
     )
     def send_message(self, request, pk=None, version=None):
         registration = self.get_object()
@@ -371,7 +368,7 @@ class SignUpViewSet(
     queryset = SignUp.objects.all()
     filter_backends = [SignUpFilterBackend]
     filterset_class = SignUpFilter
-    permission_classes = [CanAccessSignup & DataSourceResourceEditPermission]
+    permission_classes = [CanAccessSignup]
 
     def create(self, request, *args, **kwargs):
         context = super().get_serializer_context()
@@ -424,7 +421,7 @@ class SignUpGroupViewSet(
     queryset = SignUpGroup.objects.all()
     filter_backends = [SignUpFilterBackend]
     filterset_class = SignUpGroupFilter
-    permission_classes = [CanAccessSignup & DataSourceResourceEditPermission]
+    permission_classes = [CanAccessSignup]
 
     def get_serializer_class(self):
         if self.action == "create":

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -244,31 +244,18 @@ def test__unknown_api_key_cannot_delete_signup(api_client, signup):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+@pytest.mark.parametrize("user_editable_resources", [False, True])
 @pytest.mark.django_db
-def test__user_editable_resources_can_delete_signup(
-    data_source, organization, signup, user, user_api_client
+def test_registration_admin_can_delete_signup_regardless_of_non_user_editable_resources(
+    data_source, organization, signup, user, user_api_client, user_editable_resources
 ):
     user.get_default_organization().registration_admin_users.add(user)
 
     data_source.owner = organization
-    data_source.user_editable_resources = True
+    data_source.user_editable_resources = user_editable_resources
     data_source.save(update_fields=["owner", "user_editable_resources"])
 
     assert_delete_signup(user_api_client, signup.id)
-
-
-@pytest.mark.django_db
-def test__non_user_editable_resources_cannot_delete_signup(
-    data_source, organization, signup, user, user_api_client
-):
-    user.get_default_organization().registration_admin_users.add(user)
-
-    data_source.owner = organization
-    data_source.user_editable_resources = False
-    data_source.save(update_fields=["owner", "user_editable_resources"])
-
-    response = delete_signup(user_api_client, signup.id)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
Registrations, signups and signup groups will now use only their own permissions - data source edit permissions will not be used by the registrations endpoints.
### Closes
[LINK-1554](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1554)

[LINK-1554]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ