### PR TITLE
LINK-1629 | Reduce memory footprint of osoite.py

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -19,7 +19,6 @@ from events.models import Event, EventLink, Image, Language, Offer, Place
 from .. import utils
 from .util import clean_text, separate_scripts
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 EXTENSION_COURSE_FIELDS = (

--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -17,7 +17,6 @@ from events.models import DataSource, Event, Keyword, Place
 from .base import Importer, register_importer
 from .util import clean_text
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 

--- a/events/importer/espoo.py
+++ b/events/importer/espoo.py
@@ -22,7 +22,6 @@ from ..api import generate_id
 from .base import Importer, register_importer
 from .sync import ModelSyncher
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 M = TypeVar("M", bound=Model)

--- a/events/importer/harrastushaku.py
+++ b/events/importer/harrastushaku.py
@@ -19,7 +19,6 @@ from events.models import DataSource, Event, Keyword, Place
 
 from .base import Importer, register_importer
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 HARRASTUSHAKU_API_BASE_URL = "http://www.harrastushaku.fi/api/"

--- a/events/importer/helmet.py
+++ b/events/importer/helmet.py
@@ -20,7 +20,6 @@ from .sync import ModelSyncher
 from .util import clean_text
 from .yso import KEYWORDS_TO_ADD_TO_AUDIENCE
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 YSO_BASE_URL = "http://www.yso.fi/onto/yso/"

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -34,7 +34,6 @@ from .base import Importer, recur_dict, register_importer
 from .util import clean_url, unicodetext
 from .yso import KEYWORDS_TO_ADD_TO_AUDIENCE
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 

--- a/events/importer/lippupiste.py
+++ b/events/importer/lippupiste.py
@@ -20,7 +20,6 @@ from .base import Importer, recur_dict, register_importer
 from .sync import ModelSyncher
 from .util import clean_text, clean_url
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 YSO_KEYWORD_MAPS = {

--- a/events/importer/matko.py
+++ b/events/importer/matko.py
@@ -16,7 +16,6 @@ from events.models import DataSource, Event, Place
 from .base import Importer, recur_dict, register_importer
 from .util import clean_text, replace_location, unicodetext
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 MATKO_URLS = {

--- a/events/importer/osoite.py
+++ b/events/importer/osoite.py
@@ -14,6 +14,7 @@ from .sync import ModelSyncher
 logger = logging.getLogger(__name__)
 
 GK25_SRID = 3879
+CHUNK_SIZE = 10000
 
 
 @register_importer
@@ -180,7 +181,8 @@ class OsoiteImporter(Importer):
         else:
             logger.info("Loading addresses...")
             obj_list = self.pk_get("Address")
-            logger.info("%s addresses loaded" % len(obj_list))
+            logger.info(f"{obj_list.count()} addresses loaded")
+            obj_list = obj_list.iterator(chunk_size=CHUNK_SIZE)
         syncher = ModelSyncher(
             queryset,
             lambda obj: obj.origin_id,
@@ -189,7 +191,7 @@ class OsoiteImporter(Importer):
         )
         for idx, obj in enumerate(obj_list):
             if idx and (idx % 1000) == 0:
-                logger.info("%s addresses processed" % idx)
+                logger.info(f"{idx} addresses processed")
             self._import_address(syncher, obj)
 
         syncher.finish(self.options.get("remap", False))

--- a/events/importer/osoite.py
+++ b/events/importer/osoite.py
@@ -11,7 +11,6 @@ from events.models import DataSource, Place
 from .base import Importer, register_importer
 from .sync import ModelSyncher
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 GK25_SRID = 3879

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -1,5 +1,7 @@
 import logging
 
+CHUNK_SIZE = 10000
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +20,7 @@ class ModelSyncher(object):
         self.check_deleted_func = check_deleted_func
         self.allow_deleting_func = allow_deleting_func
         # Generate a list of all objects
-        for obj in queryset:
+        for obj in queryset.iterator(chunk_size=CHUNK_SIZE):
             d[generate_obj_id(obj)] = obj
             # this only resets the initial queryset, objects outside it may still have _found or _changed True
             obj._found = False

--- a/events/importer/sync.py
+++ b/events/importer/sync.py
@@ -1,6 +1,5 @@
 import logging
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 

--- a/events/importer/tprek.py
+++ b/events/importer/tprek.py
@@ -14,7 +14,6 @@ from events.models import DataSource, Place
 from .base import Importer, register_importer
 from .sync import ModelSyncher
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 URL_BASE = "http://www.hel.fi/palvelukarttaws/rest/v4/"

--- a/events/importer/util.py
+++ b/events/importer/util.py
@@ -8,7 +8,6 @@ from langdetect.lang_detect_exception import LangDetectException
 
 from events.models import Place
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 

--- a/events/importer/yso.py
+++ b/events/importer/yso.py
@@ -13,7 +13,6 @@ from events.models import BaseModel, DataSource, Keyword, KeywordLabel, Language
 from .base import Importer, register_importer
 from .sync import ModelSyncher
 
-# Per module logger
 logger = logging.getLogger(__name__)
 
 yso = rdflib.Namespace("http://www.yso.fi/onto/yso/")


### PR DESCRIPTION
This PR reduces the amount of memory used by `osoite.py` importer. Using an iterator makes sure the queryset does not cache it's result (which is not needed in this case).

Tested the importer locally. Memory consumption went from roughly 2,3 GB to 1,3 GB. Locally the change had hardly any effect on processing time. 