### PR TITLE
LINK-1564 | Send only parent draft event created notification

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -1064,6 +1064,11 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
             created
             and self.publication_status == PublicationStatus.DRAFT
             and not self.is_created_with_apikey
+            # Only send super event notification to avoid spamming from child events when recurring event.
+            and not (
+                self.super_event
+                and self.super_event.super_event_type == Event.SuperEventType.RECURRING
+            )
         ):
             self.send_draft_posted_notification()
 

--- a/events/models.py
+++ b/events/models.py
@@ -1069,6 +1069,8 @@ class Event(MPTTModel, BaseModel, SchemalessFieldMixin, ReplacedByMixin):
                 self.super_event
                 and self.super_event.super_event_type == Event.SuperEventType.RECURRING
             )
+            # Do not send draft emails from events created by admins.
+            and not self.publisher.admin_users.filter(id=self.created_by_id).exists()
         ):
             self.send_draft_posted_notification()
 

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -119,7 +119,9 @@ def test_event_published(event_published_notification_template, user, draft_even
 
 
 @pytest.mark.django_db
-def test_draft_posted(draft_posted_notification_template, user, draft_event):
+def test_draft_posted_as_super_event_sends(
+    draft_posted_notification_template, user, draft_event
+):
     strings = [
         "draft posted body, event name: %s!" % draft_event.name,
     ]
@@ -130,6 +132,33 @@ def test_draft_posted(draft_posted_notification_template, user, draft_event):
         strings,
         html_body=html_body,
     )
+
+
+@pytest.mark.django_db
+def test_recurring_child_event_saved_does_not_send(user, event):
+    event.super_event_type = event.SuperEventType.RECURRING
+    EventFactory(
+        name="testeventzor",
+        data_source=event.data_source,
+        publisher=event.publisher,
+        publication_status=PublicationStatus.DRAFT,
+        created_by=user,
+        super_event=event,
+    )
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_other_than_recurring_child_event_saved_does_send(user, event):
+    EventFactory(
+        name="testeventzor",
+        data_source=event.data_source,
+        publisher=event.publisher,
+        publication_status=PublicationStatus.DRAFT,
+        created_by=user,
+        super_event=event,
+    )
+    assert len(mail.outbox) == 1
 
 
 @pytest.mark.parametrize(

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -135,7 +135,22 @@ def test_draft_posted_as_super_event_sends(
 
 
 @pytest.mark.django_db
-def test_recurring_child_event_saved_does_not_send(user, event):
+def test_draft_posted_created_by_admin_user_does_not_send(data_source, organization):
+    admin = UserFactory()
+    organization.admin_users.add(admin)
+    EventFactory(
+        name="testeventzor",
+        data_source=data_source,
+        publisher=organization,
+        publication_status=PublicationStatus.DRAFT,
+        created_by=admin,
+    )
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_recurring_child_event_saved_does_not_send(event):
+    user = UserFactory()
     event.super_event_type = event.SuperEventType.RECURRING
     EventFactory(
         name="testeventzor",
@@ -149,7 +164,8 @@ def test_recurring_child_event_saved_does_not_send(user, event):
 
 
 @pytest.mark.django_db
-def test_other_than_recurring_child_event_saved_does_send(user, event):
+def test_other_than_recurring_child_event_saved_does_send(event):
+    user = UserFactory()
     EventFactory(
         name="testeventzor",
         data_source=event.data_source,


### PR DESCRIPTION
Do not send the notification considering child events of recurring super events. 
Also do not send draft notifications from events created by admins.

Refs LINK-1564 LINK-1633