### PR TITLE
LINK-1576 | Allow anonymous user to retrieve a registration

### DIFF
--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -9,6 +9,9 @@ from registrations.models import Registration, SignUp
 
 class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission):
     def has_permission(self, request: Request, view: APIView) -> bool:
+        if view.action == "retrieve":
+            return True
+
         if not request.user.is_authenticated:
             return False
 
@@ -35,20 +38,14 @@ class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission
     def has_object_permission(
         self, request: Request, view: APIView, obj: Registration
     ) -> bool:
+        if view.action == "retrieve":
+            return True
+
         if isinstance(request.user, ApiKeyUser):
             user_data_source, _ = view.user_data_source_and_organization
             # allow only if the api key matches instance data source
             if obj.data_source != user_data_source:
                 return False
-
-        if request.method == "GET":
-            return (
-                obj.can_be_edited_by(request.user)
-                or obj.registration_user_accesses.filter(
-                    email=request.user.email
-                ).exists()
-                or obj.created_by_id == request.user.id
-            )
 
         return obj.can_be_edited_by(request.user)
 

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -163,11 +163,12 @@ def test_regular_user_cannot_see_registration_user_accesses(
 
 
 @pytest.mark.django_db
-def test_anonymous_user_cannot_see_registration(api_client, registration):
+def test_anonymous_user_can_see_registration(api_client, registration):
     RegistrationUserAccess.objects.create(registration=registration)
 
     response = get_detail(api_client, registration.id)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_200_OK
+    assert_registration_fields_exist(response.data, is_admin_user=False)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
Allow also anonymous users to get single registration. There will be another PR to check fields that only admin users will see.  At the moment `created_by`, `last_modified_by` and `registration_user_accesses` fields are only for the admin users

## Partially closes
[LINK-1576](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1576)

[LINK-1576]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ