### PR TITLE
LINK-1618 | Mass Email to Attending Signups Only

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -142,7 +142,9 @@ class RegistrationViewSet(
             responsible_signups = (
                 signup_group.responsible_signups or signup_group.signups.all()
             )
-            for signup in responsible_signups.exclude(email=None):
+            for signup in responsible_signups.exclude(email=None).filter(
+                attendee_status=SignUp.AttendeeStatus.ATTENDING
+            ):
                 message_signups.append(signup)
                 already_included_signups.add(signup.pk)
 
@@ -190,7 +192,9 @@ class RegistrationViewSet(
         signups = serializer.validated_data.get("signups", [])
         if not (signup_groups or signups):
             signup_groups = registration.signup_groups.all()
-            signups = registration.signups.exclude(email=None)
+            signups = registration.signups.exclude(email=None).filter(
+                attendee_status=SignUp.AttendeeStatus.ATTENDING
+            )
 
         message_signups = self._get_message_signups(signups, signup_groups)
         messages = self._get_messages(

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -381,7 +381,7 @@ def test_cannot_send_message_with_nonexistent_registration_id(
 
 
 @pytest.mark.django_db
-def test__unauthenticated_user_cannot_send_message(api_client, registration):
+def test_unauthenticated_user_cannot_send_message(api_client, registration):
     api_client.force_authenticate(None)
 
     send_message_data = {"subject": "Message subject", "body": "Message body"}
@@ -391,7 +391,7 @@ def test__unauthenticated_user_cannot_send_message(api_client, registration):
 
 
 @pytest.mark.django_db
-def test__non_admin_cannot_send_message(api_client, registration, user):
+def test_non_admin_cannot_send_message(api_client, registration, user):
     user.get_default_organization().regular_users.add(user)
     user.get_default_organization().admin_users.remove(user)
     api_client.force_authenticate(user)
@@ -403,7 +403,7 @@ def test__non_admin_cannot_send_message(api_client, registration, user):
 
 
 @pytest.mark.django_db
-def test__user_from_other_organization_cannot_send_message(
+def test_user_from_other_organization_cannot_send_message(
     api_client, registration, user2
 ):
     api_client.force_authenticate(user2)
@@ -441,7 +441,7 @@ def test_registration_admin_can_send_message_with_missing_datasource_permission(
 
 
 @pytest.mark.django_db
-def test__api_key_with_organization_can_send_message(
+def test_api_key_with_organization_can_send_message(
     api_client, data_source, organization, registration, signup, signup2
 ):
     data_source.owner = organization
@@ -456,7 +456,7 @@ def test__api_key_with_organization_can_send_message(
 
 
 @pytest.mark.django_db
-def test__api_key_with_wrong_data_source_cannot_send_message(
+def test_api_key_with_wrong_data_source_cannot_send_message(
     api_client, organization, other_data_source, registration
 ):
     other_data_source.owner = organization
@@ -471,7 +471,7 @@ def test__api_key_with_wrong_data_source_cannot_send_message(
 
 
 @pytest.mark.django_db
-def test__unknown_api_key_cannot_send_message(api_client, registration):
+def test_unknown_api_key_cannot_send_message(api_client, registration):
     api_client.credentials(apikey="unknown")
 
     send_message_data = {"subject": "Message subject", "body": "Message body"}
@@ -481,7 +481,7 @@ def test__unknown_api_key_cannot_send_message(api_client, registration):
 
 
 @pytest.mark.django_db
-def test__empty_api_key_cannot_send_message(api_client, registration):
+def test_empty_api_key_cannot_send_message(api_client, registration):
     api_client.credentials(apikey="")
 
     send_message_data = {"subject": "Message subject", "body": "Message body"}


### PR DESCRIPTION
### Description
When sending a mass email to all signups, the email will now be sent to only those who have the status "attending". Wait-listed signups shouldn't get the email in this case.
### Closes
[LINK-1618](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1618)

[LINK-1618]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ