### PR TITLE
LINK-1561 | Fix registration GET permissions check

### DIFF
--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -44,7 +44,7 @@ class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission
         if request.method == "GET":
             return (
                 obj.can_be_edited_by(request.user)
-                and obj.registration_user_accesses.filter(
+                or obj.registration_user_accesses.filter(
                     email=request.user.email
                 ).exists()
                 or obj.created_by_id == request.user.id


### PR DESCRIPTION
### Description
The `CanAccessRegistration.has_object_permission` wrongly used the `and` operator when checking permissions for the `GET` request, resulting in an admin user needing to be either a "registration user access" or "created_by" user in addition to being an admin. This has now been fixed by changing to the use of the `or` operator.
### Closes
[LINK-1561](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1561)

[LINK-1561]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ