### PR TITLE
LINK-1594 | Signup permissions

### DIFF
--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -56,13 +56,7 @@ class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
             return False
 
         if request.method == "POST":
-            (
-                __,
-                user_organization,
-            ) = self.user_data_source_and_organization_from_request(request)
-            return request.user.is_superuser or request.user.is_registration_admin_of(
-                user_organization
-            )
+            return True
 
         if request.method in ("PATCH", "PUT", "DELETE"):
             (

--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -52,20 +52,7 @@ class CanAccessRegistration(UserDataFromRequestMixin, permissions.BasePermission
 
 class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
     def has_permission(self, request: Request, view: APIView) -> bool:
-        if not request.user.is_authenticated:
-            return False
-
-        if request.method == "POST":
-            return True
-
-        if request.method in ("PATCH", "PUT", "DELETE"):
-            (
-                __,
-                user_organization,
-            ) = self.user_data_source_and_organization_from_request(request)
-            return bool(user_organization)
-
-        return request.method in permissions.SAFE_METHODS
+        return request.user.is_authenticated
 
     def has_object_permission(
         self, request: Request, view: APIView, obj: SignUp

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -5,6 +5,7 @@ from rest_framework import status
 
 from events.models import Event, Language
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.models import SignUp
 from registrations.tests.factories import (
     RegistrationUserAccessFactory,
@@ -190,12 +191,11 @@ def test_created_user_without_organization_can_delete_signup(
 
 
 @pytest.mark.django_db
-def test_not_created_user_without_organization_cannot_delete_signup(
-    user_api_client, signup, user
-):
-    user.get_default_organization().admin_users.remove(user)
+def test_not_created_user_without_organization_cannot_delete_signup(api_client, signup):
+    user = UserFactory()
+    api_client.force_authenticate(user)
 
-    response = delete_signup(user_api_client, signup.id)
+    response = delete_signup(api_client, signup.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -5,7 +5,11 @@ from rest_framework import status
 
 from events.models import Event, Language
 from events.tests.utils import versioned_reverse as reverse
-from registrations.models import RegistrationUserAccess, SeatReservationCode, SignUp
+from registrations.models import SignUp
+from registrations.tests.factories import (
+    RegistrationUserAccessFactory,
+    SeatReservationCodeFactory,
+)
 from registrations.tests.test_signup_post import assert_create_signups
 
 # === util methods ===
@@ -145,7 +149,7 @@ def test_cancellation_confirmation_template_has_correct_text_per_event_type(
 
 
 @pytest.mark.django_db
-def test__cannot_delete_already_deleted_signup(signup, user_api_client, user):
+def test_cannot_delete_already_deleted_signup(signup, user_api_client, user):
     user.get_default_organization().registration_admin_users.add(user)
 
     assert_delete_signup(user_api_client, signup.id)
@@ -154,18 +158,18 @@ def test__cannot_delete_already_deleted_signup(signup, user_api_client, user):
 
 
 @pytest.mark.django_db
-def test__registration_user_access_cannot_delete_signup(
+def test_registration_user_access_cannot_delete_signup(
     registration, signup, user, user_api_client
 ):
     user.get_default_organization().admin_users.remove(user)
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
 
     response = delete_signup(user_api_client, signup.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test__regular_not_created_user_cannot_delete_signup(signup, user, user_api_client):
+def test_regular_not_created_user_cannot_delete_signup(signup, user, user_api_client):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
@@ -174,18 +178,29 @@ def test__regular_not_created_user_cannot_delete_signup(signup, user, user_api_c
 
 
 @pytest.mark.django_db
-def test__created_authenticated_user_can_delete_signup(user_api_client, signup, user):
+def test_created_user_without_organization_can_delete_signup(
+    user_api_client, signup, user
+):
     signup.created_by = user
     signup.save(update_fields=["created_by"])
 
-    user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
     assert_delete_signup(user_api_client, signup.id)
 
 
 @pytest.mark.django_db
-def test__created_not_authenticated_user_cannot_delete_signup(
+def test_not_created_user_without_organization_cannot_delete_signup(
+    user_api_client, signup, user
+):
+    user.get_default_organization().admin_users.remove(user)
+
+    response = delete_signup(user_api_client, signup.id)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_created_not_authenticated_user_cannot_delete_signup(
     user_api_client, signup, user
 ):
     signup.created_by = user
@@ -201,7 +216,7 @@ def test__created_not_authenticated_user_cannot_delete_signup(
 
 
 @pytest.mark.django_db
-def test__api_key_with_organization_can_delete_signup(
+def test_api_key_with_organization_can_delete_signup(
     api_client, data_source, organization, signup
 ):
     data_source.user_editable_registrations = True
@@ -213,7 +228,7 @@ def test__api_key_with_organization_can_delete_signup(
 
 
 @pytest.mark.django_db
-def test__api_key_of_other_organization_cannot_delete_signup(
+def test_api_key_of_other_organization_cannot_delete_signup(
     api_client, data_source, organization2, signup
 ):
     data_source.owner = organization2
@@ -225,7 +240,7 @@ def test__api_key_of_other_organization_cannot_delete_signup(
 
 
 @pytest.mark.django_db
-def test__api_key_from_wrong_data_source_cannot_delete_signup(
+def test_api_key_from_wrong_data_source_cannot_delete_signup(
     api_client, organization, other_data_source, signup
 ):
     other_data_source.owner = organization
@@ -237,7 +252,7 @@ def test__api_key_from_wrong_data_source_cannot_delete_signup(
 
 
 @pytest.mark.django_db
-def test__unknown_api_key_cannot_delete_signup(api_client, signup):
+def test_unknown_api_key_cannot_delete_signup(api_client, signup):
     api_client.credentials(apikey="unknown")
 
     response = delete_signup(api_client, signup.id)
@@ -267,7 +282,7 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
     registration.maximum_attendee_capacity = 1
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "name": "Michael Jackson1",
         "email": "test@test.com",
@@ -280,9 +295,7 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
     response = assert_create_signups(user_api_client, signups_data)
     signup_id = response.data["attending"]["people"][0]["id"]
 
-    reservation2 = SeatReservationCode.objects.create(
-        registration=registration, seats=1
-    )
+    reservation2 = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data2 = {
         "name": "Michael Jackson2",
         "email": "test1@test.com",
@@ -294,9 +307,7 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
     }
     assert_create_signups(user_api_client, signups_data2)
 
-    reservation3 = SeatReservationCode.objects.create(
-        registration=registration, seats=1
-    )
+    reservation3 = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data3 = {
         "name": "Michael Jackson3",
         "email": "test2@test.com",

--- a/registrations/tests/test_signup_get.py
+++ b/registrations/tests/test_signup_get.py
@@ -165,24 +165,22 @@ def test_regular_created_user_can_get_signup(
 
 @pytest.mark.django_db
 def test_non_created_user_without_organization_cannot_get_signup(
-    user_api_client, registration, signup, user
+    api_client, registration, signup
 ):
-    user.get_default_organization().admin_users.remove(user)
+    user = UserFactory()
+    api_client.force_authenticate(user)
 
-    response = get_detail(user_api_client, signup.id)
+    response = get_detail(api_client, signup.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test_created_user_without_organization_can_get_signup(
-    user_api_client, registration, signup, user
-):
-    signup.created_by = user
-    signup.save(update_fields=["created_by"])
+def test_created_user_without_organization_can_get_signup(api_client, registration):
+    user = UserFactory()
+    api_client.force_authenticate(user)
+    signup = SignUpFactory(created_by=user)
 
-    user.get_default_organization().admin_users.remove(user)
-
-    response = assert_get_detail(user_api_client, signup.id)
+    response = assert_get_detail(api_client, signup.id)
     assert_signup_fields_exist(response.data)
 
 

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -6,6 +6,7 @@ from rest_framework import status
 from events.models import Event
 from events.tests.factories import LanguageFactory
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.models import SignUp, SignUpGroup
 from registrations.tests.factories import (
     RegistrationUserAccessFactory,
@@ -258,13 +259,13 @@ def test_created_user_without_organization_can_delete_signup_group(
 
 @pytest.mark.django_db
 def test_not_created_user_without_organization_cannot_delete_signup_group(
-    user_api_client, user, registration
+    api_client, registration
 ):
+    user = UserFactory()
+    api_client.force_authenticate(user)
     signup_group = SignUpGroupFactory(registration=registration)
 
-    user.get_default_organization().admin_users.remove(user)
-
-    response = delete_signup_group(user_api_client, signup_group.id)
+    response = delete_signup_group(api_client, signup_group.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/registrations/tests/test_signup_group_get.py
+++ b/registrations/tests/test_signup_group_get.py
@@ -157,29 +157,29 @@ def test_regular_created_user_can_get_signup_group(user_api_client, user, organi
 
 @pytest.mark.django_db
 def test_non_created_user_without_organization_cannot_get_signup_group(
-    organization, user, user_api_client
+    api_client, organization
 ):
+    user = UserFactory()
+    api_client.force_authenticate(user)
     signup_group = SignUpGroupFactory(registration__event__publisher=organization)
 
-    organization.admin_users.remove(user)
-
-    response = get_detail(user_api_client, signup_group.id)
+    response = get_detail(api_client, signup_group.id)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
 def test_created_user_without_organization_can_get_signup_group(
-    organization, user, user_api_client
+    api_client, organization
 ):
+    user = UserFactory()
+    api_client.force_authenticate(user)
     signup_group = SignUpGroupFactory(
         registration__event__publisher=organization, created_by=user
     )
     SignUpFactory(registration=signup_group.registration, signup_group=signup_group)
     SignUpFactory(registration=signup_group.registration, signup_group=signup_group)
 
-    organization.admin_users.remove(user)
-
-    response = assert_get_detail(user_api_client, signup_group.id)
+    response = assert_get_detail(api_client, signup_group.id)
     assert len(response.json()["signups"]) == 2
     assert_signup_group_fields_exist(response.data)
 

--- a/registrations/tests/test_signup_group_get.py
+++ b/registrations/tests/test_signup_group_get.py
@@ -156,6 +156,35 @@ def test_regular_created_user_can_get_signup_group(user_api_client, user, organi
 
 
 @pytest.mark.django_db
+def test_non_created_user_without_organization_cannot_get_signup_group(
+    organization, user, user_api_client
+):
+    signup_group = SignUpGroupFactory(registration__event__publisher=organization)
+
+    organization.admin_users.remove(user)
+
+    response = get_detail(user_api_client, signup_group.id)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_created_user_without_organization_can_get_signup_group(
+    organization, user, user_api_client
+):
+    signup_group = SignUpGroupFactory(
+        registration__event__publisher=organization, created_by=user
+    )
+    SignUpFactory(registration=signup_group.registration, signup_group=signup_group)
+    SignUpFactory(registration=signup_group.registration, signup_group=signup_group)
+
+    organization.admin_users.remove(user)
+
+    response = assert_get_detail(user_api_client, signup_group.id)
+    assert len(response.json()["signups"]) == 2
+    assert_signup_group_fields_exist(response.data)
+
+
+@pytest.mark.django_db
 def test_user_from_other_organization_cannot_get_signup_group(
     api_client, user2, organization
 ):

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from events.models import Event
 from events.tests.factories import LanguageFactory
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.models import MandatoryFields, SignUp, SignUpGroup
 from registrations.tests.factories import SeatReservationCodeFactory
 
@@ -168,9 +169,10 @@ def test_regular_user_can_create_signup_group(
 
 @pytest.mark.django_db
 def test_user_without_organization_can_create_signup_group(
-    languages, organization, user, user_api_client
+    api_client, languages, organization
 ):
-    user.get_default_organization().admin_users.remove(user)
+    user = UserFactory()
+    api_client.force_authenticate(user)
     assert SignUpGroup.objects.count() == 0
     assert SignUp.objects.count() == 0
 
@@ -179,7 +181,7 @@ def test_user_without_organization_can_create_signup_group(
     signup_group_data["registration"] = reservation.registration_id
     signup_group_data["reservation_code"] = reservation.code
 
-    assert_create_signup_group(user_api_client, signup_group_data)
+    assert_create_signup_group(api_client, signup_group_data)
     assert_default_signup_group_created(reservation, signup_group_data, user)
 
 

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -10,6 +10,7 @@ from rest_framework import status
 
 from events.models import Event, Language
 from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
 from registrations.models import MandatoryFields, SignUp
 from registrations.tests.factories import (
     SeatReservationCodeFactory,
@@ -126,10 +127,9 @@ def test_regular_user_can_create_signups(
 
 
 @pytest.mark.django_db
-def test_user_without_organization_can_create_signups(
-    languages, organization, user, user_api_client
-):
-    user.get_default_organization().admin_users.remove(user)
+def test_user_without_organization_can_create_signups(api_client, languages):
+    user = UserFactory()
+    api_client.force_authenticate(user)
 
     assert SignUp.objects.count() == 0
     reservation = SeatReservationCodeFactory(seats=1)
@@ -137,7 +137,7 @@ def test_user_without_organization_can_create_signups(
     signups_data["registration"] = reservation.registration.id
     signups_data["reservation_code"] = reservation.code
 
-    assert_create_signups(user_api_client, signups_data)
+    assert_create_signups(api_client, signups_data)
     assert_default_signup_created(signups_data, user)
 
 

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -10,7 +10,7 @@ from rest_framework import status
 
 from events.models import Event, Language
 from events.tests.utils import versioned_reverse as reverse
-from registrations.models import MandatoryFields, SeatReservationCode, SignUp
+from registrations.models import MandatoryFields, SignUp
 from registrations.tests.factories import (
     SeatReservationCodeFactory,
     SignUpFactory,
@@ -225,7 +225,7 @@ def test_cannot_signup_if_enrolment_is_not_opened(
     registration.enrolment_end_time = localtime() + timedelta(days=2)
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -252,7 +252,7 @@ def test_cannot_signup_if_enrolment_is_closed(
     registration.enrolment_end_time = localtime() - timedelta(days=1)
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -297,7 +297,7 @@ def test_amount_if_signups_cannot_be_greater_than_maximum_group_size(
     registration.maximum_group_size = 2
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=3)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=3)
     code = reservation.code
     signup_payload = {
         "first_name": "Mickey",
@@ -337,9 +337,7 @@ def test_cannot_signup_if_reservation_code_is_for_different_registration(
 ):
     user.get_default_organization().registration_admin_users.add(user)
 
-    reservation = SeatReservationCode.objects.create(
-        registration=registration2, seats=2
-    )
+    reservation = SeatReservationCodeFactory(registration=registration2, seats=2)
     code = reservation.code
     signups_payload = {
         "registration": registration.id,
@@ -358,7 +356,7 @@ def test_cannot_signup_if_number_of_signups_exceeds_number_reserved_seats(
 ):
     user.get_default_organization().registration_admin_users.add(user)
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
 
     signups_data = {
         "registration": registration.id,
@@ -390,7 +388,7 @@ def test_cannot_signup_if_reservation_code_is_expired(
 ):
     user.get_default_organization().registration_admin_users.add(user)
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     reservation.timestamp = reservation.timestamp - timedelta(days=1)
     reservation.save()
 
@@ -415,7 +413,7 @@ def test_cannot_signup_if_reservation_code_is_expired(
 def test_can_signup_twice_with_same_phone_or_email(user_api_client, registration, user):
     user.get_default_organization().registration_admin_users.add(user)
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=3)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=3)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -481,7 +479,7 @@ def test_date_of_birth_is_mandatory_if_audience_min_or_max_age_specified(
     if date_of_birth:
         signup_data["date_of_birth"] = date_of_birth
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
         "reservation_code": reservation.code,
@@ -524,7 +522,7 @@ def test_signup_age_has_to_match_the_audience_min_max_age(
         "notifications": "sms",
         "date_of_birth": date_of_birth,
     }
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
         "reservation_code": reservation.code,
@@ -569,7 +567,7 @@ def test_signup_mandatory_fields_has_to_be_filled(
         "notifications": "sms",
         mandatory_field_id: "",
     }
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
         "reservation_code": reservation.code,
@@ -594,7 +592,7 @@ def test_cannot_signup_with_not_allowed_service_language(
     languages[0].service_language = False
     languages[0].save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signups_data = {
         "registration": registration.id,
         "reservation_code": reservation.code,
@@ -622,7 +620,7 @@ def test_group_signup_successful_with_waitlist(user_api_client, registration, us
     registration.waiting_list_capacity = 2
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=2)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=2)
     signups_payload = {
         "registration": registration.id,
         "reservation_code": reservation.code,
@@ -642,9 +640,7 @@ def test_group_signup_successful_with_waitlist(user_api_client, registration, us
     assert_create_signups(user_api_client, signups_payload)
     assert registration.signups.count() == 2
 
-    reservation2 = SeatReservationCode.objects.create(
-        registration=registration, seats=2
-    )
+    reservation2 = SeatReservationCodeFactory(registration=registration, seats=2)
     signups_payload = {
         "registration": registration.id,
         "reservation_code": reservation2.code,
@@ -718,9 +714,7 @@ def test_email_sent_on_successful_signup(
         registration.event.name = "Foo"
         registration.event.save()
 
-        reservation = SeatReservationCode.objects.create(
-            registration=registration, seats=1
-        )
+        reservation = SeatReservationCodeFactory(registration=registration, seats=1)
         signup_data = {
             "first_name": "Michael",
             "last_name": "Jackson",
@@ -782,7 +776,7 @@ def test_confirmation_template_has_correct_text_per_event_type(
     registration.event.name = "Foo"
     registration.event.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -834,7 +828,7 @@ def test_confirmation_message_is_shown_in_service_language(
     registration.confirmation_message_fi = "Vahvistusviesti"
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",
@@ -890,9 +884,7 @@ def test_different_email_sent_if_user_is_added_to_waiting_list(
         registration.event.save()
         registration.maximum_attendee_capacity = 1
         registration.save()
-        reservation = SeatReservationCode.objects.create(
-            registration=registration, seats=1
-        )
+        reservation = SeatReservationCodeFactory(registration=registration, seats=1)
         signup_data = {
             "first_name": "Michael",
             "last_name": "Jackson",
@@ -951,7 +943,7 @@ def test_confirmation_to_waiting_list_template_has_correct_text_per_event_type(
     registration.maximum_attendee_capacity = 1
     registration.save()
 
-    reservation = SeatReservationCode.objects.create(registration=registration, seats=1)
+    reservation = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data = {
         "first_name": "Michael",
         "last_name": "Jackson",

--- a/registrations/tests/test_signup_put.py
+++ b/registrations/tests/test_signup_put.py
@@ -3,7 +3,11 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from events.tests.utils import versioned_reverse as reverse
-from registrations.models import RegistrationUserAccess, SignUp
+from registrations.models import SignUp
+from registrations.tests.factories import RegistrationUserAccessFactory
+
+new_signup_name = "Edited name"
+new_date_of_birth = "2015-01-01"
 
 # === util methods ===
 
@@ -35,12 +39,10 @@ def assert_update_signup(api_client, signup_pk, signup_data, query_string=None):
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__registration_admin_can_update_signup(
+def test_registration_admin_can_update_signup(
     user_api_client, registration, signup, user
 ):
     user.get_default_organization().registration_admin_users.add(user)
-
-    new_signup_name = "Edited name"
 
     db_signup = SignUp.objects.get(pk=signup.id)
     assert db_signup.first_name != new_signup_name
@@ -49,20 +51,40 @@ def test__registration_admin_can_update_signup(
     signup_data = {
         "registration": registration.id,
         "first_name": new_signup_name,
-        "date_of_birth": "2015-01-01",
+        "date_of_birth": new_date_of_birth,
     }
 
     assert_update_signup(user_api_client, signup.id, signup_data)
-    db_signup = SignUp.objects.get(pk=signup.id)
+    db_signup.refresh_from_db()
     assert db_signup.first_name == new_signup_name
     assert db_signup.last_modified_by_id == user.id
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__regular_admin_cannot_update_signup(user_api_client, registration, signup):
-    new_signup_name = "Edited name"
+def test_created_admin_can_update_signup(registration, signup, user, user_api_client):
+    signup.created_by = user
+    signup.save(update_fields=["created_by"])
 
+    db_signup = SignUp.objects.get(pk=signup.id)
+    assert db_signup.first_name != new_signup_name
+    assert db_signup.last_modified_by_id is None
+
+    signup_data = {
+        "registration": registration.id,
+        "first_name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
+    }
+
+    assert_update_signup(user_api_client, signup.id, signup_data)
+    db_signup.refresh_from_db()
+    assert db_signup.first_name == new_signup_name
+    assert db_signup.last_modified_by_id == user.id
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_non_created_admin_cannot_update_signup(registration, signup, user_api_client):
     db_signup = SignUp.objects.get(pk=signup.id)
     assert db_signup.first_name != new_signup_name
     assert db_signup.first_name == signup.first_name
@@ -71,19 +93,20 @@ def test__regular_admin_cannot_update_signup(user_api_client, registration, sign
     signup_data = {
         "registration": registration.id,
         "first_name": new_signup_name,
-        "date_of_birth": "2015-01-01",
+        "date_of_birth": new_date_of_birth,
     }
 
     response = update_signup(user_api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    db_signup = SignUp.objects.get(pk=signup.id)
+
+    db_signup.refresh_from_db()
     assert db_signup.first_name == signup.first_name
     assert db_signup.last_modified_by_id is None
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__created_regular_user_can_update_signup(
+def test_created_regular_user_can_update_signup(
     user_api_client, registration, signup, user
 ):
     signup.created_by = user
@@ -92,8 +115,6 @@ def test__created_regular_user_can_update_signup(
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
-    new_signup_name = "Edited name"
-
     db_signup = SignUp.objects.get(pk=signup.id)
     assert db_signup.first_name != new_signup_name
     assert db_signup.last_modified_by_id is None
@@ -101,24 +122,23 @@ def test__created_regular_user_can_update_signup(
     signup_data = {
         "registration": registration.id,
         "first_name": new_signup_name,
-        "date_of_birth": "2015-01-01",
+        "date_of_birth": new_date_of_birth,
     }
 
     assert_update_signup(user_api_client, signup.id, signup_data)
-    db_signup = SignUp.objects.get(pk=signup.id)
+
+    db_signup.refresh_from_db()
     assert db_signup.first_name == new_signup_name
     assert db_signup.last_modified_by_id == user.id
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__non_created_regular_user_cannot_update_signup(
+def test_non_created_regular_user_cannot_update_signup(
     user_api_client, registration, signup, user
 ):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
-
-    new_signup_name = "Edited name"
 
     db_signup = SignUp.objects.get(pk=signup.id)
     assert db_signup.first_name != new_signup_name
@@ -127,19 +147,70 @@ def test__non_created_regular_user_cannot_update_signup(
     signup_data = {
         "registration": registration.id,
         "first_name": new_signup_name,
-        "date_of_birth": "2015-01-01",
+        "date_of_birth": new_date_of_birth,
     }
 
     response = update_signup(user_api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    db_signup = SignUp.objects.get(pk=signup.id)
+    db_signup.refresh_from_db()
     assert db_signup.first_name != new_signup_name
     assert db_signup.last_modified_by_id is None
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__cannot_update_attendee_status_of_signup(
+def test_created_user_without_organization_can_update_signup(
+    user_api_client, registration, signup, user
+):
+    signup.created_by = user
+    signup.save(update_fields=["created_by"])
+
+    user.get_default_organization().admin_users.remove(user)
+
+    db_signup = SignUp.objects.get(pk=signup.id)
+    assert db_signup.first_name != new_signup_name
+    assert db_signup.last_modified_by_id is None
+
+    signup_data = {
+        "registration": registration.id,
+        "first_name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
+    }
+
+    assert_update_signup(user_api_client, signup.id, signup_data)
+
+    db_signup.refresh_from_db()
+    assert db_signup.first_name == new_signup_name
+    assert db_signup.last_modified_by_id == user.id
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_non_created_user_without_organization_cannot_update_signup(
+    user_api_client, registration, signup, user
+):
+    user.get_default_organization().admin_users.remove(user)
+
+    db_signup = SignUp.objects.get(pk=signup.id)
+    assert db_signup.first_name != new_signup_name
+    assert db_signup.last_modified_by_id is None
+
+    signup_data = {
+        "registration": registration.id,
+        "first_name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
+    }
+
+    response = update_signup(user_api_client, signup.id, signup_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    db_signup.refresh_from_db()
+    assert db_signup.first_name != new_signup_name
+    assert db_signup.last_modified_by_id is None
+
+
+@freeze_time("2023-03-14 03:30:00+02:00")
+@pytest.mark.django_db
+def test_cannot_update_attendee_status_of_signup(
     registration, signup, user_api_client, user
 ):
     user.get_default_organization().registration_admin_users.add(user)
@@ -149,8 +220,8 @@ def test__cannot_update_attendee_status_of_signup(
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
         "attendee_status": SignUp.AttendeeStatus.WAITING_LIST,
     }
 
@@ -164,14 +235,14 @@ def test__cannot_update_attendee_status_of_signup(
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__cannot_update_registration_of_signup(
+def test_cannot_update_registration_of_signup(
     registration, registration2, signup, user_api_client, user
 ):
     user.get_default_organization().registration_admin_users.add(user)
 
     signup_data = {
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
         "registration": registration2.id,
     }
 
@@ -184,32 +255,30 @@ def test__cannot_update_registration_of_signup(
 
 
 @pytest.mark.django_db
-def test__registration_user_access_cannot_update_signup(
+def test_registration_user_access_cannot_update_signup(
     registration, signup, user, user_api_client
 ):
     user.get_default_organization().admin_users.remove(user)
-    RegistrationUserAccess.objects.create(registration=registration, email=user.email)
+    RegistrationUserAccessFactory(registration=registration, email=user.email)
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(user_api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test__regular_user_cannot_update_signup(
-    registration, signup, user, user_api_client
-):
+def test_regular_user_cannot_update_signup(registration, signup, user, user_api_client):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(user_api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -217,7 +286,7 @@ def test__regular_user_cannot_update_signup(
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__api_key_with_organization_and_registration_permission_can_update_signup(
+def test_api_key_with_organization_and_registration_permission_can_update_signup(
     api_client, data_source, organization, registration, signup
 ):
     data_source.user_editable_registrations = True
@@ -227,15 +296,15 @@ def test__api_key_with_organization_and_registration_permission_can_update_signu
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     assert_update_signup(api_client, signup.id, signup_data)
 
 
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
-def test__api_key_with_organization_without_registration_permission_cannot_update_signup(
+def test_api_key_with_organization_without_registration_permission_cannot_update_signup(
     api_client, data_source, organization, registration, signup
 ):
     data_source.owner = organization
@@ -244,15 +313,15 @@ def test__api_key_with_organization_without_registration_permission_cannot_updat
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test__api_key_of_other_organization_cannot_update_signup(
+def test_api_key_of_other_organization_cannot_update_signup(
     api_client, data_source, organization2, registration, signup
 ):
     data_source.owner = organization2
@@ -261,15 +330,15 @@ def test__api_key_of_other_organization_cannot_update_signup(
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test__api_key_from_wrong_data_source_cannot_update_signup(
+def test_api_key_from_wrong_data_source_cannot_update_signup(
     api_client, organization, other_data_source, registration, signup
 ):
     other_data_source.owner = organization
@@ -278,21 +347,21 @@ def test__api_key_from_wrong_data_source_cannot_update_signup(
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
-def test__unknown_api_key_cannot_update_signup(api_client, registration, signup):
+def test_unknown_api_key_cannot_update_signup(api_client, registration, signup):
     api_client.credentials(apikey="unknown")
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     response = update_signup(api_client, signup.id, signup_data)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -317,7 +386,7 @@ def test_registration_admin_can_update_signup_regardless_of_non_user_editable_re
 
     signup_data = {
         "registration": registration.id,
-        "name": "Edited name",
-        "date_of_birth": "2015-01-01",
+        "name": new_signup_name,
+        "date_of_birth": new_date_of_birth,
     }
     assert_update_signup(user_api_client, signup.id, signup_data)


### PR DESCRIPTION
## Description
Allow all authenticated users to create signups and signup groups
Allow user to update or delete signup or signup group created by himself

## 
[LINK-1594](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1594)

[LINK-1594]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ