### PR TITLE
LINK-1670 | Use the word 'jono' instead of 'varasija' in Finnish translations

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -524,7 +524,7 @@ msgstr "Paikkojen vähimmäismäärä"
 
 #: registrations/models.py:148
 msgid "Waiting list capacity"
-msgstr "Varasijapaikkojen lukumäärä"
+msgstr "Jonopaikkojen lukumäärä"
 
 #: registrations/models.py:151
 msgid "Maximum group size"
@@ -545,7 +545,7 @@ msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
 
 #: registrations/models.py:440
 msgid "Waitlisted"
-msgstr "Varasijalla"
+msgstr "Jonossa"
 
 #: registrations/models.py:441
 msgid "Attending"


### PR DESCRIPTION
### Description
Use the word 'jono' instead of 'varasija' in Finnish translations to ensure back-end translations better match with recent front-end translation changes. This will be especially necessary for the upcoming registration signups XLSX export (LINK-1658).
### Closes
[LINK-1670](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1670)

[LINK-1670]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ