### PR TITLE
LINK-1578 | Add no-cache headers for all authenticated requests

### DIFF
--- a/events/middleware.py
+++ b/events/middleware.py
@@ -1,0 +1,18 @@
+from django.utils.cache import add_never_cache_headers
+
+
+class AuthenticationCacheDisableMiddleware:
+    """
+    Middleware to disable client side caching for authenticated requests.
+    Adds a "Cache-Control: max-age=0, no-cache, no-store, must-revalidate, private"
+    header to a response to indicate that a response should never be cached.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.user.is_authenticated:
+            add_never_cache_headers(response)
+        return response

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -225,6 +225,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "events.middleware.AuthenticationCacheDisableMiddleware",
     "reversion.middleware.RevisionMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
This PR adds a middleware which will add the no-cache headers for all authenticated requests.
