### PR TITLE
LINK-1500 | Fix missing prices for harrastushaku

### DIFF
--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -568,9 +568,9 @@ class HarrastushakuImporter(Importer):
         for price_data in activity_data.get("prices", ()):
             get_string = bind_data_getters(price_data)[0]
 
-            price = get_string("price", localized=False)
+            price = get_string("price", localized=True)
             description = get_string("description", localized=True)
-            is_free = price is not None and price == "0"
+            is_free = price is not None and price["fi"] == "0"
 
             if not description and len(activity_data["prices"]) == 1:
                 description = get_string("pricedetails", localized=True)

--- a/events/tests/importers/test_harrastushaku.py
+++ b/events/tests/importers/test_harrastushaku.py
@@ -148,3 +148,24 @@ def test_build_sub_event_time_ranges(
 
     assert len(result) == len(expected_subtime_ranges)
     assert result == expected_subtime_ranges
+
+
+@pytest.mark.django_db
+def test_get_event_offers__translated_fields(importer):
+    """Test get_event_offers returns translated fields as expected."""
+    activity_data = {
+        "prices": [
+            {
+                "id": "123",
+                "activity_id": "1234",
+                "price": "50",
+                "description": "Kuvaus",
+            }
+        ],
+    }
+
+    data = importer.get_event_offers(activity_data)
+
+    assert data[0]["is_free"] is False
+    assert data[0]["price"] == {"fi": "50"}
+    assert data[0]["description"] == {"fi": "Kuvaus"}


### PR DESCRIPTION
Price is expected to be a translated field in the `Offer` model and in the LE API.

Partly reverts 96f51c5e68da0322f30deeeeff09dd0bbbecffa2