### PR TITLE
LINK-1608 | Return signups also when sending message to signup group

### DIFF
--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -123,11 +123,13 @@ def test_email_is_sent_to_selected_signup_groups_responsible_signup_only(
         "signup_groups": [second_signup_group.pk],
     }
 
-    assert_send_message(
+    response = assert_send_message(
         api_client, registration.id, send_message_data, [third_signup.email]
     )
     # Default language for the email is Finnish
     assert "Tarkastele ilmoittautumistasi täällä" in str(mail.outbox[0].alternatives[0])
+    # signups should include signup who is responsible for the group
+    assert response.data["signups"] == [third_signup.id]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
Split `_get_messages` method to `_get_message_signups` and `_get_messages` methods.
- `_get_message_signups` returns all the signups to which the email message will be sent
- `_get_message` generates messages for each of those signups 

Return value from `_get_message_signups` is used when serializing response for send_message action

## Closes
[LINK-1608](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1608)

[LINK-1608]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ