### PR TITLE
LINK-1629 | Improve cron job performance

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -40,6 +40,8 @@ def recur_dict():
 
 
 class Importer(object):
+    default_timeout = 30
+
     def __init__(self, options):
         super().__init__()
         self.options = options

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -256,7 +256,7 @@ class HarrastushakuImporter(Importer):
         logger.debug("Fetching locations...")
         try:
             url = "{}location/".format(HARRASTUSHAKU_API_BASE_URL)
-            response = requests.get(url, verify=False)
+            response = requests.get(url, verify=False, timeout=self.default_timeout)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
@@ -267,7 +267,7 @@ class HarrastushakuImporter(Importer):
         logger.debug("Fetching courses...")
         try:
             url = "{}activity/".format(HARRASTUSHAKU_API_BASE_URL)
-            response = requests.get(url, verify=False)
+            response = requests.get(url, verify=False, timeout=self.default_timeout)
             response.raise_for_status()
             return response.json()["data"]
         except requests.RequestException as e:
@@ -570,7 +570,6 @@ class HarrastushakuImporter(Importer):
         return {"id": self.location_id_to_place_id.get(location_id)}
 
     def get_event_offers(self, activity_data):
-
         offers = []
 
         for price_data in activity_data.get("prices", ()):

--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -494,7 +494,7 @@ class HelmetImporter(Importer):
     def _recur_fetch_paginated_url(self, url, lang, events):
         max_tries = 5
         for try_number in range(0, max_tries):
-            response = requests.get(url)
+            response = requests.get(url, timeout=self.default_timeout)
             if response.status_code != 200:
                 logger.warning("HelMet API reported HTTP %d" % response.status_code)
                 time.sleep(2)

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -43,7 +43,6 @@ EVENTS_URL_TEMPLATE = urljoin(
     "event?searchstarttime={begin_date}&sort=starttime&show=100&offset={offset}&language={language}",
 )
 CATEGORY_URL = urljoin(settings.ELIS_EVENT_API_URL, "category")
-EVENT_API_TIMEOUT = 30
 
 
 LOCATION_TPREK_MAP = {
@@ -396,7 +395,7 @@ class KulkeImporter(Importer):
             self.event_only_license = None
 
     def fetch_kulke_categories(self) -> dict[str, Union[str, int]]:
-        response = requests.get(CATEGORY_URL, timeout=EVENT_API_TIMEOUT)
+        response = requests.get(CATEGORY_URL, timeout=self.default_timeout)
         response.raise_for_status()
         root = etree.fromstring(response.content)
         categories = {}
@@ -1004,7 +1003,7 @@ class KulkeImporter(Importer):
                 EVENTS_URL_TEMPLATE.format(
                     begin_date=begin_date, offset=offset, language=language
                 ),
-                timeout=EVENT_API_TIMEOUT,
+                timeout=self.default_timeout,
             )
             response.raise_for_status()
             root = etree.fromstring(response.content, parser=parser)

--- a/events/importer/lippupiste.py
+++ b/events/importer/lippupiste.py
@@ -263,7 +263,7 @@ class LippupisteImporter(Importer):
 
     def _fetch_event_source_data(self, url):
         # stream=True allows lazy iteration
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, timeout=self.default_timeout)
         response_iter = response.iter_lines()
         # CSV reader wants str instead of byte, let's decode
         decoded_response_iter = codecs.iterdecode(response_iter, "utf-8")

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -443,7 +443,7 @@ class MatkoImporter(Importer):
         return places
 
     def items_from_url(self, url):
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=self.default_timeout)
         assert resp.status_code == 200
         root = etree.fromstring(resp.content)
         return root.xpath("channel/item")

--- a/events/importer/mikkelinyt.py
+++ b/events/importer/mikkelinyt.py
@@ -43,7 +43,7 @@ class MikkeliNytImporter(Importer):
     def items_from_url(self, url):
         logger.info(url)
 
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=self.default_timeout)
         if resp.status_code == 200:
             return resp.json()["data"]
 
@@ -71,7 +71,7 @@ class MikkeliNytImporter(Importer):
         return url
 
     def strip_html(self, text):
-        result = re.sub(r"\<.*?>", " ", text, 0, re.MULTILINE)
+        result = re.sub(r"\<.*?>", " ", text, count=0, flags=re.MULTILINE)
         result = unescape(result)
         result = " ".join(result.split())
         return result.strip()

--- a/events/importer/tprek.py
+++ b/events/importer/tprek.py
@@ -53,7 +53,7 @@ class TprekImporter(Importer):
         if res_id is not None:
             url = "%s%s/" % (url, res_id)
         logger.info("Fetching URL %s" % url)
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=self.default_timeout)
         assert resp.status_code == 200
         return resp.json()
 

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -139,7 +139,7 @@ class YsoImporter(Importer):
 
     def load_graph_into_memory(self, url):
         logger.debug("Fetching %s" % url)
-        resp = requests.get(url)
+        resp = requests.get(url, timeout=self.default_timeout)
         assert resp.status_code == 200
         resp.encoding = "UTF-8"
         graph = rdflib.Graph()

--- a/helevents/service_tasks/daily_tasks.sh
+++ b/helevents/service_tasks/daily_tasks.sh
@@ -4,23 +4,23 @@ echo ---------------------------------
 echo "Starting daily import"
 echo ---------------------------------
 
-timeout --preserve-status -s INT 30m python manage.py event_import yso --all
+timeout --preserve-status -s INT 30m python manage.py event_import yso --all --disable-indexing
 if [ $? -ne 0 ]; then
     echo "YSO update signaled failure"
 fi
 
-timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --places
+timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --places --disable-indexing
 if [ $? -ne 0 ]; then
     echo "Harrastushaku places update signaled failure"
 fi
 
-timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --courses
+timeout --preserve-status -s INT 60m python manage.py event_import harrastushaku --courses --disable-indexing
 if [ $? -ne 0 ]; then
     echo "Harrastushaku courses update signaled failure"
 fi
 
 
-timeout --preserve-status -s INT 60m python manage.py event_import osoite --places
+timeout --preserve-status -s INT 60m python manage.py event_import osoite --places --disable-indexing
 if [ $? -ne 0 ]; then
     echo "PKS osoiteluettelo update signaled failure"
 fi

--- a/helevents/service_tasks/hourly_tasks.sh
+++ b/helevents/service_tasks/hourly_tasks.sh
@@ -4,33 +4,33 @@ echo ---------------------------------
 echo "Starting hourly tasks"
 echo ---------------------------------
 
-timeout --preserve-status -s INT 10m python manage.py event_import tprek --places
+timeout --preserve-status -s INT 10m python manage.py event_import tprek --places --disable-indexing
 if [ $? -ne 0 ]; then
     echo "tprek importer signaled failure"
 fi
 
 echo "--- Starting kulke importer ---"
 
-timeout --preserve-status -s INT 30m python manage.py event_import kulke --keywords
+timeout --preserve-status -s INT 30m python manage.py event_import kulke --keywords --disable-indexing
 if [ $? -ne 0 ]; then
     echo "kulke importer keyword import signaled failure"
 fi
 
-timeout --preserve-status -s INT 30m python manage.py event_import kulke --events
+timeout --preserve-status -s INT 30m python manage.py event_import kulke --events --disable-indexing
 if [ $? -ne 0 ]; then
     echo "kulke importer event import signaled failure"
 fi
 
 echo "--- Starting lippupiste importer ---"
 
-timeout --preserve-status -s INT 45m python manage.py event_import lippupiste --events
+timeout --preserve-status -s INT 45m python manage.py event_import lippupiste --events --disable-indexing
 if [ $? -ne 0 ]; then
     echo "lippupiste importer signaled failure"
 fi
 
 echo "--- Starting helmet importer ---"
 
-timeout --preserve-status -s INT 75m python manage.py event_import helmet --events
+timeout --preserve-status -s INT 75m python manage.py event_import helmet --events --disable-indexing
 if [ $? -ne 0 ]; then
     echo "helmet importer signaled failure"
 fi
@@ -58,7 +58,7 @@ fi
 
 echo "--- Starting haystack index update ---"
 
-nice python manage.py update_index -a 1
+nice python manage.py update_index -m 75
 if [ $? -ne 0 ]; then
     echo "haystack index update signaled failure"
 fi

--- a/linkedevents/urls.py
+++ b/linkedevents/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
-from django.urls import reverse
+from django.urls import path, re_path, reverse
 from django.views.generic import RedirectView
 
 from .api import LinkedEventsAPIRouter
@@ -17,15 +17,15 @@ class RedirectToAPIRootView(RedirectView):
 
 
 urlpatterns = [
-    url(r"^(?P<version>(v0.1|v1))/", include(api_router.urls)),
-    url(r"^admin/", admin.site.urls),
-    url(r"^pysocial/", include("social_django.urls", namespace="social")),
-    url(r"^helauth/", include("helusers.urls")),
-    url(r"^gdpr-api/", include("helsinki_gdpr.urls")),
-    url(r"^$", RedirectToAPIRootView.as_view()),
+    re_path(r"^(?P<version>(v0.1|v1))/", include(api_router.urls)),
+    path("admin/", admin.site.urls),
+    path("pysocial/", include("social_django.urls", namespace="social")),
+    path("helauth/", include("helusers.urls")),
+    path("gdpr-api/", include("helsinki_gdpr.urls")),
+    path("", RedirectToAPIRootView.as_view()),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
-    urlpatterns += [url(r"^__debug__/", include(debug_toolbar.urls))]
+    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]


### PR DESCRIPTION
This PR disables haystack's `RealtimeSignalProcessor` for all `event_import` calls in `hourly_tasks.sh` and `daily_tasks.sh`.

Also includes some additional improvements:
- Add default timeouts to all `request.get` calls in importers
- Replace deprecated `django.conf.urls.url`
