### PR TITLE
Use console email backend if API_MAILGUN_KEY is not set

### DIFF
--- a/config_dev.toml.example
+++ b/config_dev.toml.example
@@ -149,3 +149,7 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 #MAILGUN_API_KEY=key
 #MAILGUN_SENDER_DOMAIN=do.main.com
 #MAILGUN_API_URL=https://mail.gun.api/
+
+# Linked registrations has encrypted fields. The encryption keys can be rotated.
+# See command encrypt_fields_with_new_key for more information.
+FIELD_ENCRYPTION_KEYS=c87a6669a1ded2834f1dfd0830d86ef6cdd20372ac83e8c7c23feffe87e6a051

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -585,9 +585,9 @@ if env("MAILGUN_API_KEY"):
         "MAILGUN_API_URL": env("MAILGUN_API_URL"),
     }
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-elif not env("MAILGUN_API_KEY") and DEBUG is True:
+else:
+    print("Warning: MAILGUN_API_KEY not set, using console backend for sending emails")
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
 
 # Ongoing events will be cached forever
 ONGOING_EVENTS_CACHE_TIMEOUT = None


### PR DESCRIPTION
ref https://helsinkisolutionoffice.atlassian.net/browse/LINK-1657


Originally was intending to add a separate env var EMAIL_TO_CONSOLE and raise ImproperlyConfigured if none of MAILGUN_API_KEY, EMAIL_TO_CONSOLE or DEBUG was set, but that broke management.py.