### PR TITLE
Move dysfunctional deprecated kw validation from model.save to serializer

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2171,6 +2171,17 @@ class EventSerializer(BulkSerializerMixin, EditableLinkedEventsObjectSerializer)
         data = super().to_internal_value(data)
         return data
 
+    def validate_keywords(self, keywords):
+        for kw in keywords:
+            if kw.deprecated:
+                raise serializers.ValidationError(
+                    _("Deprecated keyword not allowed ({})").format(kw.pk)
+                )
+        return keywords
+
+    def validate_audience(self, audiences):
+        return self.validate_keywords(audiences)
+
     def validate(self, data):
         context = self.context
         user = self.context["request"].user

--- a/events/models.py
+++ b/events/models.py
@@ -1037,25 +1037,6 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
                     }
                 )
 
-        if (
-            self.keywords.filter(deprecated=True)
-            or self.audience.filter(deprecated=True)
-        ) and (not self.deleted):
-            raise ValidationError(
-                {
-                    "keywords": _(
-                        "Trying to save event with deprecated keywords "
-                        + str(self.keywords.filter(deprecated=True).values("id"))
-                        + " or "
-                        + str(self.audience.filter(deprecated=True).values("id"))
-                        + ". Please use up-to-date keywords."
-                    )
-                }
-            )
-
-        # if self.location__divisions__ocd_id__endswith == MUNIGEO_MUNI:
-        #     self.local = True
-
         super().save(*args, **kwargs)
 
         # needed to cache location event numbers

--- a/events/tests/test_event.py
+++ b/events/tests/test_event.py
@@ -1,18 +1,4 @@
 import pytest
-from rest_framework.exceptions import ValidationError
-
-
-@pytest.mark.django_db
-def test_event_cannot_have_deprecated_keyword(event, keyword):
-    keyword.deprecated = True
-    keyword.save()
-    event.keywords.set([keyword])
-    with pytest.raises(ValidationError):
-        event.save()
-    event.keywords.set([])
-    event.audience.set([keyword])
-    with pytest.raises(ValidationError):
-        event.save()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Previously Event.save did m2m validation on keywords, but that does not work as intended, as serializers update m2m relations after the model save is done. Therefore an event with deprecated keywords can not be updated, as the model cannot be saved before the deprecated keywords are  removed. Also validation logic belongs to the serializer, not the model save.

Ref https://helsinkisolutionoffice.atlassian.net/browse/LINK-1605