### PR TITLE
LINK-1587 | Prevent the HEAD method for registrations API

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -52,15 +52,15 @@ from registrations.utils import send_mass_html_mail
 logger = logging.getLogger(__name__)
 
 
+class RegistrationsAllowedMethodsMixin:
+    http_method_names = ["post", "put", "patch", "get", "delete", "options"]
+
+
 class RegistrationViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    mixins.ListModelMixin,
-    mixins.CreateModelMixin,
-    viewsets.GenericViewSet,
+    RegistrationsAllowedMethodsMixin,
+    viewsets.ModelViewSet,
 ):
     serializer_class = RegistrationSerializer
     queryset = Registration.objects.all()
@@ -381,6 +381,7 @@ class SignUpGroupFilter(SignUpBaseFilter):
 
 class SignUpViewSet(
     UserDataSourceAndOrganizationMixin,
+    RegistrationsAllowedMethodsMixin,
     viewsets.ModelViewSet,
 ):
     serializer_class = SignUpSerializer
@@ -434,6 +435,7 @@ register_view(SignUpViewSet, "signup")
 
 class SignUpGroupViewSet(
     UserDataSourceAndOrganizationMixin,
+    RegistrationsAllowedMethodsMixin,
     viewsets.ModelViewSet,
 ):
     serializer_class = SignUpGroupSerializer
@@ -491,6 +493,7 @@ class SeatReservationViewSet(
 ):
     serializer_class = SeatReservationCodeSerializer
     queryset = SeatReservationCode.objects.all()
+    http_method_names = ["post", "put", "options"]
     permission_classes = [IsAuthenticated]
 
 

--- a/registrations/tests/test_registration_head.py
+++ b/registrations/tests/test_registration_head.py
@@ -1,0 +1,37 @@
+from typing import Union
+
+import pytest
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.factories import RegistrationFactory
+
+# === util methods ===
+
+
+def head_list(api_client: APIClient):
+    url = reverse("registration-list")
+
+    return api_client.head(url)
+
+
+def head_detail(api_client: APIClient, pk: Union[str, int]):
+    url = reverse("registration-detail", kwargs={"pk": pk})
+
+    return api_client.head(url)
+
+
+# === tests ===
+
+
+@pytest.mark.parametrize("url_type", ["list", "detail"])
+@pytest.mark.django_db
+def test_head_method_not_allowed_for_registration(user_api_client, url_type):
+    if url_type == "list":
+        response = head_list(user_api_client)
+    else:
+        registration = RegistrationFactory()
+        response = head_detail(user_api_client, pk=registration.pk)
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/registrations/tests/test_seatsreservation_head.py
+++ b/registrations/tests/test_seatsreservation_head.py
@@ -1,0 +1,37 @@
+from typing import Union
+
+import pytest
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.factories import SeatReservationCodeFactory
+
+# === util methods ===
+
+
+def head_list(api_client: APIClient):
+    url = reverse("seatreservationcode-list")
+
+    return api_client.head(url)
+
+
+def head_detail(api_client: APIClient, pk: Union[str, int]):
+    url = reverse("seatreservationcode-detail", kwargs={"pk": pk})
+
+    return api_client.head(url)
+
+
+# === tests ===
+
+
+@pytest.mark.parametrize("url_type", ["list", "detail"])
+@pytest.mark.django_db
+def test_head_method_not_allowed_for_seats_registration(user_api_client, url_type):
+    if url_type == "list":
+        response = head_list(user_api_client)
+    else:
+        reservation = SeatReservationCodeFactory(seats=1)
+        response = head_detail(user_api_client, pk=reservation.pk)
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -8,6 +8,16 @@ from events.models import Language
 from events.tests.utils import versioned_reverse as reverse
 from registrations.tests.factories import SignUpFactory, SignUpGroupFactory
 
+# === util methods ===
+
+
+def head_message(api_client, registration_id):
+    send_message_url = reverse(
+        "registration-send-message", kwargs={"pk": registration_id}
+    )
+
+    return api_client.head(send_message_url)
+
 
 def send_message(api_client, registration_id, send_message_data):
     send_message_url = reverse(
@@ -43,6 +53,15 @@ def assert_send_message(
         assert next(x for x in mails if signup.email in x.to) is not None
 
     return response
+
+
+# === tests ===
+
+
+@pytest.mark.django_db
+def test_head_method_not_allowed(user_api_client, registration):
+    response = head_message(user_api_client, registration.id)
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_signup_group_head.py
+++ b/registrations/tests/test_signup_group_head.py
@@ -1,0 +1,42 @@
+from typing import Union
+
+import pytest
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
+from registrations.tests.factories import SignUpGroupFactory
+
+# === util methods ===
+
+
+def head_list(api_client: APIClient):
+    url = reverse("signupgroup-list")
+
+    return api_client.head(url)
+
+
+def head_detail(api_client: APIClient, pk: Union[str, int]):
+    url = reverse("signupgroup-detail", kwargs={"pk": pk})
+
+    return api_client.head(url)
+
+
+# === tests ===
+
+
+@pytest.mark.parametrize("url_type", ["list", "detail"])
+@pytest.mark.django_db
+def test_head_method_not_allowed_for_signup_group(api_client, registration, url_type):
+    user = UserFactory()
+    user.registration_admin_organizations.add(registration.publisher)
+    api_client.force_authenticate(user)
+
+    if url_type == "list":
+        response = head_list(api_client)
+    else:
+        signup_group = SignUpGroupFactory(registration=registration)
+        response = head_detail(api_client, pk=signup_group.pk)
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/registrations/tests/test_signup_head.py
+++ b/registrations/tests/test_signup_head.py
@@ -1,0 +1,42 @@
+from typing import Union
+
+import pytest
+from rest_framework import status
+
+from events.tests.conftest import APIClient
+from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
+from registrations.tests.factories import SignUpFactory
+
+# === util methods ===
+
+
+def head_list(api_client: APIClient):
+    url = reverse("signup-list")
+
+    return api_client.head(url)
+
+
+def head_detail(api_client: APIClient, pk: Union[str, int]):
+    url = reverse("signup-detail", kwargs={"pk": pk})
+
+    return api_client.head(url)
+
+
+# === tests ===
+
+
+@pytest.mark.parametrize("url_type", ["list", "detail"])
+@pytest.mark.django_db
+def test_head_method_not_allowed_for_signup(api_client, registration, url_type):
+    user = UserFactory()
+    user.registration_admin_organizations.add(registration.publisher)
+    api_client.force_authenticate(user)
+
+    if url_type == "list":
+        response = head_list(api_client)
+    else:
+        signup = SignUpFactory(registration=registration)
+        response = head_detail(api_client, pk=signup.pk)
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED


### PR DESCRIPTION
### Description
OWASP states that only necessary HTTP verbs / methods should be allowed for an API. The HEAD method is seen as such for the registrations API and will not be allowed after these changes.

To ensure a semantically correct HTTP response status code (405), the method has been prevented in the ViewSets instead of in the permissions.
### Closes
[LINK-1587](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1587)

[LINK-1587]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ