### PR TITLE
LINK-1589 | Use bleach to clean registration related text fields

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
 from rest_framework.fields import DateTimeField
 
 from events.models import Language
+from events.utils import clean_text_fields
 from registrations.exceptions import ConflictException
 from registrations.models import (
     Registration,
@@ -157,6 +158,8 @@ class SignUpSerializer(CreatedModifiedBaseSerializer):
         return instance
 
     def validate(self, data):
+        # Clean html tags from the text fields
+        data = clean_text_fields(data, strip=True)
         errors = {}
 
         if isinstance(self.instance, SignUp):
@@ -377,6 +380,8 @@ class CreateSignUpsSerializer(serializers.Serializer):
     def validate(self, data):
         reservation_code = data["reservation_code"]
         registration = data["registration"]
+        # Clean html tags from the text fields
+        data = clean_text_fields(data, strip=True)
 
         # Prevent to signup if enrolment is not open.
         # Raises 409 error if enrolment is not open
@@ -435,6 +440,8 @@ class SignUpGroupCreateSerializer(
     extra_info = serializers.CharField(required=False, allow_blank=True)
 
     def validate(self, data):
+        # Clean html tags from the text fields
+        data = clean_text_fields(data, strip=True)
         validated_data = super().validate(data)
 
         errors = {}
@@ -519,6 +526,8 @@ class SignUpGroupSerializer(CreatedModifiedBaseSerializer):
         return fields
 
     def validate(self, data):
+        # Clean html tags from the text fields
+        data = clean_text_fields(data, strip=True)
         validated_data = super().validate(data)
 
         errors = {}


### PR DESCRIPTION
## Description
- Move `clean_text_fields` method to `events/utils` to avoid circular imports 
- Sanitize `Signup`, `SignupGroup` and `Registration` serializers text fields

## Closes
[LINK-1589](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1589)

[LINK-1589]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ