### PR TITLE
LINK-1576 | Registration admin fields

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1859,8 +1859,9 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
         super().__init__(*args, **kwargs)
         context = self.context
 
-        if "registration_admin_tree_ids" in context:
-            self.registration_admin_tree_ids = context["registration_admin_tree_ids"]
+        self.registration_admin_tree_ids = context.get(
+            "registration_admin_tree_ids", set()
+        )
 
     def to_representation(self, obj):
         # These fields are visible only if user is admin, registration admin or registration user access user

--- a/events/auth.py
+++ b/events/auth.py
@@ -84,6 +84,9 @@ class ApiKeyUser(get_user_model(), UserModelPermissionMixin):
     def is_regular_user_of(self, publisher):
         return False
 
+    def is_registration_user_access_user_of(self, registration_user_accesses):
+        return False
+
     @property
     def admin_organizations(self):
         if not self.data_source.owner:

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -36,8 +36,8 @@ class UserModelPermissionMixin:
         self._token_amr_claim = value
 
     @property
-    def is_strongly_identificated(self):
-        """Check if the user is strongly identificated"""
+    def is_strongly_identified(self):
+        """Check if the user is strongly identified"""
         return (
             self.token_amr_claim
             in settings.STRONG_IDENTIFICATION_AUTHENTICATION_METHODS
@@ -252,6 +252,6 @@ class User(AbstractUser, UserModelPermissionMixin):
     def is_registration_user_access_user_of(self, registration_user_accesses):
         """Check if current user can be found in registration user accesses"""
         return (
-            self.is_strongly_identificated
+            self.is_strongly_identified
             and registration_user_accesses.filter(email=self.email).exists()
         )

--- a/helevents/serializers.py
+++ b/helevents/serializers.py
@@ -32,6 +32,6 @@ class UserSerializer(serializers.ModelSerializer):
             "is_staff",
             "display_name",
             "is_external",
-            "is_strongly_identificated",
+            "is_strongly_identified",
         ]
         model = get_user_model()

--- a/helevents/tests/test_user_get.py
+++ b/helevents/tests/test_user_get.py
@@ -34,7 +34,7 @@ def assert_user_fields_exist(data, version="v1"):
         "registration_admin_organizations",
         "organization_memberships",
         "is_external",
-        "is_strongly_identificated",
+        "is_strongly_identified",
     )
     assert_fields_exist(data, fields)
 

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -272,7 +272,7 @@ class SignUpBaseFilter(django_filters.rest_framework.FilterSet):
         q_filter = Q(
             registration__event__publisher__in=user.get_registration_admin_organizations_and_descendants()
         )
-        if user.is_strongly_identificated:
+        if user.is_strongly_identified:
             q_filter |= Q(registration__registration_user_accesses__email=user.email)
 
         return queryset.filter(q_filter)

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -289,10 +289,9 @@ class SignUpMixin:
         return (
             user.is_superuser
             or user.is_registration_admin_of(self.publisher)
-            or user.is_strongly_identificated
-            and self.registration.registration_user_accesses.filter(
-                email=user.email
-            ).exists()
+            or user.is_registration_user_access_user_of(
+                self.registration.registration_user_accesses
+            )
             or user.id == self.created_by_id
         )
 

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -253,7 +253,7 @@ class RegistrationBaseSerializer(CreatedModifiedBaseSerializer):
         user = self.user
         return (
             user.is_authenticated
-            and user.is_strongly_identificated
+            and user.is_strongly_identified
             and obj.registration_user_accesses.filter(email=user.email).exists()
         )
 

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -9,14 +9,18 @@ from events.tests.factories import EventFactory
 from events.tests.test_event_get import get_list_and_assert_events
 from events.tests.utils import assert_fields_exist
 from events.tests.utils import versioned_reverse as reverse
-from registrations.models import RegistrationUserAccess, SeatReservationCode
-from registrations.tests.factories import RegistrationFactory
+from registrations.tests.factories import (
+    RegistrationFactory,
+    RegistrationUserAccessFactory,
+    SeatReservationCodeFactory,
+)
 from registrations.tests.test_signup_post import assert_create_signups
 
 include_signups_query = "include=signups"
+test_email = "test@email.com"
+
 
 # === util methods ===
-test_email = "test@email.com"
 
 
 def get_list(api_client: APIClient, query_string: str = None):
@@ -144,8 +148,8 @@ def test_admin_can_get_registration_not_created_by_self(
 
 @pytest.mark.django_db
 def test_admin_user_can_see_registration_user_accesses(registration, user_api_client):
-    RegistrationUserAccess.objects.create(registration=registration)
-    RegistrationUserAccess.objects.create(registration=registration, email=test_email)
+    RegistrationUserAccessFactory(registration=registration)
+    RegistrationUserAccessFactory(registration=registration, email=test_email)
 
     response = get_detail_and_assert_registration(user_api_client, registration.id)
     response_registration_user_accesses = response.data["registration_user_accesses"]
@@ -160,8 +164,8 @@ def test_registration_admin_user_can_see_registration_user_accesses(
     user.get_default_organization().registration_admin_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
-    RegistrationUserAccess.objects.create(registration=registration)
-    RegistrationUserAccess.objects.create(registration=registration, email=test_email)
+    RegistrationUserAccessFactory(registration=registration)
+    RegistrationUserAccessFactory(registration=registration, email=test_email)
 
     response = get_detail_and_assert_registration(user_api_client, registration.id)
     response_registration_user_accesses = response.data["registration_user_accesses"]
@@ -175,10 +179,8 @@ def test_registration_user_access_user_can_see_if_he_has_access(
 ):
     user.get_default_organization().admin_users.remove(user)
 
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
-    RegistrationUserAccess.objects.create(
-        registration=registration, email="test@email.com"
-    )
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=test_email)
 
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
@@ -199,7 +201,7 @@ def test_regular_user_cannot_see_registration_user_accesses(
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
     response = get_detail_and_assert_registration(user_api_client, registration.id)
 
     assert response.data.get("registration_user_accesses") is None
@@ -207,7 +209,7 @@ def test_regular_user_cannot_see_registration_user_accesses(
 
 @pytest.mark.django_db
 def test_anonymous_user_can_see_registration(api_client, registration):
-    RegistrationUserAccess.objects.create(registration=registration)
+    RegistrationUserAccessFactory(registration=registration)
 
     response = get_detail(api_client, registration.id)
     assert response.status_code == status.HTTP_200_OK
@@ -283,12 +285,12 @@ def test_get_registration_with_correct_attendee_capacity(
     assert response.data["remaining_attendee_capacity"] == 4
     assert response.data["remaining_waiting_list_capacity"] == 5
 
-    SeatReservationCode.objects.create(registration=registration, seats=3)
+    SeatReservationCodeFactory(registration=registration, seats=3)
     response = get_detail_and_assert_registration(user_api_client, registration.id)
     assert response.data["remaining_attendee_capacity"] == 1
     assert response.data["remaining_waiting_list_capacity"] == 5
 
-    SeatReservationCode.objects.create(registration=registration, seats=3)
+    SeatReservationCodeFactory(registration=registration, seats=3)
     response = get_detail_and_assert_registration(user_api_client, registration.id)
     assert response.data["remaining_attendee_capacity"] == 0
     assert response.data["remaining_waiting_list_capacity"] == 3
@@ -324,7 +326,7 @@ def test_registration_user_access_can_include_signups_when_strongly_identified(
     registration, signup, signup2, user, user_api_client
 ):
     user.get_default_organization().admin_users.remove(user)
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
 
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
@@ -344,7 +346,7 @@ def test_registration_user_access_cannot_include_signups_when_not_strongly_ident
     registration, signup, signup2, user, user_api_client
 ):
     user.get_default_organization().admin_users.remove(user)
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
 
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
@@ -384,7 +386,7 @@ def test_current_attendee_and_waitlist_count(user_api_client, registration, user
     assert response.data["current_attendee_count"] == 0
     assert response.data["current_waiting_list_count"] == 0
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -402,9 +404,7 @@ def test_current_attendee_and_waitlist_count(user_api_client, registration, user
     assert response.data["current_attendee_count"] == 1
     assert response.data["current_waiting_list_count"] == 0
 
-    reservation2 = SeatReservationCode.objects.create(
-        registration=registration, seats=1
-    )
+    reservation2 = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data2 = {
         "first_name": "Michael",
         "last_name": "Jackson 2",


### PR DESCRIPTION
## Description
- Allow admin and registration admin users to see `created_by`, `last_modified_by` and `registration_user_accesses` fields
- `has_registration_user_access` field which is set to true if current user is strongly identificated and is in registration_user_accesses

## Closes
[LINK-1576](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1576)

[LINK-1576]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ