### PR TITLE
LINK-1642 | Return signups as an array after successful bulk create signup response

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -403,8 +403,7 @@ class SignUpViewSet(
         serializer = CreateSignUpsSerializer(data=data, context=context)
         serializer.is_valid(raise_exception=True)
 
-        attending = []
-        waitlisted = []
+        signups = []
 
         # Create SignUps and add persons to correct list
         for i in data["signups"]:
@@ -412,20 +411,13 @@ class SignUpViewSet(
             signup.is_valid()
             signee = signup.create(validated_data=signup.validated_data)
 
-            if signee.attendee_status == SignUp.AttendeeStatus.ATTENDING:
-                attending.append(SignUpSerializer(signee, context=context).data)
-            else:
-                waitlisted.append(SignUpSerializer(signee, context=context).data)
-        data = {
-            "attending": {"count": len(attending), "people": attending},
-            "waitlisted": {"count": len(waitlisted), "people": waitlisted},
-        }
+            signups.append(SignUpSerializer(signee, context=context).data)
 
         # Delete reservation
         reservation = serializer.validated_data["reservation"]
         reservation.delete()
 
-        return Response(data, status=status.HTTP_201_CREATED)
+        return Response(data=signups, status=status.HTTP_201_CREATED)
 
     @transaction.atomic
     def perform_destroy(self, instance):

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -303,7 +303,7 @@ def test_signup_deletion_leads_to_changing_status_of_first_waitlisted_user(
         "signups": [signup_data],
     }
     response = assert_create_signups(api_client, signups_data)
-    signup_id = response.data[attendee_status]["people"][0]["id"]
+    signup_id = response.data[0]["id"]
 
     reservation2 = SeatReservationCodeFactory(registration=registration, seats=1)
     signup_data2 = {

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -757,10 +757,7 @@ def test_email_sent_on_successful_signup(
         }
 
         response = assert_create_signups(user_api_client, signups_data)
-        assert (
-            signup_data["first_name"]
-            in response.data["attending"]["people"][0]["first_name"]
-        )
+        assert signup_data["first_name"] in response.data[0]["first_name"]
 
         #  assert that the email was sent
         assert mail.outbox[0].subject.startswith(expected_subject)
@@ -818,10 +815,7 @@ def test_confirmation_template_has_correct_text_per_event_type(
     }
 
     response = assert_create_signups(user_api_client, signups_data)
-    assert (
-        signup_data["first_name"]
-        in response.data["attending"]["people"][0]["first_name"]
-    )
+    assert signup_data["first_name"] in response.data[0]["first_name"]
 
     #  assert that the email was sent
     assert expected_heading in str(mail.outbox[0].alternatives[0])
@@ -926,10 +920,7 @@ def test_different_email_sent_if_user_is_added_to_waiting_list(
         }
 
         response = assert_create_signups(user_api_client, signups_data)
-        assert (
-            signup_data["first_name"]
-            in response.data["waitlisted"]["people"][0]["first_name"]
-        )
+        assert signup_data["first_name"] in response.data[0]["first_name"]
 
         #  assert that the email was sent
         assert mail.outbox[0].subject.startswith(expected_subject)
@@ -985,10 +976,7 @@ def test_confirmation_to_waiting_list_template_has_correct_text_per_event_type(
     }
 
     response = assert_create_signups(user_api_client, signups_data)
-    assert (
-        signup_data["first_name"]
-        in response.data["waitlisted"]["people"][0]["first_name"]
-    )
+    assert signup_data["first_name"] in response.data[0]["first_name"]
     #  assert that the email was sent
     assert expected_text in str(mail.outbox[0].alternatives[0])
 
@@ -1018,7 +1006,7 @@ def test_signup_text_fields_are_sanitized(
     signups_data["reservation_code"] = reservation.code
 
     response = assert_create_signups(user_api_client, signups_data)
-    response_signup = response.data["attending"]["people"][0]
+    response_signup = response.data[0]
     assert response_signup["first_name"] == "Michael Html"
     assert response_signup["last_name"] == "Jackson Html"
     assert response_signup["extra_info"] == "Extra info Html"


### PR DESCRIPTION
## Description
At the moment bulk create signups response is returned as format:
```
"attending": {
  "count": 1, 
  "people": [{
    // signup 1 data
  }]},
"waitlisted": {
  "count": 1, 
  "people": [{
    // signup 2 data
  }]},
},
```
Instead returns signups as an array to make it consistent with bulk create events response

## Closes
[LINK-1642](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1642)