### PR TITLE
Relocate free_text filter

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -959,6 +959,12 @@ class KeywordListViewSet(
             self.request.query_params.get("has_upcoming_events"), "has_upcoming_events"
         ):
             queryset = queryset.filter(has_upcoming_events=True)
+        else:
+            if not self.request.query_params.get("show_all_keywords"):
+                queryset = queryset.filter(n_events__gt=0)
+            if not self.request.query_params.get("show_deprecated"):
+                queryset = queryset.filter(deprecated=False)
+
         if self.request.query_params.get("free_text"):
             val = self.request.query_params.get("free_text")
             # no need to search English if there are accented letters
@@ -971,11 +977,6 @@ class KeywordListViewSet(
             queryset = queryset.annotate(simile=Greatest(*tri)).filter(simile__gt=0.2)
             self.ordering_fields = ("simile", *self.ordering_fields)
             self.ordering = ("-simile", *self.ordering)
-        else:
-            if not self.request.query_params.get("show_all_keywords"):
-                queryset = queryset.filter(n_events__gt=0)
-            if not self.request.query_params.get("show_deprecated"):
-                queryset = queryset.filter(deprecated=False)
 
         # Optionally filter keywords by filter parameter,
         # can be used e.g. with typeahead.js

--- a/events/tests/test_keyword_get.py
+++ b/events/tests/test_keyword_get.py
@@ -138,7 +138,9 @@ def test_get_keyword_free_search(api_client, keyword, keyword2, keyword3):
     keyword2.save()
     keyword3.save()
 
-    response = get_list(api_client, data={"free_text": "cheeese"})
+    response = get_list(
+        api_client, data={"free_text": "cheeese", "show_all_keywords": True}
+    )
     ids = [entry["id"] for entry in response.data["data"]]
     assert ids == [keyword.id, keyword2.id, keyword3.id]
 


### PR DESCRIPTION
free_text filter was originally probably accidentally inserted in the middle of an unrelated if/else clause, breaking filtering of deprecated events.

Ref LINK-1654