### PR TITLE
LINK-1660 | Prevent removing the only responsible person of a group

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -13,6 +13,7 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -421,6 +422,11 @@ class SignUpViewSet(
 
     @transaction.atomic
     def perform_destroy(self, instance):
+        if instance.is_only_responsible_signup:
+            raise ValidationError(
+                _("Cannot delete the only responsible person of a group")
+            )
+
         instance._individually_deleted = True
         instance.delete()
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -603,6 +603,16 @@ class SignUp(CreatedModifiedBaseModel, SignUpMixin, SerializableMixin):
     )
 
     @cached_property
+    def is_only_responsible_signup(self):
+        return (
+            self.signup_group_id
+            and self.responsible_for_group
+            and not self.signup_group.signups.exclude(pk=self.pk)
+            .filter(responsible_for_group=True)
+            .exists()
+        )
+
+    @cached_property
     def date_of_birth(self):
         protected_data = getattr(self, "protected_data", None)
         return getattr(protected_data, "date_of_birth", None)

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -208,6 +208,15 @@ class SignUpSerializer(CreatedModifiedBaseSerializer):
                 ):
                     errors["date_of_birth"] = _("The participant is too old.")
 
+        if (
+            data.get("responsible_for_group") is False
+            and self.instance
+            and self.instance.is_only_responsible_signup
+        ):
+            errors["responsible_for_group"] = _(
+                "Cannot set responsible_for_group to False for the only responsible person of a group"
+            )
+
         if errors:
             raise serializers.ValidationError(errors)
 

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -230,3 +230,18 @@ class TestSignUp(TestCase):
         self.signup.save()
 
         self.assertEqual(self.signup.get_service_language_pk(), "fi")
+
+    def test_is_only_responsible_signup(self):
+        group = SignUpGroupFactory(registration=self.signup.registration)
+        SignUpFactory(signup_group=group, registration=self.signup.registration)
+
+        self.signup.signup_group = group
+        self.signup.save(update_fields=["signup_group"])
+
+        self.assertFalse(self.signup.is_only_responsible_signup)
+
+        self.signup.responsible_for_group = True
+        self.signup.save(update_fields=["responsible_for_group"])
+
+        del self.signup.is_only_responsible_signup
+        self.assertTrue(self.signup.is_only_responsible_signup)


### PR DESCRIPTION
### Description
Prevents deleting or removing through editing the only responsible person of a `SignUpGroup`. Such a person is technically a `SignUp` with `responsible_for_group=True`.
### Closes
[LINK-1660](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1660)

[LINK-1660]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ