### PR TITLE
LINK-1620 | Log only a user's username to Sentry

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -50,7 +50,7 @@ def user_created_notification(sender, instance, created, **kwargs):
         if len(recipient_list) == 0:
             logger.warning(
                 "No recipients for notification type '%s'" % notification_type,
-                extra={"event": instance},
+                extra={"user": instance.username},
             )
             return
         try:
@@ -69,4 +69,4 @@ def user_created_notification(sender, instance, created, **kwargs):
                 html_message=rendered_notification["html_body"],
             )
         except SMTPException as e:
-            logger.error(e, exc_info=True, extra={"user": instance})
+            logger.error(e, exc_info=True, extra={"user": instance.username})

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -9,10 +9,12 @@ import bleach
 import environ
 import sentry_sdk
 from django.conf.global_settings import LANGUAGES as GLOBAL_LANGUAGES
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django_jinja.builtins import DEFAULT_EXTENSIONS
 from easy_thumbnails.conf import Settings as thumbnail_settings  # noqa: N813
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.serializer import add_global_repr_processor
 
 CONFIG_FILE_NAME = "config_dev.toml"
 
@@ -42,6 +44,14 @@ def get_git_revision_hash() -> str:
         # Ditto
         git_hash = "no_repository"
     return git_hash.rstrip()
+
+
+@add_global_repr_processor
+def sentry_anonymize_user_repr(obj, hint):
+    if isinstance(obj, get_user_model()):
+        return f"<{obj.__class__.__name__}: {obj.username}>"
+
+    return NotImplemented
 
 
 root = environ.Path(__file__) - 2  # two levels back in hierarchy

--- a/linkedevents/tests/test_sentry.py
+++ b/linkedevents/tests/test_sentry.py
@@ -1,0 +1,24 @@
+import pytest
+from sentry_sdk.serializer import global_repr_processors
+
+from events.tests.factories import ApiKeyUserFactory
+from helevents.tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_anonymize_user_repr_function():
+    assert len(global_repr_processors) == 1
+
+    user = UserFactory()
+    user_repr = global_repr_processors[0](user, None)
+    assert user_repr == f"<{user.__class__.__name__}: {user.username}>"
+
+    apikey_user = ApiKeyUserFactory()
+    apikey_user_repr = global_repr_processors[0](apikey_user, None)
+    assert (
+        apikey_user_repr
+        == f"<{apikey_user.__class__.__name__}: {apikey_user.username}>"
+    )
+
+    nonetype_repr = global_repr_processors[0](None, None)
+    assert nonetype_repr == NotImplemented


### PR DESCRIPTION
### Description
Currently, a user's full name and email address are logged to Sentry if an exception involves a `User` instance. It was decided that we should not log those but instead just the user's `username` and that's what has been implemented in this PR.

### Closes
[LINK-1620](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1620)

[LINK-1620]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ