### PR TITLE
LINK-1593: Escape regex input

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2619,7 +2619,8 @@ def _terms_to_regex(terms, operator):
             e = 1
         else:
             e = 2
-        expr = r"(\b" + f"({val}){{e<{e}}})"
+        escaped_val = regex.escape(val)
+        expr = r"(\b" + f"({escaped_val}){{e<{e}}})"
         valexprs.extend(expr)
     if operator == "AND":
         regex_join = ""


### PR DESCRIPTION
Using unescaped user input (via query strings) in regexes causes errors and is a security vulnerability. This PR escapes the input before using it in regex.

Also wrote some unit tests for `_terms_to_regex`. Apparently, the OR operator is completely busted, which I'm not going to address in this PR, so marked the OR cases with xfail.