### PR TITLE
LINK-1011 | Helsinki Profile GDPR Endpoints

### DIFF
--- a/helevents/models.py
+++ b/helevents/models.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
 from django_orghierarchy.models import Organization
+from helsinki_gdpr.models import SerializableMixin
 from helusers.models import AbstractUser
 
 from events.models import PublicationStatus
@@ -181,9 +182,18 @@ class UserModelPermissionMixin:
         )
 
 
-class User(AbstractUser, UserModelPermissionMixin):
+class User(AbstractUser, UserModelPermissionMixin, SerializableMixin):
     registration_admin_organizations = models.ManyToManyField(
         Organization, blank=True, related_name="registration_admin_users"
+    )
+
+    serialize_fields = (
+        {"name": "id"},
+        {"name": "first_name"},
+        {"name": "last_name"},
+        {"name": "email"},
+        {"name": "signupgroup_created_by"},
+        {"name": "signup_created_by"},
     )
 
     def __str__(self):

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -192,7 +192,6 @@ class User(AbstractUser, UserModelPermissionMixin, SerializableMixin):
         {"name": "first_name"},
         {"name": "last_name"},
         {"name": "email"},
-        {"name": "signupgroup_created_by"},
         {"name": "signup_created_by"},
     )
 

--- a/helevents/tests/conftest.py
+++ b/helevents/tests/conftest.py
@@ -1,1 +1,49 @@
+import datetime
+
+from helusers.settings import api_token_auth_settings
+from jose import jwt
+
+from events.tests.keys import rsa_key
 from linkedevents.tests.conftest import *  # noqa
+
+
+def get_api_token_for_user_with_scopes(
+    user_uuid, scopes: list, requests_mock, amr: str = None
+):
+    """Build a proper auth token with desired scopes."""
+    audience = api_token_auth_settings.AUDIENCE
+    issuer = api_token_auth_settings.ISSUER
+    auth_field = api_token_auth_settings.API_AUTHORIZATION_FIELD
+    config_url = f"{issuer}/.well-known/openid-configuration"
+    jwks_url = f"{issuer}/jwks"
+
+    configuration = {
+        "issuer": issuer,
+        "jwks_uri": jwks_url,
+    }
+
+    keys = {"keys": [rsa_key.public_key_jwk]}
+
+    now = datetime.datetime.now()
+    expire = now + datetime.timedelta(days=14)
+
+    jwt_data = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": str(user_uuid),
+        "iat": int(now.timestamp()),
+        "exp": int(expire.timestamp()),
+        auth_field: scopes,
+    }
+    if amr:
+        jwt_data["amr"] = amr
+    encoded_jwt = jwt.encode(
+        jwt_data, key=rsa_key.private_key_pem, algorithm=rsa_key.jose_algorithm
+    )
+
+    requests_mock.get(config_url, json=configuration)
+    requests_mock.get(jwks_url, json=keys)
+
+    auth_header = f"{api_token_auth_settings.AUTH_SCHEME} {encoded_jwt}"
+
+    return auth_header

--- a/helevents/tests/test_gdpr_api_delete.py
+++ b/helevents/tests/test_gdpr_api_delete.py
@@ -1,0 +1,123 @@
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+import requests_mock
+from django.urls import reverse
+from helusers.settings import api_token_auth_settings
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from helevents.models import User
+from helevents.tests.conftest import get_api_token_for_user_with_scopes
+from helevents.tests.factories import UserFactory
+from registrations.models import SignUp, SignUpGroup
+from registrations.tests.factories import (
+    RegistrationFactory,
+    SignUpFactory,
+    SignUpGroupFactory,
+)
+
+# === util methods ===
+
+
+def _delete_gdpr_data(api_client: APIClient, user_uuid: UUID):
+    gdpr_profile_url = reverse("helsinki_gdpr:gdpr_v1", kwargs={"uuid": user_uuid})
+    return api_client.delete(gdpr_profile_url)
+
+
+# === tests ===
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_delete_own_data(api_client, settings):
+    settings.GDPR_API_DELETE_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+
+    registration = RegistrationFactory()
+
+    signup_group = SignUpGroupFactory(registration=registration, created_by=user)
+    SignUpFactory(signup_group=signup_group, registration=registration, created_by=user)
+    SignUpFactory(registration=registration, created_by=user)
+
+    assert User.objects.count() == 1
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+    with (
+        requests_mock.Mocker() as req_mock,
+        patch(
+            "registrations.signals._signup_or_group_post_delete"
+        ) as mocked_signup_post_delete,
+    ):
+        auth_header = get_api_token_for_user_with_scopes(
+            user.uuid, [settings.GDPR_API_DELETE_SCOPE], req_mock
+        )
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        response = _delete_gdpr_data(api_client, user.uuid)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        assert mocked_signup_post_delete.called is True
+
+    assert User.objects.count() == 0
+    assert SignUpGroup.objects.count() == 0
+    assert SignUp.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_authenticated_user_cannot_delete_other_users_data(api_client, settings):
+    settings.GDPR_API_DELETE_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+    other_user = UserFactory()
+
+    registration = RegistrationFactory()
+
+    signup_group = SignUpGroupFactory(registration=registration, created_by=other_user)
+    SignUpFactory(
+        registration=registration, signup_group=signup_group, created_by=other_user
+    )
+    SignUpFactory(registration=registration, created_by=other_user)
+
+    assert User.objects.count() == 2
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+    with requests_mock.Mocker() as req_mock:
+        auth_header = get_api_token_for_user_with_scopes(
+            user.uuid, [settings.GDPR_API_DELETE_SCOPE], req_mock
+        )
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        response = _delete_gdpr_data(api_client, other_user.uuid)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    assert User.objects.count() == 2
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_non_authenticated_user_cannot_delete_any_data(api_client, settings):
+    settings.GDPR_API_DELETE_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+
+    registration = RegistrationFactory()
+
+    signup_group = SignUpGroupFactory(registration=registration, created_by=user)
+    SignUpFactory(registration=registration, signup_group=signup_group, created_by=user)
+    SignUpFactory(registration=registration, created_by=user)
+
+    assert User.objects.count() == 1
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2
+
+    response = _delete_gdpr_data(api_client, user.uuid)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    assert User.objects.count() == 1
+    assert SignUpGroup.objects.count() == 1
+    assert SignUp.objects.count() == 2

--- a/helevents/tests/test_gdpr_api_get.py
+++ b/helevents/tests/test_gdpr_api_get.py
@@ -1,0 +1,234 @@
+from uuid import UUID
+
+import pytest
+import requests_mock
+from django.db.models import QuerySet
+from django.urls import reverse
+from helusers.settings import api_token_auth_settings
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from events.tests.factories import LanguageFactory
+from helevents.models import User
+from helevents.tests.conftest import get_api_token_for_user_with_scopes
+from helevents.tests.factories import UserFactory
+from registrations.models import SignUp, SignUpGroup
+from registrations.tests.factories import (
+    RegistrationFactory,
+    SignUpFactory,
+    SignUpGroupFactory,
+)
+
+# === util methods ===
+
+
+def _get_signup_profile_data(signup: SignUp) -> dict:
+    return {
+        "key": "SIGNUP",
+        "children": [
+            {"key": "FIRST_NAME", "value": signup.first_name},
+            {"key": "LAST_NAME", "value": signup.last_name},
+            {
+                "key": "DATE_OF_BIRTH",
+                "value": signup.date_of_birth.strftime("%Y-%m-%d")
+                if signup.date_of_birth
+                else None,
+            },
+            {"key": "CITY", "value": signup.city},
+            {"key": "STREET_ADDRESS", "value": signup.street_address},
+            {"key": "ZIPCODE", "value": signup.zipcode},
+            {"key": "EMAIL", "value": signup.email},
+            {"key": "PHONE_NUMBER", "value": signup.phone_number},
+            {
+                "key": "NATIVE_LANGUAGE",
+                "value": str(signup.native_language),
+            },
+            {
+                "key": "SERVICE_LANGUAGE",
+                "value": str(signup.service_language),
+            },
+            {"key": "REGISTRATION_ID", "value": signup.registration_id},
+            {"key": "SIGNUP_GROUP_ID", "value": signup.signup_group_id},
+            {
+                "key": "RESPONSIBLE_FOR_GROUP",
+                "value": signup.responsible_for_group,
+            },
+            {"key": "EXTRA_INFO", "value": signup.extra_info},
+            {
+                "key": "MEMBERSHIP_NUMBER",
+                "value": signup.membership_number,
+            },
+            {
+                "key": "NOTIFICATIONS",
+                "value": dict(SignUp.NOTIFICATION_TYPES)[signup.notifications],
+            },
+            {
+                "key": "ATTENDEE_STATUS",
+                "value": dict(SignUp.ATTENDEE_STATUSES)[signup.attendee_status],
+            },
+            {
+                "key": "PRESENCE_STATUS",
+                "value": dict(SignUp.PRESENCE_STATUSES)[signup.presence_status],
+            },
+        ],
+    }
+
+
+def _get_signups_profile_data(signups_qs: QuerySet[SignUp]) -> list[dict]:
+    signup_datas = []
+
+    for signup in signups_qs:
+        signup_data = _get_signup_profile_data(signup)
+        signup_datas.append(signup_data)
+
+    return signup_datas
+
+
+def _get_signup_groups_profile_data(
+    signup_groups_qs: QuerySet[SignUpGroup],
+) -> list[dict]:
+    group_datas = []
+
+    for signup_group in signup_groups_qs:
+        group_data = {
+            "key": "SIGNUPGROUP",
+            "children": [
+                {"key": "ID", "value": signup_group.id},
+                {"key": "REGISTRATION_ID", "value": signup_group.registration_id},
+                {"key": "EXTRA_INFO", "value": signup_group.extra_info},
+                {
+                    "key": "SIGNUPS",
+                    "children": _get_signups_profile_data(signup_group.signups.all()),
+                },
+            ],
+        }
+        group_datas.append(group_data)
+
+    return group_datas
+
+
+def _get_user_data(user: User) -> list[dict]:
+    return [
+        {"key": "ID", "value": user.id},
+        {"key": "FIRST_NAME", "value": user.first_name},
+        {"key": "LAST_NAME", "value": user.last_name},
+        {"key": "EMAIL", "value": user.email},
+        {
+            "key": "SIGNUPGROUP_CREATED_BY",
+            "children": _get_signup_groups_profile_data(
+                user.signupgroup_created_by.prefetch_related("signups").all()
+            ),
+        },
+        {
+            "key": "SIGNUP_CREATED_BY",
+            "children": _get_signups_profile_data(user.signup_created_by.all()),
+        },
+    ]
+
+
+def _get_gdpr_data(api_client: APIClient, user_uuid: UUID):
+    gdpr_profile_url = reverse("helsinki_gdpr:gdpr_v1", kwargs={"uuid": user_uuid})
+    return api_client.get(gdpr_profile_url)
+
+
+def _assert_profile_data_in_response(response, user: User):
+    profile_data = {"key": "USER", "children": _get_user_data(user)}
+
+    assert response.json() == profile_data
+
+
+# === tests ===
+
+
+@pytest.mark.django_db
+def test_authenticated_user_can_get_own_data(api_client, settings):
+    settings.GDPR_API_QUERY_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+
+    language_en = LanguageFactory(id="en", name="English")
+    language_fi = LanguageFactory(id="fi", name="Suomi", service_language=True)
+
+    registration = RegistrationFactory()
+
+    signup_group = SignUpGroupFactory(registration=registration, created_by=user)
+
+    SignUpFactory(
+        registration=registration,
+        signup_group=signup_group,
+        responsible_for_group=True,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        date_of_birth="1928-05-15",
+        city="Test City",
+        street_address="Test Street 1",
+        zipcode="12345",
+        phone_number="+123123456789",
+        native_language=language_en,
+        service_language=language_fi,
+        extra_info="Test extra info #1",
+        membership_number="00000",
+        notifications=SignUp.NotificationType.EMAIL,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+        presence_status=SignUp.PresenceStatus.PRESENT,
+        created_by=user,
+    )
+
+    SignUpFactory(
+        registration=registration,
+        first_name="James",
+        last_name="Bond",
+        email="test007@test.com",
+        date_of_birth="1920-11-11",
+        city="Test City #2",
+        street_address="Test Street 2",
+        zipcode="12121",
+        phone_number="+123000111222",
+        native_language=language_en,
+        service_language=language_en,
+        extra_info="Test extra info #2",
+        membership_number="00001",
+        notifications=SignUp.NotificationType.SMS,
+        attendee_status=SignUp.AttendeeStatus.WAITING_LIST,
+        presence_status=SignUp.PresenceStatus.NOT_PRESENT,
+        created_by=user,
+    )
+
+    with requests_mock.Mocker() as req_mock:
+        auth_header = get_api_token_for_user_with_scopes(
+            user.uuid, [settings.GDPR_API_QUERY_SCOPE], req_mock
+        )
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        response = _get_gdpr_data(api_client, user.uuid)
+        assert response.status_code == status.HTTP_200_OK
+
+    _assert_profile_data_in_response(response, user)
+
+
+@pytest.mark.django_db
+def test_authenticated_user_cannot_get_other_users_data(api_client, settings):
+    settings.GDPR_API_QUERY_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+    other_user = UserFactory()
+
+    with requests_mock.Mocker() as req_mock:
+        auth_header = get_api_token_for_user_with_scopes(
+            user.uuid, [settings.GDPR_API_QUERY_SCOPE], req_mock
+        )
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        response = _get_gdpr_data(api_client, other_user.uuid)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_non_authenticated_user_cannot_get_any_data(api_client, settings):
+    settings.GDPR_API_QUERY_SCOPE = api_token_auth_settings.API_SCOPE_PREFIX
+
+    user = UserFactory()
+
+    response = _get_gdpr_data(api_client, user.uuid)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/helevents/utils.py
+++ b/helevents/utils.py
@@ -22,7 +22,7 @@ def delete_user_and_gdpr_data(user: get_user_model(), dry_run: bool) -> None:
     :param dry_run: a boolean telling if this is a dry run of the function or not
     """
 
-    for signup in user.signup_created_by.all():
+    for signup in user.signup_created_by.filter(signup_group_id__isnull=True):
         signup._individually_deleted = (
             True  # post_delete signal function will check this
         )

--- a/helevents/utils.py
+++ b/helevents/utils.py
@@ -1,0 +1,33 @@
+from django.contrib.auth import get_user_model
+
+
+def get_user_for_gdpr_api(user: get_user_model()) -> get_user_model():
+    """
+    Function used by the Helsinki Profile GDPR API to get the "user" instance from the "GDPR Model"
+    instance. Since in our case the GDPR Model and the user are one and the same, we simply return
+    the same User instance that is given as a parameter.
+
+    :param user: the User instance whose GDPR data is being queried
+    :return: the same User instance
+    """
+    return user
+
+
+def delete_user_and_gdpr_data(user: get_user_model(), dry_run: bool) -> None:
+    """
+    Function used by the Helsinki Profile GDPR API to delete all GDPR data collected of the user.
+    The GDPR API package will run this within a transaction.
+
+    :param  user: the User instance to be deleted along with related GDPR data
+    :param dry_run: a boolean telling if this is a dry run of the function or not
+    """
+
+    for signup in user.signup_created_by.all():
+        signup._individually_deleted = (
+            True  # post_delete signal function will check this
+        )
+        signup.delete()
+
+    user.signupgroup_created_by.all().delete()
+
+    user.delete()

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -63,6 +63,8 @@ env = environ.Env(
     ENKORA_API_USER=(str, "JoeEnkora"),
     ENKORA_API_PASSWORD=(str, None),
     EXTRA_INSTALLED_APPS=(list, []),
+    GDPR_API_QUERY_SCOPE=(str, ""),
+    GDPR_API_DELETE_SCOPE=(str, ""),
     INSTANCE_NAME=(str, "Linked Events"),
     INTERNAL_IPS=(list, []),
     LANGUAGES=(list, ["fi", "sv", "en", "zh-hans", "ru", "ar"]),
@@ -609,3 +611,12 @@ OIDC_AUTH = {"OIDC_LEEWAY": 60 * 60}
 # Enkora course importer
 ENKORA_API_USER = env("ENKORA_API_USER")
 ENKORA_API_PASSWORD = env("ENKORA_API_PASSWORD")
+
+# GDPR API settings
+GDPR_API_MODEL = "helevents.User"
+GDPR_API_MODEL_LOOKUP = "uuid"
+GDPR_API_URL_PATTERN = "v1/user/<uuid:uuid>"
+GDPR_API_USER_PROVIDER = "helevents.utils.get_user_for_gdpr_api"
+GDPR_API_DELETER = "helevents.utils.delete_user_and_gdpr_data"
+GDPR_API_QUERY_SCOPE = env("GDPR_API_QUERY_SCOPE")
+GDPR_API_DELETE_SCOPE = env("GDPR_API_DELETE_SCOPE")

--- a/linkedevents/urls.py
+++ b/linkedevents/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     url(r"^admin/", admin.site.urls),
     url(r"^pysocial/", include("social_django.urls", namespace="social")),
     url(r"^helauth/", include("helusers.urls")),
+    url(r"^gdpr-api/", include("helsinki_gdpr.urls")),
     url(r"^$", RedirectToAPIRootView.as_view()),
 ]
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -324,8 +324,12 @@ class SignUpGroup(CreatedModifiedBaseModel, SignUpMixin, SerializableMixin):
         {"name": "id"},
         {"name": "registration_id"},
         {"name": "extra_info"},
-        {"name": "signups"},
+        {"name": "signups_count"},
     )
+
+    @cached_property
+    def signups_count(self):
+        return self.signups.count()
 
     @cached_property
     def responsible_signups(self):
@@ -556,7 +560,7 @@ class SignUp(CreatedModifiedBaseModel, SignUpMixin, SerializableMixin):
         {"name": "native_language", "accessor": lambda value: str(value)},
         {"name": "service_language", "accessor": lambda value: str(value)},
         {"name": "registration_id"},
-        {"name": "signup_group_id"},
+        {"name": "signup_group"},
         {"name": "responsible_for_group"},
         {"name": "extra_info"},
         {"name": "membership_number"},

--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,7 @@ djangorestframework-gis
 drf-oidc-auth==0.10.0
 easy_thumbnails
 elasticsearch<8
+helsinki-profile-gdpr-api
 httmock
 icalendar
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ django==3.2.20
     #   djangorestframework-bulk
     #   drf-oidc-auth
     #   easy-thumbnails
+    #   helsinki-profile-gdpr-api
 django-admin-autocomplete-filter==0.7.1
     # via -r requirements.in
 django-anymail==9.0
@@ -85,7 +86,9 @@ django-filter==22.1
 django-haystack==3.2.1
     # via -r requirements.in
 django-helusers==0.7.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   helsinki-profile-gdpr-api
 django-image-cropping==1.7
     # via -r requirements.in
 django-jinja==2.10.2
@@ -123,12 +126,15 @@ djangorestframework==3.14.0
     #   djangorestframework-bulk
     #   djangorestframework-gis
     #   drf-oidc-auth
+    #   helsinki-profile-gdpr-api
 djangorestframework-bulk==0.2.1
     # via -r requirements.in
 djangorestframework-gis==1.0
     # via -r requirements.in
 drf-oidc-auth==0.10.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   helsinki-profile-gdpr-api
 easy-thumbnails==2.8.5
     # via -r requirements.in
 ecdsa==0.18.0
@@ -141,6 +147,8 @@ executing==1.2.0
     # via stack-data
 future==0.18.3
     # via pyjwkest
+helsinki-profile-gdpr-api==0.2.0
+    # via -r requirements.in
 httmock==1.4.0
     # via -r requirements.in
 icalendar==5.0.4


### PR DESCRIPTION
### Description
Adds the [Helsinki Profile GDPR API ](https://github.com/City-of-Helsinki/helsinki-profile-gdpr-api/) to the project, and makes it possible for a user to query and delete their own GDPR data. It has been determined that at this point the data stored in the `helevents_user`, `registrations_signup` and `registrations_signup_group` tables are the ones to be subject to querying and deleting like this.
### Closes
[LINK-1011](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1011)


[LINK-1011]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ