### PR TITLE
LINK-1641 | Audit Log to DB

### DIFF
--- a/audit_log/enums.py
+++ b/audit_log/enums.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class Operation(Enum):
+    CREATE = "CREATE"
+    READ = "READ"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+
+
+class Role(Enum):
+    ADMIN = "ADMIN"
+    USER = "USER"
+    EXTERNAL = "EXTERNAL"
+    SYSTEM = "SYSTEM"
+    ANONYMOUS = "ANONYMOUS"
+
+
+class Status(Enum):
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    FORBIDDEN = "FORBIDDEN"
+    REDIRECT = "REDIRECT"

--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -1,0 +1,22 @@
+import re
+
+from django.conf import settings
+
+from audit_log.utils import commit_to_audit_log
+
+_AUDIT_LOGGED_ENDPOINTS_RE = re.compile(r"^/(v1|v0.1|gdpr-api)/")
+
+
+class AuditLogMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if settings.AUDIT_LOG_ENABLED and re.match(
+            _AUDIT_LOGGED_ENDPOINTS_RE, request.path
+        ):
+            commit_to_audit_log(request, response)
+
+        return response

--- a/audit_log/tests/conftest.py
+++ b/audit_log/tests/conftest.py
@@ -1,0 +1,45 @@
+from functools import wraps
+
+import pytest
+from django.conf import settings
+
+from audit_log.models import AuditLogEntry
+
+
+@pytest.mark.django_db
+@pytest.fixture(autouse=True)
+def use_audit_log(request):
+    audit_log_enabled = (
+        settings.AUDIT_LOG_ENABLED and "no_use_audit_log" not in request.keywords
+    )
+
+    if audit_log_enabled:
+        assert AuditLogEntry.objects.exists() is False
+
+    yield
+
+    if audit_log_enabled:
+        assert AuditLogEntry.objects.exists() is True
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def use_audit_log_class(request):
+    if settings.AUDIT_LOG_ENABLED:
+
+        def audit_log_test_wrapper(test_function):
+            @wraps(test_function)
+            def wrapper(*args, **kwargs):
+                assert AuditLogEntry.objects.exists() is False
+
+                test_function()
+
+                assert AuditLogEntry.objects.exists() is True
+
+            return wrapper
+
+        setattr(
+            request.cls,
+            request.function.__name__,
+            audit_log_test_wrapper(request.function),
+        )

--- a/audit_log/tests/conftest.py
+++ b/audit_log/tests/conftest.py
@@ -8,9 +8,9 @@ from audit_log.models import AuditLogEntry
 
 @pytest.mark.django_db
 @pytest.fixture(autouse=True)
-def use_audit_log(request):
+def test_audit_log(request):
     audit_log_enabled = (
-        settings.AUDIT_LOG_ENABLED and "no_use_audit_log" not in request.keywords
+        settings.AUDIT_LOG_ENABLED and "no_test_audit_log" not in request.keywords
     )
 
     if audit_log_enabled:
@@ -24,7 +24,7 @@ def use_audit_log(request):
 
 @pytest.mark.django_db
 @pytest.fixture
-def use_audit_log_class(request):
+def test_audit_log_class(request):
     if settings.AUDIT_LOG_ENABLED:
 
         def audit_log_test_wrapper(test_function):

--- a/audit_log/tests/test_middleware.py
+++ b/audit_log/tests/test_middleware.py
@@ -5,7 +5,7 @@ import pytest
 from audit_log.middleware import AuditLogMiddleware
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize("audit_log_enabled", [True, False])
 def test_middleware_audit_log_setting(settings, audit_log_enabled):
     settings.AUDIT_LOG_ENABLED = audit_log_enabled
@@ -16,7 +16,7 @@ def test_middleware_audit_log_setting(settings, audit_log_enabled):
         assert mocked.called is audit_log_enabled
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "path,expected_called",
     [

--- a/audit_log/tests/test_middleware.py
+++ b/audit_log/tests/test_middleware.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from audit_log.middleware import AuditLogMiddleware
+
+
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize("audit_log_enabled", [True, False])
+def test_middleware_audit_log_setting(settings, audit_log_enabled):
+    settings.AUDIT_LOG_ENABLED = audit_log_enabled
+
+    with patch("audit_log.middleware.commit_to_audit_log") as mocked:
+        middleware = AuditLogMiddleware(Mock())
+        middleware(Mock(path="/v1/"))
+        assert mocked.called is audit_log_enabled
+
+
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize(
+    "path,expected_called",
+    [
+        ("/v1/signup/", True),
+        ("/v0.1/signup/", True),
+        ("/gdpr-api/v1/user/uuid/", True),
+        ("/admin/", False),
+        ("/pysocial/", False),
+        ("/helusers/", False),
+        ("/", False),
+    ],
+)
+@pytest.mark.django_db
+def test_middleware_audit_logged_paths(settings, path, expected_called):
+    settings.AUDIT_LOG_ENABLED = True
+
+    with patch("audit_log.middleware.commit_to_audit_log") as mocked:
+        middleware = AuditLogMiddleware(Mock())
+        middleware(Mock(path=path))
+        assert mocked.called is expected_called

--- a/audit_log/tests/test_utils.py
+++ b/audit_log/tests/test_utils.py
@@ -24,7 +24,7 @@ def _assert_basic_log_entry_data(log_entry):
 
 
 @freeze_time("2023-10-17 13:30:00+02:00")
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "status_code,audit_status",
     [
@@ -71,7 +71,7 @@ def test_commit_to_audit_log_response_status(status_code, audit_status):
 
 
 @freeze_time("2023-10-17 13:30:00+02:00")
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "http_method,audit_operation",
     [
@@ -108,7 +108,7 @@ def test_commit_to_audit_log_crud_operations(http_method, audit_operation):
 
 
 @freeze_time("2023-10-17 13:30:00+02:00")
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "user_role,audit_role",
     [
@@ -166,7 +166,7 @@ def test_commit_to_audit_log_actor_data(user_role, audit_role):
     _assert_basic_log_entry_data(log_entry)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "remote_address,expected,x_forwarded_for",
     [

--- a/audit_log/tests/test_utils.py
+++ b/audit_log/tests/test_utils.py
@@ -1,0 +1,198 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from freezegun import freeze_time
+
+from audit_log.enums import Operation, Role, Status
+from audit_log.models import AuditLogEntry
+from audit_log.utils import _get_remote_address, commit_to_audit_log
+from events.tests.factories import ApiKeyUserFactory, OrganizationFactory
+from helevents.tests.factories import UserFactory
+
+
+def _assert_basic_log_entry_data(log_entry):
+    current_time = datetime.now(tz=timezone.utc)
+    iso_8601_date = f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z"
+
+    assert log_entry.message["audit_event"]["origin"] == "linkedevents"
+    assert log_entry.message["audit_event"]["date_time_epoch"] == int(
+        current_time.timestamp() * 1000
+    )
+    assert log_entry.message["audit_event"]["date_time"] == iso_8601_date
+
+
+@freeze_time("2023-10-17 13:30:00+02:00")
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize(
+    "status_code,audit_status",
+    [
+        (200, Status.SUCCESS.value),
+        (201, Status.SUCCESS.value),
+        (204, Status.SUCCESS.value),
+        (299, Status.SUCCESS.value),
+        (301, Status.REDIRECT.value),
+        (307, Status.REDIRECT.value),
+        (308, Status.REDIRECT.value),
+        (399, Status.REDIRECT.value),
+        (400, Status.FAILED.value),
+        (401, Status.FORBIDDEN.value),
+        (403, Status.FORBIDDEN.value),
+        (405, Status.FAILED.value),
+        (409, Status.FAILED.value),
+        (499, Status.FAILED.value),
+        (500, Status.FAILED.value),
+        (502, Status.FAILED.value),
+        (599, Status.FAILED.value),
+        (None, Status.FAILED.value),
+    ],
+)
+@pytest.mark.django_db
+def test_commit_to_audit_log_response_status(status_code, audit_status):
+    user = UserFactory()
+
+    req_mock = Mock(
+        method="GET",
+        user=user,
+        path="/v1/endpoint",
+        headers={"x-forwarded-for": "1.2.3.4:80"},
+    )
+    res_mock = Mock(status_code=status_code)
+
+    assert AuditLogEntry.objects.count() == 0
+
+    commit_to_audit_log(req_mock, res_mock)
+
+    assert AuditLogEntry.objects.count() == 1
+    log_entry = AuditLogEntry.objects.first()
+    assert log_entry.message["audit_event"]["status"] == audit_status
+    _assert_basic_log_entry_data(log_entry)
+
+
+@freeze_time("2023-10-17 13:30:00+02:00")
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize(
+    "http_method,audit_operation",
+    [
+        ("GET", Operation.READ.value),
+        ("HEAD", Operation.READ.value),
+        ("OPTIONS", Operation.READ.value),
+        ("POST", Operation.CREATE.value),
+        ("PUT", Operation.UPDATE.value),
+        ("PATCH", Operation.UPDATE.value),
+        ("DELETE", Operation.DELETE.value),
+    ],
+)
+@pytest.mark.django_db
+def test_commit_to_audit_log_crud_operations(http_method, audit_operation):
+    user = UserFactory()
+
+    req_mock = Mock(
+        method=http_method,
+        user=user,
+        path="/v1/endpoint",
+        headers={"x-forwarded-for": "1.2.3.4:80"},
+    )
+    res_mock = Mock(status_code=200)
+
+    assert AuditLogEntry.objects.count() == 0
+
+    commit_to_audit_log(req_mock, res_mock)
+
+    assert AuditLogEntry.objects.count() == 1
+    log_entry = AuditLogEntry.objects.first()
+    assert log_entry.message["audit_event"]["operation"] == audit_operation
+    assert log_entry.message["audit_event"]["target"] == "/v1/endpoint"
+    _assert_basic_log_entry_data(log_entry)
+
+
+@freeze_time("2023-10-17 13:30:00+02:00")
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize(
+    "user_role,audit_role",
+    [
+        ("admin", Role.ADMIN.value),
+        ("registration_admin", Role.ADMIN.value),
+        ("regular_user", Role.USER.value),
+        ("anonymous", Role.ANONYMOUS.value),
+        ("apikey_user", Role.ADMIN.value),
+        ("superuser", Role.ADMIN.value),
+        ("system", Role.SYSTEM.value),
+    ],
+)
+@pytest.mark.django_db
+def test_commit_to_audit_log_actor_data(user_role, audit_role):
+    organization = OrganizationFactory()
+
+    if user_role == "apikey_user":
+        user = ApiKeyUserFactory(data_source__owner=organization)
+    elif user_role == "anonymous":
+        user = AnonymousUser()
+    elif user_role == "system":
+        user = None
+    else:
+        user = UserFactory(is_superuser=user_role == "superuser")
+
+    org_role_mapping = {
+        "admin": lambda usr: usr.admin_organizations.add(organization),
+        "registration_admin": lambda usr: usr.registration_admin_organizations.add(
+            organization
+        ),
+        "regular_user": lambda usr: usr.organization_memberships.add(organization),
+    }
+    org_role = org_role_mapping.get(user_role)
+    if callable(org_role):
+        org_role(user)
+
+    req_mock = Mock(
+        method="GET",
+        user=user,
+        path="/v1/endpoint",
+        headers={"x-forwarded-for": "1.2.3.4:80"},
+    )
+    res_mock = Mock(status_code=200)
+
+    assert AuditLogEntry.objects.count() == 0
+
+    commit_to_audit_log(req_mock, res_mock)
+
+    assert AuditLogEntry.objects.count() == 1
+    log_entry = AuditLogEntry.objects.first()
+    assert log_entry.message["audit_event"]["actor"]["role"] == audit_role
+    assert log_entry.message["audit_event"]["actor"]["ip_address"] == "1.2.3.4"
+    if hasattr(user, "uuid"):
+        assert log_entry.message["audit_event"]["actor"]["uuid"] == str(user.uuid)
+    _assert_basic_log_entry_data(log_entry)
+
+
+@pytest.mark.no_use_audit_log
+@pytest.mark.parametrize(
+    "remote_address,expected,x_forwarded_for",
+    [
+        ("1.2.3.4:443", "1.2.3.4", True),
+        ("1.2.3.4", "1.2.3.4", True),
+        (
+            "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            True,
+        ),
+        (
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            True,
+        ),
+        ("1.2.3.4", "1.2.3.4", False),
+        (
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            False,
+        ),
+    ],
+)
+def test_get_remote_address(remote_address, expected, x_forwarded_for):
+    req_mock = Mock(
+        headers={"x-forwarded-for": remote_address} if x_forwarded_for else {},
+        META={"REMOTE_ADDR": remote_address} if not x_forwarded_for else {},
+    )
+    assert _get_remote_address(req_mock) == expected

--- a/audit_log/utils.py
+++ b/audit_log/utils.py
@@ -37,10 +37,10 @@ def _get_operation_name(request):
 
 
 def _get_remote_address(request):
-    if not request.headers.get("x-forwarded-for"):
+    if not (x_forwarded_for := request.headers.get("x-forwarded-for")):
         return request.META.get("REMOTE_ADDR")
 
-    remote_addr = request.headers.get("x-forwarded-for", "").split(",")[0]
+    remote_addr = x_forwarded_for.split(",")[0]
 
     # Remove port number from remote_addr
     if "." in remote_addr and ":" in remote_addr:

--- a/audit_log/utils.py
+++ b/audit_log/utils.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+
+from audit_log.enums import Operation, Role, Status
+from audit_log.models import AuditLogEntry
+from events.auth import ApiKeyUser
+
+_OPERATION_MAPPING = {
+    "GET": Operation.READ.value,
+    "HEAD": Operation.READ.value,
+    "OPTIONS": Operation.READ.value,
+    "POST": Operation.CREATE.value,
+    "PUT": Operation.UPDATE.value,
+    "PATCH": Operation.UPDATE.value,
+    "DELETE": Operation.DELETE.value,
+}
+
+
+def _get_response_status(response):
+    if not getattr(response, "status_code", None):
+        return Status.FAILED.value
+
+    if 200 <= response.status_code < 300:
+        return Status.SUCCESS.value
+    elif 300 <= response.status_code < 400:
+        return Status.REDIRECT.value
+    elif response.status_code in (401, 403):
+        return Status.FORBIDDEN.value
+    else:
+        return Status.FAILED.value
+
+
+def _get_operation_name(request):
+    return _OPERATION_MAPPING.get(request.method, f"Unknown: {request.method}")
+
+
+def _get_remote_address(request):
+    if not request.headers.get("x-forwarded-for"):
+        return request.META.get("REMOTE_ADDR")
+
+    remote_addr = request.headers.get("x-forwarded-for", "").split(",")[0]
+
+    # Remove port number from remote_addr
+    if "." in remote_addr and ":" in remote_addr:
+        # IPv4 with port (`x.x.x.x:x`)
+        remote_addr = remote_addr.split(":")[0]
+    elif "[" in remote_addr:
+        # IPv6 with port (`[:::]:x`)
+        remote_addr = remote_addr[1:].split("]")[0]
+
+    return remote_addr
+
+
+def _get_user_role(user):
+    if user is None:
+        return Role.SYSTEM.value
+
+    if isinstance(user, AnonymousUser):
+        return Role.ANONYMOUS.value
+
+    if (
+        user.is_superuser
+        or user.admin_organizations.exists()
+        or user.registration_admin_organizations.exists()
+        or isinstance(user, ApiKeyUser)
+        and user.apikey_registration_admin_organizations.exists()
+    ):
+        return Role.ADMIN.value
+
+    if user.is_external:
+        return Role.EXTERNAL.value
+
+    return Role.USER.value
+
+
+def _get_actor_data(request):
+    user = getattr(request, "user", None)
+    uuid = getattr(user, "uuid", None)
+
+    return {
+        "role": _get_user_role(user),
+        "uuid": str(uuid) if uuid else None,
+        "ip_address": _get_remote_address(request),
+    }
+
+
+def commit_to_audit_log(request, response):
+    current_time = datetime.now(tz=timezone.utc)
+    iso_8601_date = f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z"
+
+    message = {
+        "audit_event": {
+            "origin": settings.AUDIT_LOG_ORIGIN,
+            "status": _get_response_status(response),
+            "date_time_epoch": int(current_time.timestamp() * 1000),
+            "date_time": iso_8601_date,
+            "actor": _get_actor_data(request),
+            "operation": _get_operation_name(request),
+            "target": request.path,
+        }
+    }
+
+    AuditLogEntry.objects.create(message=message)

--- a/audit_log/utils.py
+++ b/audit_log/utils.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timezone
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 
 from audit_log.enums import Operation, Role, Status
 from audit_log.models import AuditLogEntry
@@ -57,7 +56,7 @@ def _get_user_role(user):
     if user is None:
         return Role.SYSTEM.value
 
-    if isinstance(user, AnonymousUser):
+    if not user.is_authenticated:
         return Role.ANONYMOUS.value
 
     if (

--- a/audit_log/utils.py
+++ b/audit_log/utils.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timezone
-
 from django.conf import settings
+from django.utils import timezone
 
 from audit_log.enums import Operation, Role, Status
 from audit_log.models import AuditLogEntry
@@ -86,15 +85,15 @@ def _get_actor_data(request):
 
 
 def commit_to_audit_log(request, response):
-    current_time = datetime.now(tz=timezone.utc)
-    iso_8601_date = f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z"
+    current_time = timezone.now()
+    iso_8601_datetime = f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z"
 
     message = {
         "audit_event": {
             "origin": settings.AUDIT_LOG_ORIGIN,
             "status": _get_response_status(response),
             "date_time_epoch": int(current_time.timestamp() * 1000),
-            "date_time": iso_8601_date,
+            "date_time": iso_8601_datetime,
             "actor": _get_actor_data(request),
             "operation": _get_operation_name(request),
             "target": request.path,

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -14,6 +14,7 @@ from munigeo.models import (
 )
 from parler.utils.context import switch_language
 
+from audit_log.tests.conftest import *  # noqa
 from events.api import KeywordSerializer, LanguageSerializer, PlaceSerializer
 
 # events

--- a/events/tests/importers/test_enkora.py
+++ b/events/tests/importers/test_enkora.py
@@ -12,7 +12,7 @@ from events.models import Event
 
 
 class TestEnkoraImporter:
-    @pytest.mark.no_use_audit_log
+    @pytest.mark.no_test_audit_log
     @pytest.mark.django_db
     @pytest.mark.parametrize(
         "test_input_descriptions,expected_ages",
@@ -382,7 +382,7 @@ class TestEnkoraImporter:
             == expected_ages
         )
 
-    @pytest.mark.no_use_audit_log
+    @pytest.mark.no_test_audit_log
     @pytest.mark.django_db
     @pytest.mark.parametrize(
         "test_input_descriptions,expected_keywords",
@@ -1908,7 +1908,7 @@ class TestEnkoraImporter:
 
         return save_cnt
 
-    @pytest.mark.no_use_audit_log
+    @pytest.mark.no_test_audit_log
     @pytest.mark.django_db
     @patch("events.importer.enkora.Enkora._request_json")
     @patch("events.importer.enkora.EnkoraImporter._get_timestamps")

--- a/events/tests/importers/test_enkora.py
+++ b/events/tests/importers/test_enkora.py
@@ -12,6 +12,7 @@ from events.models import Event
 
 
 class TestEnkoraImporter:
+    @pytest.mark.no_use_audit_log
     @pytest.mark.django_db
     @pytest.mark.parametrize(
         "test_input_descriptions,expected_ages",
@@ -381,6 +382,7 @@ class TestEnkoraImporter:
             == expected_ages
         )
 
+    @pytest.mark.no_use_audit_log
     @pytest.mark.django_db
     @pytest.mark.parametrize(
         "test_input_descriptions,expected_keywords",
@@ -1906,6 +1908,7 @@ class TestEnkoraImporter:
 
         return save_cnt
 
+    @pytest.mark.no_use_audit_log
     @pytest.mark.django_db
     @patch("events.importer.enkora.Enkora._request_json")
     @patch("events.importer.enkora.EnkoraImporter._get_timestamps")

--- a/events/tests/importers/test_espoo.py
+++ b/events/tests/importers/test_espoo.py
@@ -44,7 +44,7 @@ class EventDataFactory(BaseDataFactory):
     publisher = None
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_parse_jsonld_id():
     assert ["tprek:8100", "espoo:asdfasdf"] == (
         [
@@ -76,7 +76,7 @@ def sleep(monkeypatch):
     return sleep_instance
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_get_data(requests_mock):
     url = "http://localhost"
     data = {"hello": "world"}
@@ -85,7 +85,7 @@ def test_get_data(requests_mock):
     assert mock.call_count == 1
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_get_max_retries(sleep):
     def build_response(status_code):
         response = HTTPResponse(Mock())
@@ -113,7 +113,7 @@ def test_get_max_retries(sleep):
         assert "Exceeded max retries" in str(error.value)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_list_data(requests_mock, sleep):
     url = "http://localhost/"
     mock = requests_mock.get(
@@ -131,7 +131,7 @@ def test_list_data(requests_mock, sleep):
     assert sleep.call_count == 2
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_list_max_pages(requests_mock, sleep):
     url = "http://localhost/"
     mock = requests_mock.get(url, json={"meta": {"next": url}, "data": []})
@@ -140,7 +140,7 @@ def test_list_max_pages(requests_mock, sleep):
     assert mock.call_count == settings.ESPOO_MAX_PAGES
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 def test_get_origin_objs(requests_mock, sleep):
     requests_mock.get("http://localhost/model/ds:id1/", json={"id": "ds:id1"})
     requests_mock.get("http://localhost/model/ds:id2/", json={"id": "ds:id2"})
@@ -149,7 +149,7 @@ def test_get_origin_objs(requests_mock, sleep):
     assert objs == [{"id": "ds:id1"}, {"id": "ds:id2"}]
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_import_origin_objs():
     importer_ds = DataSourceFactory(id="importer_ds")
@@ -176,7 +176,7 @@ def test_import_origin_objs():
         Organization.objects.get(id=imported_unused_org.id)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_import_origin_objs_with_super_event():
     common_ds = DataSourceFactory(id="common_ds")
@@ -242,7 +242,7 @@ def test_import_origin_objs_with_super_event():
     assert recurring_event2.super_event_type == Event.SuperEventType.RECURRING
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_split_common_objs():
     common_ds = DataSourceFactory(id="common_ds")
@@ -353,7 +353,7 @@ def mock_org_list_response(requests_mock, pks=(1, 2, 3)):
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_importer(settings, requests_mock, sleep, api_client):
     settings.ESPOO_API_URL = "http://localhost/"

--- a/events/tests/importers/test_espoo.py
+++ b/events/tests/importers/test_espoo.py
@@ -44,6 +44,7 @@ class EventDataFactory(BaseDataFactory):
     publisher = None
 
 
+@pytest.mark.no_use_audit_log
 def test_parse_jsonld_id():
     assert ["tprek:8100", "espoo:asdfasdf"] == (
         [
@@ -75,6 +76,7 @@ def sleep(monkeypatch):
     return sleep_instance
 
 
+@pytest.mark.no_use_audit_log
 def test_get_data(requests_mock):
     url = "http://localhost"
     data = {"hello": "world"}
@@ -83,6 +85,7 @@ def test_get_data(requests_mock):
     assert mock.call_count == 1
 
 
+@pytest.mark.no_use_audit_log
 def test_get_max_retries(sleep):
     def build_response(status_code):
         response = HTTPResponse(Mock())
@@ -110,6 +113,7 @@ def test_get_max_retries(sleep):
         assert "Exceeded max retries" in str(error.value)
 
 
+@pytest.mark.no_use_audit_log
 def test_list_data(requests_mock, sleep):
     url = "http://localhost/"
     mock = requests_mock.get(
@@ -127,6 +131,7 @@ def test_list_data(requests_mock, sleep):
     assert sleep.call_count == 2
 
 
+@pytest.mark.no_use_audit_log
 def test_list_max_pages(requests_mock, sleep):
     url = "http://localhost/"
     mock = requests_mock.get(url, json={"meta": {"next": url}, "data": []})
@@ -135,6 +140,7 @@ def test_list_max_pages(requests_mock, sleep):
     assert mock.call_count == settings.ESPOO_MAX_PAGES
 
 
+@pytest.mark.no_use_audit_log
 def test_get_origin_objs(requests_mock, sleep):
     requests_mock.get("http://localhost/model/ds:id1/", json={"id": "ds:id1"})
     requests_mock.get("http://localhost/model/ds:id2/", json={"id": "ds:id2"})
@@ -143,6 +149,7 @@ def test_get_origin_objs(requests_mock, sleep):
     assert objs == [{"id": "ds:id1"}, {"id": "ds:id2"}]
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_import_origin_objs():
     importer_ds = DataSourceFactory(id="importer_ds")
@@ -169,6 +176,7 @@ def test_import_origin_objs():
         Organization.objects.get(id=imported_unused_org.id)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_import_origin_objs_with_super_event():
     common_ds = DataSourceFactory(id="common_ds")
@@ -234,6 +242,7 @@ def test_import_origin_objs_with_super_event():
     assert recurring_event2.super_event_type == Event.SuperEventType.RECURRING
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_split_common_objs():
     common_ds = DataSourceFactory(id="common_ds")
@@ -344,6 +353,7 @@ def mock_org_list_response(requests_mock, pks=(1, 2, 3)):
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_importer(settings, requests_mock, sleep, api_client):
     settings.ESPOO_API_URL = "http://localhost/"

--- a/events/tests/importers/test_harrastushaku.py
+++ b/events/tests/importers/test_harrastushaku.py
@@ -33,7 +33,7 @@ def importer():
     return HarrastushakuImporter(dict())
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "timestamp,expected",
     [
@@ -51,7 +51,7 @@ def test_get_datetime_from_data_success(timestamp, expected):
     assert dt.isoformat() == expected
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize("val", [None, False, ""])
 @pytest.mark.django_db
 def test_get_datetime_from_data_falsey(val):
@@ -62,7 +62,7 @@ def test_get_datetime_from_data_falsey(val):
     assert dt is None
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "start_date,end_date,timetables,expected",
     [
@@ -161,7 +161,7 @@ def test_build_sub_event_time_ranges(
     assert result == expected_subtime_ranges
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_get_event_offers__translated_fields(importer):
     """Test get_event_offers returns translated fields as expected."""
@@ -183,7 +183,7 @@ def test_get_event_offers__translated_fields(importer):
     assert data[0]["description"] == {"fi": "Kuvaus"}
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_map_harrastushaku_location_ids_to_tprek_ids(importer):
     """Check that different Place matching criteria works as expected."""

--- a/events/tests/importers/test_harrastushaku.py
+++ b/events/tests/importers/test_harrastushaku.py
@@ -33,6 +33,7 @@ def importer():
     return HarrastushakuImporter(dict())
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "timestamp,expected",
     [
@@ -50,6 +51,7 @@ def test_get_datetime_from_data_success(timestamp, expected):
     assert dt.isoformat() == expected
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize("val", [None, False, ""])
 @pytest.mark.django_db
 def test_get_datetime_from_data_falsey(val):
@@ -60,6 +62,7 @@ def test_get_datetime_from_data_falsey(val):
     assert dt is None
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "start_date,end_date,timetables,expected",
     [
@@ -158,6 +161,7 @@ def test_build_sub_event_time_ranges(
     assert result == expected_subtime_ranges
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_get_event_offers__translated_fields(importer):
     """Test get_event_offers returns translated fields as expected."""
@@ -179,6 +183,7 @@ def test_get_event_offers__translated_fields(importer):
     assert data[0]["description"] == {"fi": "Kuvaus"}
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_map_harrastushaku_location_ids_to_tprek_ids(importer):
     """Check that different Place matching criteria works as expected."""

--- a/events/tests/importers/test_kulke.py
+++ b/events/tests/importers/test_kulke.py
@@ -12,7 +12,7 @@ from events.tests.factories import DataSourceFactory, EventFactory, KeywordFacto
 from events.tests.utils import create_super_event
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -32,7 +32,7 @@ def test_parse_age_range_returns_correct_result(test_input, expected):
     assert parse_age_range(test_input) == expected
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -65,7 +65,7 @@ def test_parse_course_time_returns_correct_result(test_input, expected):
     assert parse_course_time(test_input) == expected
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestKulkeImporter(TestCase):
     def setUp(self) -> None:
         with patch.object(KulkeImporter, "fetch_kulke_categories", return_value={}):

--- a/events/tests/importers/test_kulke.py
+++ b/events/tests/importers/test_kulke.py
@@ -12,6 +12,7 @@ from events.tests.factories import DataSourceFactory, EventFactory, KeywordFacto
 from events.tests.utils import create_super_event
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -31,6 +32,7 @@ def test_parse_age_range_returns_correct_result(test_input, expected):
     assert parse_age_range(test_input) == expected
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "test_input,expected",
@@ -63,6 +65,7 @@ def test_parse_course_time_returns_correct_result(test_input, expected):
     assert parse_course_time(test_input) == expected
 
 
+@pytest.mark.no_use_audit_log
 class TestKulkeImporter(TestCase):
     def setUp(self) -> None:
         with patch.object(KulkeImporter, "fetch_kulke_categories", return_value={}):

--- a/events/tests/management/test_check_deprecated_yso_keywords.py
+++ b/events/tests/management/test_check_deprecated_yso_keywords.py
@@ -18,12 +18,12 @@ yso:p29911 a skosext:DeprecatedConcept,
         skos:Concept ;
     dct:isReplacedBy yso:p3065 ;
     owl:deprecated true .
-    
+
 yso:test_replacement_not_exists a skosext:DeprecatedConcept,
         skos:Concept ;
     dct:isReplacedBy yso:test_does_not_exist ;
     owl:deprecated true .
-    
+
 yso:test_replacement_invalid_yso_id a skosext:DeprecatedConcept,
         skos:Concept ;
     dct:isReplacedBy yso_foo:test_does_not_exist ;
@@ -33,7 +33,7 @@ yso:test_all_done a skosext:DeprecatedConcept,
         skos:Concept ;
     dct:isReplacedBy yso:p3065 ;
     owl:deprecated true .
-    
+
 """
 
 
@@ -98,6 +98,7 @@ def kw_deprecated_invalid_yso_id(yso_ds):
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_dryrun(
     requests_mock_graph,
@@ -112,6 +113,7 @@ def test_command_dryrun(
     assert "WOULD replace 1 keywords" in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_apply(
     requests_mock_graph,
@@ -129,6 +131,7 @@ def test_command_apply(
     assert "Replaced 1 keywords" in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_nothing_to_do(requests_mock_graph, kw_deprecated_and_replaced):
     out = StringIO()
@@ -136,6 +139,7 @@ def test_command_nothing_to_do(requests_mock_graph, kw_deprecated_and_replaced):
     assert "No keywords need or can be updated." in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_replacement_does_not_exist(
     requests_mock_graph, kw_deprecated_invalid_replacement
@@ -146,6 +150,7 @@ def test_command_replacement_does_not_exist(
     assert "No keywords need or can be updated." in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_replacement_is_invalid(
     requests_mock_graph, kw_deprecated_invalid_yso_id
@@ -156,6 +161,7 @@ def test_command_replacement_is_invalid(
     assert "No keywords need or can be updated." in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_command_replacement_all(
     requests_mock_graph,

--- a/events/tests/management/test_check_deprecated_yso_keywords.py
+++ b/events/tests/management/test_check_deprecated_yso_keywords.py
@@ -98,7 +98,7 @@ def kw_deprecated_invalid_yso_id(yso_ds):
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_dryrun(
     requests_mock_graph,
@@ -113,7 +113,7 @@ def test_command_dryrun(
     assert "WOULD replace 1 keywords" in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_apply(
     requests_mock_graph,
@@ -131,7 +131,7 @@ def test_command_apply(
     assert "Replaced 1 keywords" in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_nothing_to_do(requests_mock_graph, kw_deprecated_and_replaced):
     out = StringIO()
@@ -139,7 +139,7 @@ def test_command_nothing_to_do(requests_mock_graph, kw_deprecated_and_replaced):
     assert "No keywords need or can be updated." in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_replacement_does_not_exist(
     requests_mock_graph, kw_deprecated_invalid_replacement
@@ -150,7 +150,7 @@ def test_command_replacement_does_not_exist(
     assert "No keywords need or can be updated." in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_replacement_is_invalid(
     requests_mock_graph, kw_deprecated_invalid_yso_id
@@ -161,7 +161,7 @@ def test_command_replacement_is_invalid(
     assert "No keywords need or can be updated." in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_command_replacement_all(
     requests_mock_graph,

--- a/events/tests/management/test_create_languages.py
+++ b/events/tests/management/test_create_languages.py
@@ -7,6 +7,7 @@ from pytest_django.asserts import assertNumQueries
 from events.models import Language
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_create_languages():
     out = StringIO()
@@ -22,6 +23,7 @@ def test_create_languages():
         assert lang.name_en
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_create_languages_check_should_create():
     """Re-running the command does a cheap check."""

--- a/events/tests/management/test_create_languages.py
+++ b/events/tests/management/test_create_languages.py
@@ -7,7 +7,7 @@ from pytest_django.asserts import assertNumQueries
 from events.models import Language
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_create_languages():
     out = StringIO()
@@ -23,7 +23,7 @@ def test_create_languages():
         assert lang.name_en
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_create_languages_check_should_create():
     """Re-running the command does a cheap check."""

--- a/events/tests/management/test_remap_events.py
+++ b/events/tests/management/test_remap_events.py
@@ -12,6 +12,7 @@ def create_remap_file(tmp_path: Path, data: dict[str, str]) -> Path:
     return path
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_remap_events_with_apply(tmp_path, place, place2, event):
     remap_path = create_remap_file(tmp_path, {place.id: place2.id})
@@ -29,6 +30,7 @@ def test_remap_events_with_apply(tmp_path, place, place2, event):
     assert "Done" in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_remap_events_without_apply(tmp_path, place, place2, event):
     remap_path = create_remap_file(tmp_path, {place.id: place2.id})
@@ -46,6 +48,7 @@ def test_remap_events_without_apply(tmp_path, place, place2, event):
     assert "no changes applied" in out.getvalue()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_remap_events_target_does_not_exist(tmp_path, place, event):
     remap_path = create_remap_file(tmp_path, {place.id: "does_not_exist:1234"})

--- a/events/tests/management/test_remap_events.py
+++ b/events/tests/management/test_remap_events.py
@@ -12,7 +12,7 @@ def create_remap_file(tmp_path: Path, data: dict[str, str]) -> Path:
     return path
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_remap_events_with_apply(tmp_path, place, place2, event):
     remap_path = create_remap_file(tmp_path, {place.id: place2.id})
@@ -30,7 +30,7 @@ def test_remap_events_with_apply(tmp_path, place, place2, event):
     assert "Done" in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_remap_events_without_apply(tmp_path, place, place2, event):
     remap_path = create_remap_file(tmp_path, {place.id: place2.id})
@@ -48,7 +48,7 @@ def test_remap_events_without_apply(tmp_path, place, place2, event):
     assert "no changes applied" in out.getvalue()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_remap_events_target_does_not_exist(tmp_path, place, event):
     remap_path = create_remap_file(tmp_path, {place.id: "does_not_exist:1234"})

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -33,7 +33,7 @@ def test_api_page_size(api_client, event):
     assert len(resp.data["data"]) <= 100
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_get_authenticated_data_source_and_publisher(data_source):
     org = Organization.objects.create(
@@ -50,7 +50,7 @@ def test_get_authenticated_data_source_and_publisher(data_source):
     assert publisher == org
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_serializer_validate_publisher():
     data_source = DataSource.objects.create(
@@ -94,7 +94,7 @@ def test_serializer_validate_publisher():
     assert le_serializer.validate_publisher(org_2) == org_1
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestOrganizationListSerializer(TestCase):
     def setUp(self):
         data_source = DataSource.objects.create(
@@ -144,8 +144,8 @@ class TestOrganizationListSerializer(TestCase):
         self.assertTrue(has_regular_users)
 
 
-@pytest.mark.no_use_audit_log
-@pytest.mark.usefixtures("use_audit_log_class")
+@pytest.mark.no_test_audit_log
+@pytest.mark.usefixtures("test_audit_log_class")
 class TestOrganizationAPI(APITestCase):
     def setUp(self):
         data_source = DataSource.objects.create(
@@ -205,8 +205,8 @@ class TestOrganizationAPI(APITestCase):
         self.assertEqual(len(response.data["data"]), 0)
 
 
-@pytest.mark.no_use_audit_log
-@pytest.mark.usefixtures("use_audit_log_class")
+@pytest.mark.no_test_audit_log
+@pytest.mark.usefixtures("test_audit_log_class")
 class TestImageAPI(APITestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -294,7 +294,7 @@ class TestImageAPI(APITestCase):
         self.assertEqual(alt_text, "Lorem")
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "val,operator,expected_regex",
     [

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -294,6 +294,7 @@ class TestImageAPI(APITestCase):
         self.assertEqual(alt_text, "Lorem")
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "val,operator,expected_regex",
     [

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -33,6 +33,7 @@ def test_api_page_size(api_client, event):
     assert len(resp.data["data"]) <= 100
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_get_authenticated_data_source_and_publisher(data_source):
     org = Organization.objects.create(
@@ -49,6 +50,7 @@ def test_get_authenticated_data_source_and_publisher(data_source):
     assert publisher == org
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_serializer_validate_publisher():
     data_source = DataSource.objects.create(
@@ -92,6 +94,7 @@ def test_serializer_validate_publisher():
     assert le_serializer.validate_publisher(org_2) == org_1
 
 
+@pytest.mark.no_use_audit_log
 class TestOrganizationListSerializer(TestCase):
     def setUp(self):
         data_source = DataSource.objects.create(
@@ -141,6 +144,8 @@ class TestOrganizationListSerializer(TestCase):
         self.assertTrue(has_regular_users)
 
 
+@pytest.mark.no_use_audit_log
+@pytest.mark.usefixtures("use_audit_log_class")
 class TestOrganizationAPI(APITestCase):
     def setUp(self):
         data_source = DataSource.objects.create(
@@ -200,6 +205,8 @@ class TestOrganizationAPI(APITestCase):
         self.assertEqual(len(response.data["data"]), 0)
 
 
+@pytest.mark.no_use_audit_log
+@pytest.mark.usefixtures("use_audit_log_class")
 class TestImageAPI(APITestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_auth.py
+++ b/events/tests/test_auth.py
@@ -41,6 +41,7 @@ def do_authentication(user_uuid):
     return auth.authenticate(request)
 
 
+@pytest.mark.no_use_audit_log
 class TestApiKeyUser(TestCase):
     def setUp(self):
         self.data_source = DataSource.objects.create(
@@ -83,6 +84,7 @@ class TestApiKeyUser(TestCase):
         self.assertFalse(is_external)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_valid_jwt_is_accepted():
     """JWT generated in tests has a valid signature and is accepted."""

--- a/events/tests/test_auth.py
+++ b/events/tests/test_auth.py
@@ -41,7 +41,7 @@ def do_authentication(user_uuid):
     return auth.authenticate(request)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestApiKeyUser(TestCase):
     def setUp(self):
         self.data_source = DataSource.objects.create(
@@ -84,7 +84,7 @@ class TestApiKeyUser(TestCase):
         self.assertFalse(is_external)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_valid_jwt_is_accepted():
     """JWT generated in tests has a valid signature and is accepted."""

--- a/events/tests/test_caching.py
+++ b/events/tests/test_caching.py
@@ -4,7 +4,7 @@ from events.api import _get_queryset_from_cache, _get_queryset_from_cache_many
 from events.models import Event
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_queryset_from_cache(django_cache, event):
     django_cache.set("local_ids", {event.id: "lapsi"})
@@ -19,7 +19,7 @@ def test_queryset_from_cache(django_cache, event):
     assert queryset.first().id == event.id
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_missing_cache_not_throwing_error_and_returns_none(django_cache):
     django_cache.set("local_ids", {})
@@ -34,7 +34,7 @@ def test_missing_cache_not_throwing_error_and_returns_none(django_cache):
     assert queryset.first() == None
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_queryset_from_cache_many(django_cache, event):
     django_cache.set("local_ids", {event.id: "lapsi"})
@@ -49,7 +49,7 @@ def test_queryset_from_cache_many(django_cache, event):
     assert queryset.first().id == event.id
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_missing_cache_many_not_throwing_error_and_returns_none(django_cache):
     django_cache.set("local_ids", {})

--- a/events/tests/test_caching.py
+++ b/events/tests/test_caching.py
@@ -4,6 +4,7 @@ from events.api import _get_queryset_from_cache, _get_queryset_from_cache_many
 from events.models import Event
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_queryset_from_cache(django_cache, event):
     django_cache.set("local_ids", {event.id: "lapsi"})
@@ -18,6 +19,7 @@ def test_queryset_from_cache(django_cache, event):
     assert queryset.first().id == event.id
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_missing_cache_not_throwing_error_and_returns_none(django_cache):
     django_cache.set("local_ids", {})
@@ -32,6 +34,7 @@ def test_missing_cache_not_throwing_error_and_returns_none(django_cache):
     assert queryset.first() == None
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_queryset_from_cache_many(django_cache, event):
     django_cache.set("local_ids", {event.id: "lapsi"})
@@ -46,6 +49,7 @@ def test_queryset_from_cache_many(django_cache, event):
     assert queryset.first().id == event.id
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_missing_cache_many_not_throwing_error_and_returns_none(django_cache):
     django_cache.set("local_ids", {})

--- a/events/tests/test_event.py
+++ b/events/tests/test_event.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_deleted_event_can_have_deprecated_keyword(event, keyword):
     keyword.deprecated = True
@@ -14,6 +15,7 @@ def test_deleted_event_can_have_deprecated_keyword(event, keyword):
     event.save()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_event_cannot_replace_itself(event):
     event.replaced_by = event
@@ -22,6 +24,7 @@ def test_event_cannot_replace_itself(event):
         event.save()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_event_replacement(event, event2, event3):
     event.replaced_by = event2

--- a/events/tests/test_event.py
+++ b/events/tests/test_event.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_deleted_event_can_have_deprecated_keyword(event, keyword):
     keyword.deprecated = True
@@ -15,7 +15,7 @@ def test_deleted_event_can_have_deprecated_keyword(event, keyword):
     event.save()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_event_cannot_replace_itself(event):
     event.replaced_by = event
@@ -24,7 +24,7 @@ def test_event_cannot_replace_itself(event):
         event.save()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_event_replacement(event, event2, event3):
     event.replaced_by = event2

--- a/events/tests/test_event_auth_api.py
+++ b/events/tests/test_event_auth_api.py
@@ -14,12 +14,12 @@ from .utils import versioned_reverse as reverse
 
 @override_settings(ENABLE_EXTERNAL_USER_EVENTS=False)
 @pytest.mark.usefixtures(
-    "use_audit_log_class",
+    "test_audit_log_class",
     "make_complex_event_dict_class",
     "make_minimal_event_dict_class",
     "languages_class",
 )
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestEventAPI(APITestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_event_auth_api.py
+++ b/events/tests/test_event_auth_api.py
@@ -14,8 +14,12 @@ from .utils import versioned_reverse as reverse
 
 @override_settings(ENABLE_EXTERNAL_USER_EVENTS=False)
 @pytest.mark.usefixtures(
-    "make_complex_event_dict_class", "make_minimal_event_dict_class", "languages_class"
+    "use_audit_log_class",
+    "make_complex_event_dict_class",
+    "make_minimal_event_dict_class",
+    "languages_class",
 )
+@pytest.mark.no_use_audit_log
 class TestEventAPI(APITestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_event_filters.py
+++ b/events/tests/test_event_filters.py
@@ -6,7 +6,7 @@ from events.tests.factories import EventFactory
 from events.tests.utils import create_super_event
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_get_event_list_hide_recurring_children_true():
     event_1 = EventFactory()
@@ -22,7 +22,7 @@ def test_get_event_list_hide_recurring_children_true():
     assert super_1 in result
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_get_event_list_hide_recurring_children_false():
     event_1 = EventFactory()

--- a/events/tests/test_event_filters.py
+++ b/events/tests/test_event_filters.py
@@ -6,6 +6,7 @@ from events.tests.factories import EventFactory
 from events.tests.utils import create_super_event
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_get_event_list_hide_recurring_children_true():
     event_1 = EventFactory()
@@ -21,6 +22,7 @@ def test_get_event_list_hide_recurring_children_true():
     assert super_1 in result
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_get_event_list_hide_recurring_children_false():
     event_1 = EventFactory()

--- a/events/tests/test_events_search.py
+++ b/events/tests/test_events_search.py
@@ -18,8 +18,8 @@ for _key, val in settings.HAYSTACK_CONNECTIONS.items():
         val["INDEX_NAME"] = "test_%s" % val["INDEX_NAME"]
 
 
-@pytest.mark.no_use_audit_log
-@pytest.mark.usefixtures("use_audit_log_class")
+@pytest.mark.no_test_audit_log
+@pytest.mark.usefixtures("test_audit_log_class")
 class EventSearchTests(TestCase, TestDataMixin):
     def setUp(self):
         self.client = APIClient()

--- a/events/tests/test_events_search.py
+++ b/events/tests/test_events_search.py
@@ -1,6 +1,7 @@
 import datetime
 
 import haystack
+import pytest
 from django.conf import settings
 from django.test import TestCase
 from pytz import timezone
@@ -17,6 +18,8 @@ for _key, val in settings.HAYSTACK_CONNECTIONS.items():
         val["INDEX_NAME"] = "test_%s" % val["INDEX_NAME"]
 
 
+@pytest.mark.no_use_audit_log
+@pytest.mark.usefixtures("use_audit_log_class")
 class EventSearchTests(TestCase, TestDataMixin):
     def setUp(self):
         self.client = APIClient()

--- a/events/tests/test_importer_util.py
+++ b/events/tests/test_importer_util.py
@@ -4,6 +4,7 @@ from events.importer.util import replace_location
 from events.models import Event
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_replace_location_by_different_source(place, place2, other_data_source, event):
     assert event.location == place

--- a/events/tests/test_importer_util.py
+++ b/events/tests/test_importer_util.py
@@ -4,7 +4,7 @@ from events.importer.util import replace_location
 from events.models import Event
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_replace_location_by_different_source(place, place2, other_data_source, event):
     assert event.location == place

--- a/events/tests/test_keyword.py
+++ b/events/tests/test_keyword.py
@@ -5,6 +5,7 @@ from events.api import _find_keyword_replacements
 from events.tests.factories import KeywordFactory
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_cannot_replace_itself(keyword):
     keyword.replaced_by = keyword
@@ -13,6 +14,7 @@ def test_keyword_cannot_replace_itself(keyword):
         keyword.save()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_keyword_replacement(keyword, keyword2, keyword3):
     keyword.replaced_by = keyword2
@@ -24,6 +26,7 @@ def test_prevent_circular_keyword_replacement(keyword, keyword2, keyword3):
         keyword.save()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_is_automatically_deprecated_on_replace(keyword, keyword2):
     keyword.replaced_by = keyword2
@@ -31,6 +34,7 @@ def test_keyword_is_automatically_deprecated_on_replace(keyword, keyword2):
     assert keyword.deprecated
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_remap_keyword_set_on_replace(keyword, keyword2, keyword3, keyword_set):
     keyword.replaced_by = keyword3
@@ -40,6 +44,7 @@ def test_keyword_remap_keyword_set_on_replace(keyword, keyword2, keyword3, keywo
     assert set(keyword_set.keywords.all()) == set([keyword2, keyword3])
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_remap_event_on_replace(keyword, keyword2, event):
     event.keywords.set([keyword])
@@ -65,6 +70,7 @@ def test_keyword_remap_event_on_replace(keyword, keyword2, event):
     assert set(event.audience.all()) == set([keyword2])
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_is_none():
     keyword = KeywordFactory(deprecated=True)
@@ -72,6 +78,7 @@ def test_keyword_get_replacement_is_none():
     assert keyword.get_replacement() is None
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_single_level():
     new_keyword = KeywordFactory()
@@ -80,6 +87,7 @@ def test_keyword_get_replacement_single_level():
     assert old_keyword.get_replacement().pk == new_keyword.pk
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_multi_level():
     new_keyword = KeywordFactory()
@@ -89,6 +97,7 @@ def test_keyword_get_replacement_multi_level():
     assert old_keyword_2.get_replacement().pk == new_keyword.pk
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_find_keyword_replacements():
     new_keyword = KeywordFactory()

--- a/events/tests/test_keyword.py
+++ b/events/tests/test_keyword.py
@@ -5,7 +5,7 @@ from events.api import _find_keyword_replacements
 from events.tests.factories import KeywordFactory
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_cannot_replace_itself(keyword):
     keyword.replaced_by = keyword
@@ -14,7 +14,7 @@ def test_keyword_cannot_replace_itself(keyword):
         keyword.save()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_keyword_replacement(keyword, keyword2, keyword3):
     keyword.replaced_by = keyword2
@@ -26,7 +26,7 @@ def test_prevent_circular_keyword_replacement(keyword, keyword2, keyword3):
         keyword.save()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_is_automatically_deprecated_on_replace(keyword, keyword2):
     keyword.replaced_by = keyword2
@@ -34,7 +34,7 @@ def test_keyword_is_automatically_deprecated_on_replace(keyword, keyword2):
     assert keyword.deprecated
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_remap_keyword_set_on_replace(keyword, keyword2, keyword3, keyword_set):
     keyword.replaced_by = keyword3
@@ -44,7 +44,7 @@ def test_keyword_remap_keyword_set_on_replace(keyword, keyword2, keyword3, keywo
     assert set(keyword_set.keywords.all()) == set([keyword2, keyword3])
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_remap_event_on_replace(keyword, keyword2, event):
     event.keywords.set([keyword])
@@ -70,7 +70,7 @@ def test_keyword_remap_event_on_replace(keyword, keyword2, event):
     assert set(event.audience.all()) == set([keyword2])
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_is_none():
     keyword = KeywordFactory(deprecated=True)
@@ -78,7 +78,7 @@ def test_keyword_get_replacement_is_none():
     assert keyword.get_replacement() is None
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_single_level():
     new_keyword = KeywordFactory()
@@ -87,7 +87,7 @@ def test_keyword_get_replacement_single_level():
     assert old_keyword.get_replacement().pk == new_keyword.pk
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_get_replacement_multi_level():
     new_keyword = KeywordFactory()
@@ -97,7 +97,7 @@ def test_keyword_get_replacement_multi_level():
     assert old_keyword_2.get_replacement().pk == new_keyword.pk
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_find_keyword_replacements():
     new_keyword = KeywordFactory()

--- a/events/tests/test_keyword_get.py
+++ b/events/tests/test_keyword_get.py
@@ -145,7 +145,7 @@ def test_get_keyword_free_search(api_client, keyword, keyword2, keyword3):
     assert ids == [keyword.id, keyword2.id, keyword3.id]
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_list_keyword_query_counts(api_client, keyword, keyword2, keyword3, settings):
     """

--- a/events/tests/test_keyword_get.py
+++ b/events/tests/test_keyword_get.py
@@ -145,8 +145,9 @@ def test_get_keyword_free_search(api_client, keyword, keyword2, keyword3):
     assert ids == [keyword.id, keyword2.id, keyword3.id]
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
-def test_list_keyword_query_counts(api_client, keyword, keyword2, keyword3):
+def test_list_keyword_query_counts(api_client, keyword, keyword2, keyword3, settings):
     """
     Expect 5 queries when listing keywords
     1) COUNT
@@ -155,5 +156,7 @@ def test_list_keyword_query_counts(api_client, keyword, keyword2, keyword3):
     4) SELECT related keyword labels
     5) SELECT system data source
     """
+    settings.AUDIT_LOG_ENABLED = False
+
     with assertNumQueries(5):
         get_list(api_client, data={"show_all_keywords": True})

--- a/events/tests/test_keywordmatcher.py
+++ b/events/tests/test_keywordmatcher.py
@@ -5,6 +5,7 @@ from events.keywords import KeywordMatcher
 from events.models import KeywordLabel, Language
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_label_trigger(languages):
     """Triggers were added in Postgres to update search vectors each time a KeywordLabel in matching language is
@@ -42,6 +43,7 @@ def test_keyword_label_trigger(languages):
 #  matches is repeated.
 #  Syntactic dust - punctuation marks etc. - is ignored.
 #  If the language is specified the search is conducted only within the language specific search vectors.
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_match(languages, data_source, organization, keyword, keyword2):
     kl = KeywordLabel(language=Language.objects.get(id="fi"), name="lapsi")
@@ -59,6 +61,7 @@ def test_keyword_match(languages, data_source, organization, keyword, keyword2):
     assert matcher.match("[lapsi! teatteriin}", language="en") is None
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keyword_match_trgrm(languages, data_source, organization, keyword, keyword2):
     kl = KeywordLabel(language=Language.objects.get(id="fi"), name="asdfg")

--- a/events/tests/test_keywordmatcher.py
+++ b/events/tests/test_keywordmatcher.py
@@ -5,7 +5,7 @@ from events.keywords import KeywordMatcher
 from events.models import KeywordLabel, Language
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_label_trigger(languages):
     """Triggers were added in Postgres to update search vectors each time a KeywordLabel in matching language is
@@ -43,7 +43,7 @@ def test_keyword_label_trigger(languages):
 #  matches is repeated.
 #  Syntactic dust - punctuation marks etc. - is ignored.
 #  If the language is specified the search is conducted only within the language specific search vectors.
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_match(languages, data_source, organization, keyword, keyword2):
     kl = KeywordLabel(language=Language.objects.get(id="fi"), name="lapsi")
@@ -61,7 +61,7 @@ def test_keyword_match(languages, data_source, organization, keyword, keyword2):
     assert matcher.match("[lapsi! teatteriin}", language="en") is None
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keyword_match_trgrm(languages, data_source, organization, keyword, keyword2):
     kl = KeywordLabel(language=Language.objects.get(id="fi"), name="asdfg")

--- a/events/tests/test_keywordset_post.py
+++ b/events/tests/test_keywordset_post.py
@@ -23,6 +23,7 @@ def assert_create_keyword_set(api_client, keyword_set_data, data_source=None):
     return response
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_keywordset_cannot_have_deprecated_keyword(keyword, keyword_set):
     keyword.deprecated = True

--- a/events/tests/test_keywordset_post.py
+++ b/events/tests/test_keywordset_post.py
@@ -23,7 +23,7 @@ def assert_create_keyword_set(api_client, keyword_set_data, data_source=None):
     return response
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_keywordset_cannot_have_deprecated_keyword(keyword, keyword_set):
     keyword.deprecated = True

--- a/events/tests/test_models.py
+++ b/events/tests/test_models.py
@@ -8,7 +8,7 @@ from helevents.tests.factories import UserFactory
 from ..models import DataSource, Event, Image, KeywordSet, PublicationStatus
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestImage(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -79,7 +79,7 @@ class TestImage(TestCase):
         self.assertTrue(can_be_deleted)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestImageExternal(TestCase):
     def setUp(self):
         self.user = UserFactory()
@@ -108,7 +108,7 @@ class TestImageExternal(TestCase):
         self.assertFalse(can_be_edited)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestEvent(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -176,7 +176,7 @@ class TestEvent(TestCase):
         self.assertTrue(can_be_edited)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestKeywordSet(TestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_models.py
+++ b/events/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django_orghierarchy.models import Organization
@@ -7,6 +8,7 @@ from helevents.tests.factories import UserFactory
 from ..models import DataSource, Event, Image, KeywordSet, PublicationStatus
 
 
+@pytest.mark.no_use_audit_log
 class TestImage(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -77,6 +79,7 @@ class TestImage(TestCase):
         self.assertTrue(can_be_deleted)
 
 
+@pytest.mark.no_use_audit_log
 class TestImageExternal(TestCase):
     def setUp(self):
         self.user = UserFactory()
@@ -105,6 +108,7 @@ class TestImageExternal(TestCase):
         self.assertFalse(can_be_edited)
 
 
+@pytest.mark.no_use_audit_log
 class TestEvent(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -172,6 +176,7 @@ class TestEvent(TestCase):
         self.assertTrue(can_be_edited)
 
 
+@pytest.mark.no_use_audit_log
 class TestKeywordSet(TestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -72,7 +72,7 @@ def user_created_notification_template():
     return template
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_draft_event_deleted(event_deleted_notification_template, user, event):
     event.created_by = user
@@ -92,7 +92,7 @@ def test_draft_event_deleted(event_deleted_notification_template, user, event):
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_public_event_deleted_doesnt_trigger_notification(
     event_deleted_notification_template, user, event
@@ -103,7 +103,7 @@ def test_public_event_deleted_doesnt_trigger_notification(
     assert len(mail.outbox) == 0
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_event_published(event_published_notification_template, user, draft_event):
     draft_event.created_by = user
@@ -121,7 +121,7 @@ def test_event_published(event_published_notification_template, user, draft_even
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_draft_posted_as_super_event_sends(
     draft_posted_notification_template, user, draft_event
@@ -138,7 +138,7 @@ def test_draft_posted_as_super_event_sends(
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_draft_posted_created_by_admin_user_does_not_send(data_source, organization):
     admin = UserFactory()
@@ -153,7 +153,7 @@ def test_draft_posted_created_by_admin_user_does_not_send(data_source, organizat
     assert len(mail.outbox) == 0
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_recurring_child_event_saved_does_not_send(event):
     user = UserFactory()
@@ -169,7 +169,7 @@ def test_recurring_child_event_saved_does_not_send(event):
     assert len(mail.outbox) == 0
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_other_than_recurring_child_event_saved_does_send(event):
     user = UserFactory()
@@ -184,7 +184,7 @@ def test_other_than_recurring_child_event_saved_does_send(event):
     assert len(mail.outbox) == 1
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "uses_api_key, expect_email",
     [
@@ -214,7 +214,7 @@ def test_draft_notification_is_not_sent_when_using_api_key(
     assert bool(mail.outbox) == expect_email
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_user_created(user_created_notification_template, super_user):
     user = get_user_model().objects.create(

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -72,6 +72,7 @@ def user_created_notification_template():
     return template
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_draft_event_deleted(event_deleted_notification_template, user, event):
     event.created_by = user
@@ -91,6 +92,7 @@ def test_draft_event_deleted(event_deleted_notification_template, user, event):
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_public_event_deleted_doesnt_trigger_notification(
     event_deleted_notification_template, user, event
@@ -101,6 +103,7 @@ def test_public_event_deleted_doesnt_trigger_notification(
     assert len(mail.outbox) == 0
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_event_published(event_published_notification_template, user, draft_event):
     draft_event.created_by = user
@@ -118,6 +121,7 @@ def test_event_published(event_published_notification_template, user, draft_even
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_draft_posted_as_super_event_sends(
     draft_posted_notification_template, user, draft_event
@@ -134,6 +138,7 @@ def test_draft_posted_as_super_event_sends(
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_draft_posted_created_by_admin_user_does_not_send(data_source, organization):
     admin = UserFactory()
@@ -148,6 +153,7 @@ def test_draft_posted_created_by_admin_user_does_not_send(data_source, organizat
     assert len(mail.outbox) == 0
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_recurring_child_event_saved_does_not_send(event):
     user = UserFactory()
@@ -163,6 +169,7 @@ def test_recurring_child_event_saved_does_not_send(event):
     assert len(mail.outbox) == 0
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_other_than_recurring_child_event_saved_does_send(event):
     user = UserFactory()
@@ -177,6 +184,7 @@ def test_other_than_recurring_child_event_saved_does_send(event):
     assert len(mail.outbox) == 1
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "uses_api_key, expect_email",
     [
@@ -206,6 +214,7 @@ def test_draft_notification_is_not_sent_when_using_api_key(
     assert bool(mail.outbox) == expect_email
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_user_created(user_created_notification_template, super_user):
     user = get_user_model().objects.create(

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -90,6 +90,7 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
 @pytest.mark.parametrize(
     "is_admin,is_registration_admin,is_regular_user,expected",
     [
+        (True, True, True, False),
         (True, False, True, False),
         (True, False, False, False),
         (False, False, True, False),

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -10,7 +10,7 @@ from ..models import DataSource, Event, PublicationStatus
 from .factories import OrganizationFactory
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestUserModelPermissionMixin(TestCase):
     def setUp(self):
         self.instance = UserModelPermissionMixin()
@@ -42,7 +42,7 @@ class TestUserModelPermissionMixin(TestCase):
         )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "membership_status, expected_public, expected_draft",
     [
@@ -86,7 +86,7 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
         )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "is_admin,is_registration_admin,is_regular_user,expected",
     [
@@ -122,7 +122,7 @@ def test_user_is_external_based_on_group_membership(
         assert User().is_external is expected
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestUserModelPermissions(TestCase):
     def setUp(self):
         self.instance = User.objects.create()

--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -10,6 +10,7 @@ from ..models import DataSource, Event, PublicationStatus
 from .factories import OrganizationFactory
 
 
+@pytest.mark.no_use_audit_log
 class TestUserModelPermissionMixin(TestCase):
     def setUp(self):
         self.instance = UserModelPermissionMixin()
@@ -41,6 +42,7 @@ class TestUserModelPermissionMixin(TestCase):
         )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "membership_status, expected_public, expected_draft",
     [
@@ -84,18 +86,22 @@ def test_can_edit_event(membership_status, expected_public, expected_draft):
         )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
-    "is_admin,is_regular_user,expected",
+    "is_admin,is_registration_admin,is_regular_user,expected",
     [
-        (True, True, False),
-        (True, False, False),
-        (False, True, False),
-        (False, False, True),
+        (True, False, True, False),
+        (True, False, False, False),
+        (False, False, True, False),
+        (True, True, False, False),
+        (False, True, True, False),
+        (False, True, False, False),
+        (False, False, False, True),
     ],
 )
 @pytest.mark.django_db
 def test_user_is_external_based_on_group_membership(
-    is_admin, is_regular_user, expected
+    is_admin, is_registration_admin, is_regular_user, expected
 ):
     with (
         patch.object(
@@ -104,13 +110,18 @@ def test_user_is_external_based_on_group_membership(
         patch.object(
             User, "admin_organizations", new_callable=MagicMock
         ) as admin_organizations,
+        patch.object(
+            User, "registration_admin_organizations", new_callable=MagicMock
+        ) as registration_admin_organizations,
     ):
         organization_memberships.exists.return_value = is_regular_user
         admin_organizations.exists.return_value = is_admin
+        registration_admin_organizations.exists.return_value = is_registration_admin
 
         assert User().is_external is expected
 
 
+@pytest.mark.no_use_audit_log
 class TestUserModelPermissions(TestCase):
     def setUp(self):
         self.instance = User.objects.create()

--- a/events/tests/test_place.py
+++ b/events/tests/test_place.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.gis.geos import Point
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "position, is_division_expected",
     [(None, False), (Point(1000, 1000), False), (Point(100, 100), True)],
@@ -21,7 +21,7 @@ def test_place_divisions_by_position(
         assert place.divisions.count() == 0
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "division_type, is_division_expected",
     [
@@ -47,7 +47,7 @@ def test_place_divisions_by_division_type(
         assert place.divisions.count() == 0
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_place_cannot_replace_itself(place):
     place.replaced_by = place
@@ -56,7 +56,7 @@ def test_place_cannot_replace_itself(place):
         place.save()
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_place_replacement(place, place2, place3):
     place.replaced_by = place2

--- a/events/tests/test_place.py
+++ b/events/tests/test_place.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.gis.geos import Point
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "position, is_division_expected",
     [(None, False), (Point(1000, 1000), False), (Point(100, 100), True)],
@@ -20,6 +21,7 @@ def test_place_divisions_by_position(
         assert place.divisions.count() == 0
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.parametrize(
     "division_type, is_division_expected",
     [
@@ -45,6 +47,7 @@ def test_place_divisions_by_division_type(
         assert place.divisions.count() == 0
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_place_cannot_replace_itself(place):
     place.replaced_by = place
@@ -53,6 +56,7 @@ def test_place_cannot_replace_itself(place):
         place.save()
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_prevent_circular_place_replacement(place, place2, place3):
     place.replaced_by = place2

--- a/events/tests/test_place_get.py
+++ b/events/tests/test_place_get.py
@@ -200,7 +200,7 @@ def test_get_place_with_upcoming_events(api_client, place, place2, event, past_e
     assert place2.id in ids
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_list_place_query_counts(api_client, place, place2, place3, settings):
     """

--- a/events/tests/test_place_get.py
+++ b/events/tests/test_place_get.py
@@ -200,8 +200,9 @@ def test_get_place_with_upcoming_events(api_client, place, place2, event, past_e
     assert place2.id in ids
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
-def test_list_place_query_counts(api_client, place, place2, place3):
+def test_list_place_query_counts(api_client, place, place2, place3, settings):
     """
     Expect 7 queries when listing places
     1) COUNT
@@ -212,5 +213,7 @@ def test_list_place_query_counts(api_client, place, place2, place3):
     6) SELECT related division translations
     7) SELECT system data source
     """
+    settings.AUDIT_LOG_ENABLED = False
+
     with assertNumQueries(7):
         get_list(api_client, data={"show_all_places": True})

--- a/events/tests/test_signals.py
+++ b/events/tests/test_signals.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django_orghierarchy.models import Organization
@@ -5,6 +6,7 @@ from django_orghierarchy.models import Organization
 from ..models import DataSource
 
 
+@pytest.mark.no_use_audit_log
 class TestOrganizationPostSave(TestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_signals.py
+++ b/events/tests/test_signals.py
@@ -6,7 +6,7 @@ from django_orghierarchy.models import Organization
 from ..models import DataSource
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestOrganizationPostSave(TestCase):
     def setUp(self):
         user_model = get_user_model()

--- a/events/tests/test_utils.py
+++ b/events/tests/test_utils.py
@@ -23,7 +23,7 @@ def local_tz():
     return pytz.timezone(django_settings.TIME_ZONE)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_parse_time_iso8601(local_tz):
     assert parse_time("2022-07-17T17:17:17+03:00") == (
@@ -32,7 +32,7 @@ def test_parse_time_iso8601(local_tz):
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_parse_time_iso8601_invalid_offset(local_tz):
     with pytest.raises(ParseError) as ex:
@@ -44,7 +44,7 @@ def test_parse_time_iso8601_invalid_offset(local_tz):
     assert "out of bounds" in str(ex.value)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_parse_time_invalid_format(local_tz):
     with pytest.raises(ParseError) as ex:
@@ -52,7 +52,7 @@ def test_parse_time_invalid_format(local_tz):
     assert "time in invalid format" in str(ex.value)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_parse_time_overflow_error(local_tz):
     # Underlying overflow error that needs to be separately
@@ -62,7 +62,7 @@ def test_parse_time_overflow_error(local_tz):
     assert "time in invalid format" in str(ex.value)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_parse_time_dst_handling(local_tz):
     assert parse_end_time("2022-3-27") == (
@@ -91,7 +91,7 @@ def test_parse_time_dst_handling(local_tz):
         assert parse_end_time("now") == (timezone.now(), False)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_start_of_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -102,7 +102,7 @@ def test_start_of_day(local_tz):
     assert start_of_day(utc_dt) == aware_dt
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_start_of_next_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -116,7 +116,7 @@ def test_start_of_next_day(local_tz):
     assert start_of_next_day(utc_dt) == aware_tomorrow_dt
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_start_of_previous_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -130,7 +130,7 @@ def test_start_of_previous_day(local_tz):
     assert start_of_previous_day(utc_dt) == aware_previous_dt
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_inconsistent_tz_default(api_client, minimal_event_dict, user, settings):
     """

--- a/events/tests/test_utils.py
+++ b/events/tests/test_utils.py
@@ -23,6 +23,7 @@ def local_tz():
     return pytz.timezone(django_settings.TIME_ZONE)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_parse_time_iso8601(local_tz):
     assert parse_time("2022-07-17T17:17:17+03:00") == (
@@ -31,6 +32,7 @@ def test_parse_time_iso8601(local_tz):
     )
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_parse_time_iso8601_invalid_offset(local_tz):
     with pytest.raises(ParseError) as ex:
@@ -42,6 +44,7 @@ def test_parse_time_iso8601_invalid_offset(local_tz):
     assert "out of bounds" in str(ex.value)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_parse_time_invalid_format(local_tz):
     with pytest.raises(ParseError) as ex:
@@ -49,6 +52,7 @@ def test_parse_time_invalid_format(local_tz):
     assert "time in invalid format" in str(ex.value)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_parse_time_overflow_error(local_tz):
     # Underlying overflow error that needs to be separately
@@ -58,6 +62,7 @@ def test_parse_time_overflow_error(local_tz):
     assert "time in invalid format" in str(ex.value)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_parse_time_dst_handling(local_tz):
     assert parse_end_time("2022-3-27") == (
@@ -86,6 +91,7 @@ def test_parse_time_dst_handling(local_tz):
         assert parse_end_time("now") == (timezone.now(), False)
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_start_of_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -96,6 +102,7 @@ def test_start_of_day(local_tz):
     assert start_of_day(utc_dt) == aware_dt
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_start_of_next_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -109,6 +116,7 @@ def test_start_of_next_day(local_tz):
     assert start_of_next_day(utc_dt) == aware_tomorrow_dt
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_start_of_previous_day(local_tz):
     naive_dt = datetime(2022, 3, 27)
@@ -122,6 +130,7 @@ def test_start_of_previous_day(local_tz):
     assert start_of_previous_day(utc_dt) == aware_previous_dt
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_inconsistent_tz_default(api_client, minimal_event_dict, user, settings):
     """

--- a/helevents/models.py
+++ b/helevents/models.py
@@ -266,4 +266,5 @@ class User(AbstractUser, UserModelPermissionMixin, SerializableMixin):
         return (
             not self.organization_memberships.exists()
             and not self.admin_organizations.exists()
+            and not self.registration_admin_organizations.exists()
         )

--- a/helevents/tests/conftest.py
+++ b/helevents/tests/conftest.py
@@ -3,6 +3,7 @@ import datetime
 from helusers.settings import api_token_auth_settings
 from jose import jwt
 
+from audit_log.tests.conftest import *  # noqa
 from events.tests.keys import rsa_key
 from linkedevents.tests.conftest import *  # noqa
 

--- a/helevents/tests/test_admin.py
+++ b/helevents/tests/test_admin.py
@@ -8,7 +8,7 @@ from django_orghierarchy.models import Organization
 from events.tests.factories import OrganizationFactory
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestLocalOrganizationAdmin(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/helevents/tests/test_admin.py
+++ b/helevents/tests/test_admin.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
@@ -7,6 +8,7 @@ from django_orghierarchy.models import Organization
 from events.tests.factories import OrganizationFactory
 
 
+@pytest.mark.no_use_audit_log
 class TestLocalOrganizationAdmin(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/helevents/tests/test_models.py
+++ b/helevents/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 from django_orghierarchy.models import Organization
 
@@ -6,6 +7,7 @@ from events.models import DataSource
 from ..models import User
 
 
+@pytest.mark.no_use_audit_log
 class TestUser(TestCase):
     def setUp(self):
         self.user = User.objects.create(username="testuser")

--- a/helevents/tests/test_models.py
+++ b/helevents/tests/test_models.py
@@ -7,7 +7,7 @@ from events.models import DataSource
 from ..models import User
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestUser(TestCase):
     def setUp(self):
         self.user = User.objects.create(username="testuser")

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -266,6 +266,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "events.middleware.AuthenticationCacheDisableMiddleware",
+    "audit_log.middleware.AuditLogMiddleware",
     "reversion.middleware.RevisionMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/linkedevents/tests/conftest.py
+++ b/linkedevents/tests/conftest.py
@@ -1,6 +1,5 @@
 import shutil
 
-import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -8,6 +7,7 @@ from django.core.management import call_command
 from django_orghierarchy.models import Organization, OrganizationClass
 from rest_framework.test import APIClient
 
+from audit_log.tests.conftest import *  # noqa
 from events.models import DataSource
 
 OTHER_DATA_SOURCE_ID = "testotherdatasourceid"

--- a/linkedevents/tests/test_api_root_view.py
+++ b/linkedevents/tests/test_api_root_view.py
@@ -34,6 +34,7 @@ def test_return_correct_routes(api_client):
     assert response.data.get("guest-feedback") is None
 
 
+@pytest.mark.django_db
 def test_has_correct_name(api_client):
     response = api_client.get(reverse("api-root"), HTTP_ACCEPT="text/html")
     assert "<h1>Linked Events</h1>" in str(response.content)

--- a/linkedevents/tests/test_sentry.py
+++ b/linkedevents/tests/test_sentry.py
@@ -5,7 +5,7 @@ from events.tests.factories import ApiKeyUserFactory
 from helevents.tests.factories import UserFactory
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_anonymize_user_repr_function():
     assert len(global_repr_processors) == 1

--- a/linkedevents/tests/test_sentry.py
+++ b/linkedevents/tests/test_sentry.py
@@ -5,6 +5,7 @@ from events.tests.factories import ApiKeyUserFactory
 from helevents.tests.factories import UserFactory
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_anonymize_user_repr_function():
     assert len(global_repr_processors) == 1

--- a/registrations/tests/conftest.py
+++ b/registrations/tests/conftest.py
@@ -1,17 +1,18 @@
 from django.utils import translation
 
+from audit_log.tests.conftest import *  # noqa
 from events.tests.conftest import *  # noqa
 from linkedevents.tests.conftest import *  # noqa
 from registrations.models import SignUp
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: F405
 def use_english():
     with translation.override("en"):
         yield
 
 
-@pytest.fixture
+@pytest.fixture  # noqa: F405
 def signup(registration):
     return SignUp.objects.create(
         registration=registration,
@@ -19,7 +20,7 @@ def signup(registration):
     )
 
 
-@pytest.fixture
+@pytest.fixture  # noqa: F405
 def signup2(registration):
     return SignUp.objects.create(
         registration=registration,
@@ -27,7 +28,7 @@ def signup2(registration):
     )
 
 
-@pytest.fixture
+@pytest.fixture  # noqa: F405
 def signup3(registration):
     return SignUp.objects.create(
         registration=registration,

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -23,7 +23,7 @@ def make_admin(username="testadmin", is_superuser=True):
     )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestRegistrationAdmin(TestCase):
     def setUp(self):
         self.admin = make_admin()

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
@@ -22,6 +23,7 @@ def make_admin(username="testadmin", is_superuser=True):
     )
 
 
+@pytest.mark.no_use_audit_log
 class TestRegistrationAdmin(TestCase):
     def setUp(self):
         self.admin = make_admin()

--- a/registrations/tests/test_commands.py
+++ b/registrations/tests/test_commands.py
@@ -12,6 +12,7 @@ _ENCRYPTION_KEY = "c87a6669a1ded2834f1dfd0830d86ef6cdd20372ac83e8c7c23feffe87e6a
 _ENCRYPTION_KEY2 = "f1a79d4b60a947b988beaf1eae871289fb03f2b9fd443d67107a7d05d05f831e"
 
 
+@pytest.mark.no_use_audit_log
 @pytest.mark.django_db
 def test_encrypt_fields_with_new_key(settings):
     old_keys = (_ENCRYPTION_KEY,)

--- a/registrations/tests/test_commands.py
+++ b/registrations/tests/test_commands.py
@@ -12,7 +12,7 @@ _ENCRYPTION_KEY = "c87a6669a1ded2834f1dfd0830d86ef6cdd20372ac83e8c7c23feffe87e6a
 _ENCRYPTION_KEY2 = "f1a79d4b60a947b988beaf1eae871289fb03f2b9fd443d67107a7d05d05f831e"
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 @pytest.mark.django_db
 def test_encrypt_fields_with_new_key(settings):
     old_keys = (_ENCRYPTION_KEY,)

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
@@ -11,6 +12,7 @@ from registrations.tests.factories import (
 )
 
 
+@pytest.mark.no_use_audit_log
 class TestRegistration(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -64,6 +66,7 @@ class TestRegistration(TestCase):
         self.assertTrue(can_be_edited)
 
 
+@pytest.mark.no_use_audit_log
 class TestRegistrationUserAccess(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -99,6 +102,7 @@ class TestRegistrationUserAccess(TestCase):
         self.assertTrue(can_be_edited)
 
 
+@pytest.mark.no_use_audit_log
 class TestSignUpGroup(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -163,6 +167,7 @@ class TestSignUpGroup(TestCase):
         self.assertEqual(self.signup_group.data_source.id, self.data_source.id)
 
 
+@pytest.mark.no_use_audit_log
 class TestSignUp(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -12,7 +12,7 @@ from registrations.tests.factories import (
 )
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestRegistration(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -66,7 +66,7 @@ class TestRegistration(TestCase):
         self.assertTrue(can_be_edited)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestRegistrationUserAccess(TestCase):
     def setUp(self):
         user_model = get_user_model()
@@ -102,7 +102,7 @@ class TestRegistrationUserAccess(TestCase):
         self.assertTrue(can_be_edited)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestSignUpGroup(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -167,7 +167,7 @@ class TestSignUpGroup(TestCase):
         self.assertEqual(self.signup_group.data_source.id, self.data_source.id)
 
 
-@pytest.mark.no_use_audit_log
+@pytest.mark.no_test_audit_log
 class TestSignUp(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ extend-ignore = E203
 DJANGO_SETTINGS_MODULE = linkedevents.test_settings
 norecursedirs = .git venv
 markers =
-    no_use_audit_log: don't automatically use the use_audit_log fixture
+    no_test_audit_log: don't automatically test audit logging with the test_audit_log fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,5 @@ extend-ignore = E203
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = linkedevents.test_settings
 norecursedirs = .git venv
+markers =
+    no_use_audit_log: don't automatically use the use_audit_log fixture


### PR DESCRIPTION
### Description
Adds audit logging for all events, registrations and GDPR API operations. This is achieved through `AuditLogMiddleware`. The log entries are stored into the DB as `AuditLogEntry` rows where the `message` field contains the log data.
### Closes
[LINK-1641](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1641)

[LINK-1641]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ