### PR TITLE
LINK-1615 | Fix external organisation set as publisher

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2319,10 +2319,6 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer)
         offers = validated_data.pop("offers", [])
         links = validated_data.pop("external_links", [])
         videos = validated_data.pop("videos", [])
-        publisher = (
-            validated_data.get("publisher")
-            or utils.get_or_create_default_organization()
-        )
 
         validated_data.update(
             {
@@ -2330,9 +2326,14 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer)
                 "last_modified_by": user,
                 "created_time": Event.now(),  # we must specify creation time as we are setting id
                 "event_status": Event.Status.SCHEDULED,  # mark all newly created events as scheduled
-                "publisher": publisher,
             }
         )
+
+        if settings.ENABLE_EXTERNAL_USER_EVENTS and user.is_external:
+            validated_data["publisher"] = (
+                validated_data.get("publisher")
+                or utils.get_or_create_default_organization()
+            )
 
         # pop out extension related fields because create() cannot stand them
         original_validated_data = deepcopy(validated_data)

--- a/events/auth.py
+++ b/events/auth.py
@@ -111,6 +111,10 @@ class ApiKeyUser(get_user_model(), UserModelPermissionMixin):
             "apikey_registration_admin_organizations"
         )
 
+    @property
+    def is_external(self):
+        return False
+
 
 class ApiKeyAuth(object):
     def __init__(self, data_source):

--- a/events/tests/test_auth.py
+++ b/events/tests/test_auth.py
@@ -78,6 +78,10 @@ class TestApiKeyUser(TestCase):
         is_regular_user = self.user.is_regular_user_of(self.org_2)
         self.assertFalse(is_regular_user)
 
+    def test_is_external(self):
+        is_external = self.user.is_external
+        self.assertFalse(is_external)
+
 
 @pytest.mark.django_db
 def test_valid_jwt_is_accepted():

--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -91,6 +91,21 @@ def test__api_key_with_organization_can_create_an_event(
 
 
 @pytest.mark.django_db
+def test__api_key_with_organization_event_create_sets_correct_publisher(
+    api_client, minimal_event_dict, data_source, organization
+):
+    """Empty publisher in data should set the data source owner as the publisher."""
+    del minimal_event_dict["publisher"]
+    data_source.owner = organization
+    data_source.save()
+
+    response = create_with_post(api_client, minimal_event_dict, data_source)
+
+    minimal_event_dict["publisher"] = organization.id
+    assert_event_data_is_equal(minimal_event_dict, response.data)
+
+
+@pytest.mark.django_db
 def test__api_key_with_organization_can_create_a_suborganization_event(
     api_client, minimal_event_dict, data_source, organization, organization2
 ):

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -99,16 +99,16 @@ def test_user_is_external_based_on_group_membership(
 ):
     with (
         patch.object(
-            UserModelPermissionMixin, "organization_memberships", new_callable=MagicMock
+            User, "organization_memberships", new_callable=MagicMock
         ) as organization_memberships,
         patch.object(
-            UserModelPermissionMixin, "admin_organizations", new_callable=MagicMock
+            User, "admin_organizations", new_callable=MagicMock
         ) as admin_organizations,
     ):
         organization_memberships.exists.return_value = is_regular_user
         admin_organizations.exists.return_value = is_admin
 
-        assert UserModelPermissionMixin().is_external is expected
+        assert User().is_external is expected
 
 
 class TestUserModelPermissions(TestCase):

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -44,17 +44,10 @@ class UserModelPermissionMixin:
             in settings.STRONG_IDENTIFICATION_AUTHENTICATION_METHODS
         )
 
-    @cached_property
+    @property
     def is_external(self):
         """Check if the user is an external user"""
-
-        if self.token_amr_claim in settings.NON_EXTERNAL_AUTHENTICATION_METHODS:
-            return False
-
-        return (
-            not self.organization_memberships.exists()
-            and not self.admin_organizations.exists()
-        )
+        raise NotImplementedError()
 
     def is_admin_of(self, publisher):
         """Check if current user is an admin user of the publisher organization"""
@@ -263,4 +256,14 @@ class User(AbstractUser, UserModelPermissionMixin, SerializableMixin):
         return (
             self.is_strongly_identified
             and registration_user_accesses.filter(email=self.email).exists()
+        )
+
+    @cached_property
+    def is_external(self):
+        if self.token_amr_claim in settings.NON_EXTERNAL_AUTHENTICATION_METHODS:
+            return False
+
+        return (
+            not self.organization_memberships.exists()
+            and not self.admin_organizations.exists()
         )


### PR DESCRIPTION
When creating an event the publisher field is not required. If the publisher field is not sent it will default to:
- users organization, 
- data sources owner when api key is used or 
- to the external organization when external user sends the event. 

There was an issue where the external organization was set as the publisher if the publisher was not in the event data. The fix is to set the default external organization only if an external user sends the data and the publisher is missing.