### PR TITLE
Ensure last_modified_time is updated when an event is saved

### DIFF
--- a/events/migrations/0035_add_n_events_to_keyword.py
+++ b/events/migrations/0035_add_n_events_to_keyword.py
@@ -14,7 +14,7 @@ def forward(apps, schema_editor):
         if n_events != keyword.n_events:
             print("Updating event number for " + str(keyword.name))
             keyword.n_events = n_events
-            keyword.save(update_fields=("n_events",))
+            keyword.save(update_fields=("n_events",), skip_last_modified_time=True)
 
 
 class Migration(migrations.Migration):

--- a/events/migrations/0036_add_n_events_to_place.py
+++ b/events/migrations/0036_add_n_events_to_place.py
@@ -11,7 +11,7 @@ def forward(apps, schema_editor):
         n_events = place.events.all().count()
         if n_events != place.n_events:
             place.n_events = n_events
-            place.save(update_fields=("n_events",))
+            place.save(update_fields=("n_events",), skip_last_modified_time=True)
 
 
 class Migration(migrations.Migration):

--- a/events/tests/test_event.py
+++ b/events/tests/test_event.py
@@ -1,3 +1,6 @@
+import operator
+from typing import Callable
+
 import pytest
 
 
@@ -34,3 +37,21 @@ def test_prevent_circular_event_replacement(event, event2, event3):
     event3.replaced_by = event
     with pytest.raises(Exception):
         event.save()
+
+
+@pytest.mark.no_test_audit_log
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "skip_last_modified_time,compare_time,compare_user",
+    [[False, operator.gt, operator.is_], [True, operator.eq, operator.is_not]],
+)
+def test_event_update_fields_updates_last_modified_time(
+    event, skip_last_modified_time, compare_time: Callable, compare_user: Callable
+):
+    old_last_modified_time = event.last_modified_time
+    event.name = "New name"
+    event.save(update_fields=["name"], skip_last_modified_time=skip_last_modified_time)
+    event.refresh_from_db()
+
+    assert compare_time(event.last_modified_time, old_last_modified_time)
+    assert compare_user(event.last_modified_by_id, None)


### PR DESCRIPTION
Especially in case of soft deletion by importers
save(update_fields=[...]) would be called, which leaves last_modified_time untouched. This commit changes the updating of last_modified_time as opt-out. The last_modified_time is not updated when n_events is updated.