### PR TITLE
LINK-1543 | Remove stale allauth tables and contenttypes

### DIFF
--- a/linkedevents/apps.py
+++ b/linkedevents/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LinkedEventsConfig(AppConfig):
+    name = "linkedevents"
+    verbose_name = "Linked Events"

--- a/linkedevents/migrations/0001_remove_allauth_remnants.py
+++ b/linkedevents/migrations/0001_remove_allauth_remnants.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def remove_contenttypes(apps, schema_editor):
+    content_type_model = apps.get_model("contenttypes", "ContentType")
+    content_type_model.objects.filter(app_label="account").delete()
+    content_type_model.objects.filter(app_label="socialaccount").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = []
+
+    tables_to_remove = [
+        "account_emailaddress",
+        "account_emailconfirmation",
+        "socialaccount_socialaccount",
+        "socialaccount_socialapp",
+        "socialaccount_socialapp_sites",
+        "socialaccount_socialtoken",
+    ]
+
+    operations = [
+        migrations.RunPython(remove_contenttypes),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS {}".format(", ".join(tables_to_remove))
+        ),
+    ]


### PR DESCRIPTION
In commit bf155e2 the dependency to django-allauth was removed. But that commit didn't clean allauth stuff away from the database. This commit does that.

A migration file handles the cleaning. The migration file is added to the linkedevents app.
