### PR TITLE
LINK-1637 | Don't move waitlisted to attending on waitlisted deletion

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -255,7 +255,7 @@ class Registration(CreatedModifiedBaseModel):
             .select_for_update()
             .order_by("id")
         )
-        if waitlisted.count() > 0:
+        if waitlisted.exists():
             first_on_list = waitlisted[0]
             first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
             first_on_list.save(update_fields=["attendee_status"])
@@ -333,6 +333,10 @@ class SignUpGroup(CreatedModifiedBaseModel, SignUpMixin, SerializableMixin):
     @cached_property
     def responsible_signups(self):
         return self.signups.filter(responsible_for_group=True)
+
+    @cached_property
+    def attending_signups(self):
+        return self.signups.filter(attendee_status=SignUp.AttendeeStatus.ATTENDING)
 
     def send_notification(self, notification_type):
         signups = self.responsible_signups or self.signups.all()

--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -8,7 +8,11 @@ from registrations.models import SignUp, SignUpGroup, SignUpNotificationType
 
 def _signup_or_group_post_delete(instance: Union[SignUp, SignUpGroup]) -> None:
     instance.send_notification(SignUpNotificationType.CANCELLATION)
-    instance.registration.move_first_waitlisted_to_attending()
+
+    attendee_status = getattr(instance, "attendee_status", "")
+    attending_signups = getattr(instance, "attending_signups", None)
+    if attendee_status == SignUp.AttendeeStatus.ATTENDING or attending_signups:
+        instance.registration.move_first_waitlisted_to_attending()
 
 
 @receiver(


### PR DESCRIPTION
### Description
When a waitlisted `SignUp` or a `SignUpGroup` that has only waitlisted signups is deleted, don't change the `attendee_status` of the first waitlisted signup to `attending`.

### Closes
[LINK-1637](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1637)

[LINK-1637]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ