### PR TITLE
Rename config_dev.toml -> config_dev.env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,7 @@
 #################################################
 # Whitelisted files
 #################################################
-!config_dev.toml
+!config_dev.env
 !local_settings.py
 !manage.py
 !pyproject.toml

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Linkedevents uses Elasticsearch for generating results on the /search-endpoint. 
 
 3. Configure the thing
 
-    Set the `ELASTICSEARCH_URL` environment variable (or variable in `config_dev.toml`, if you are running in development mode) to your elasticsearch instance. The default value is `http://localhost:9200/`.
+    Set the `ELASTICSEARCH_URL` environment variable (or variable in `config_dev.env`, if you are running in development mode) to your elasticsearch instance. The default value is `http://localhost:9200/`.
 
     Haystack configuration for all Linkedevents languages happens automatically if `ELASTICSEARCH_URL` is set, but you may customize it manually using `local_settings.py` if you know Haystack and wish to do so.
 

--- a/config_dev.env.example
+++ b/config_dev.env.example
@@ -1,7 +1,7 @@
 # Linkedevents environment configuration
 # This file defines a set of (environment) variables that configure most
 # of the functionality of linkedevents. In order for linkedevents to read
-# this file, rename it to `config_dev.toml`. As the name implies, this
+# this file, rename it to `config_dev.env`. As the name implies, this
 # file is supposed to be used only in development. For production use
 # we recommend setting the environment variables using the facilities
 # of your runtime environment.

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -16,7 +16,7 @@ from easy_thumbnails.conf import Settings as thumbnail_settings  # noqa: N813
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.serializer import add_global_repr_processor
 
-CONFIG_FILE_NAME = "config_dev.toml"
+CONFIG_FILE_NAME = "config_dev.env"
 
 DEBUG_TOOLBAR_AVAILABLE = importlib.util.find_spec("debug_toolbar") is not None
 DJANGO_EXTENSIONS_AVAILABLE = importlib.util.find_spec("django_extensions") is not None


### PR DESCRIPTION
Since the file is not and never was a toml file by content.

As this may affect your local development setup rather unexpectedly, FYI also 

* @jorilindell
* @harriris-vincit 
* @City-of-Helsinki/ratkaisutoimiston-frontend 