### PR TITLE
LINK-1612 | Add translations for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ sudo -u postgres psql linkedevents -c "CREATE EXTENSION hstore;"
 python manage.py migrate
 # This adds language fields based on settings.LANGUAGES (which may be missing in external dependencies)
 python manage.py sync_translation_fields
+# This creates language objects with correct translations
+python manage.py create_languages
 ```
 
 If you wish to install Linkedevents without any Helsinki specific data (an empty database), and instead customize everything for your own city, you have a working install right now.
@@ -286,7 +288,7 @@ Linkedevents uses Elasticsearch for generating results on the /search-endpoint. 
 1. Install elasticsearch
 
     We've only tested using the rather ancient 1.7 version. If you are using Ubuntu 16.04, 1.7 will be available in the official repository.
-    This limitation was originally due to django-haystack not supporting versions above 1. 
+    This limitation was originally due to django-haystack not supporting versions above 1.
     As of writing this the django-haystack version in use does support versions 1, 2, 5 and 7.
 
 2. (For Finnish support) Install elasticsearch-analyzer-voikko, libvoikko and needed dictionaries

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -13,6 +13,8 @@ if [[ "$APPLY_MIGRATIONS" = "true" ]]; then
     ./manage.py migrate --noinput
     echo "Applying sync_translation_fields migrations..."
     ./manage.py sync_translation_fields --noinput
+    echo "Create language objects..."
+    ./manage.py create_languages
 fi
 
 

--- a/events/management/commands/add_helsinki_audience.py
+++ b/events/management/commands/add_helsinki_audience.py
@@ -43,11 +43,15 @@ NEW_SOTE_KEYWORDS_DATA = [
     {
         "id": "helsinki:aflfbatkwe",
         "name_fi": "omaishoitoperheet",
+        "name_en": "informal care families",
+        "name_sv": "närståendevård familjer",
         "data_source_id": "helsinki",
     },
     {
         "id": "helsinki:aflfbat76e",
         "name_fi": "palvelukeskuskortti",
+        "name_en": "service centre card",
+        "name_sv": "närståendevård kort",
         "data_source_id": "helsinki",
     },
 ]

--- a/events/management/commands/create_languages.py
+++ b/events/management/commands/create_languages.py
@@ -1,0 +1,113 @@
+from django.core.management.base import BaseCommand
+
+from events.models import Language
+
+LANGUAGES = [
+    {
+        "id": "ru",
+        "name_fi": "venäjä",
+        "name_sv": "ryska",
+        "name_en": "Russian",
+    },
+    {
+        "id": "et",
+        "name_fi": "viro",
+        "name_sv": "estniska",
+        "name_en": "Estonian",
+    },
+    {
+        "id": "fr",
+        "name_fi": "ranska",
+        "name_sv": "franska",
+        "name_en": "French",
+    },
+    {
+        "id": "so",
+        "name_fi": "somali",
+        "name_sv": "somaliska",
+        "name_en": "Somali",
+    },
+    {
+        "id": "es",
+        "name_fi": "espanja",
+        "name_sv": "spanska",
+        "name_en": "Spanish",
+    },
+    {
+        "id": "tr",
+        "name_fi": "turkki",
+        "name_sv": "turkiska",
+        "name_en": "Turkish",
+    },
+    {
+        "id": "fa",
+        "name_fi": "persia",
+        "name_sv": "persiska",
+        "name_en": "Persian",
+    },
+    {
+        "id": "ar",
+        "name_fi": "arabia",
+        "name_sv": "arabiska",
+        "name_en": "Arabic",
+    },
+    {
+        "id": "zh_hans",
+        "name_fi": "kiina",
+        "name_sv": "kinesiska",
+        "name_en": "Chinese",
+    },
+    {
+        "id": "en",
+        "name_fi": "englanti",
+        "name_sv": "engelska",
+        "name_en": "English",
+    },
+    {
+        "id": "fi",
+        "name_fi": "suomi",
+        "name_sv": "finska",
+        "name_en": "Finnish",
+    },
+    {
+        "id": "sv",
+        "name_fi": "ruotsi",
+        "name_sv": "svenska",
+        "name_en": "Swedish",
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Create language objects with correct translations."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            dest="force",
+            help="Forcefully update all languages with translations.",
+        )
+
+    def handle(self, *args, **options):
+        if options["force"]:
+            method = Language.objects.update_or_create
+        else:
+            method = Language.objects.get_or_create
+
+        language_ids = [language_data["id"] for language_data in LANGUAGES]
+        should_run = options["force"] or Language.objects.filter(
+            id__in=language_ids
+        ).count() < len(language_ids)
+
+        if should_run:
+            for language_data in LANGUAGES:
+                language, created = method(
+                    id=language_data["id"], defaults=language_data
+                )
+                if created:
+                    self.stdout.write(f"Created language {language_data['id']}.")
+                else:
+                    self.stdout.write(f"Language {language_data['id']} already exist.")
+        else:
+            self.stdout.write("All language objects are in order.")

--- a/events/tests/management/test_create_languages.py
+++ b/events/tests/management/test_create_languages.py
@@ -1,0 +1,31 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from pytest_django.asserts import assertNumQueries
+
+from events.models import Language
+
+
+@pytest.mark.django_db
+def test_create_languages():
+    out = StringIO()
+
+    call_command("create_languages", stdout=out)
+
+    languages = Language.objects.all()
+    assert languages.count() == 12
+    for lang in languages:
+        assert f"Created language {lang.pk}" in out.getvalue()
+        assert lang.name_fi
+        assert lang.name_sv
+        assert lang.name_en
+
+
+@pytest.mark.django_db
+def test_create_languages_check_should_create():
+    """Re-running the command does a cheap check."""
+    call_command("create_languages")
+
+    with assertNumQueries(1):
+        call_command("create_languages")


### PR DESCRIPTION
This PR adds translations for keywords added by `add_helsinki_audience` and also for `Language` instances which currently exist in production. For `Language` objects a separate new script `create_languages` is added which can create all instances which currently exists in production and is also able to update translations. For language names I tried to use translations provided by Django, but unfortunately they were not perfect so I decided to hard code the values in the script.

Translations in this PR have already been done in production, but for any new or existing environment these are missing and therefore they should also be part of the codebase.