### PR TITLE
LINK-1687 | is_created_by_current_user field to signup serializer

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -51,6 +51,14 @@ class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
     created_by = serializers.StringRelatedField(required=False, allow_null=True)
     last_modified_by = serializers.StringRelatedField(required=False, allow_null=True)
 
+    is_created_by_current_user = serializers.SerializerMethodField()
+
+    def get_is_created_by_current_user(self, obj):
+        if not (request := self.context.get("request")):
+            return False
+
+        return request.user == obj.created_by
+
     def create(self, validated_data):
         validated_data["created_by"] = self.context["request"].user
         validated_data["last_modified_by"] = self.context["request"].user
@@ -240,6 +248,7 @@ class SignUpSerializer(CreatedModifiedBaseSerializer):
             "signup_group",
             "native_language",
             "user_consent",
+            "is_created_by_current_user",
         )
         model = SignUp
 
@@ -500,6 +509,7 @@ class SignUpGroupCreateSerializer(
             "last_modified_time",
             "created_by",
             "last_modified_by",
+            "is_created_by_current_user",
         )
         model = SignUpGroup
 
@@ -586,6 +596,7 @@ class SignUpGroupSerializer(CreatedModifiedBaseSerializer):
             "last_modified_time",
             "created_by",
             "last_modified_by",
+            "is_created_by_current_user",
         )
         model = SignUpGroup
 

--- a/registrations/tests/test_signup_get.py
+++ b/registrations/tests/test_signup_get.py
@@ -81,6 +81,7 @@ def assert_signup_fields_exist(data):
         "signup_group",
         "native_language",
         "user_consent",
+        "is_created_by_current_user",
     )
     assert_fields_exist(data, fields)
 
@@ -102,7 +103,8 @@ def test_registration_admin_user_can_get_signup(
     default_organization.admin_users.remove(user)
     default_organization.registration_admin_users.add(user)
 
-    assert_get_detail(user_api_client, signup.id)
+    response = assert_get_detail(user_api_client, signup.id)
+    assert response.data["is_created_by_current_user"] == False
 
 
 @pytest.mark.django_db
@@ -120,6 +122,7 @@ def test_registration_user_access_can_get_signup_when_strongly_identified(
         response = assert_get_detail(user_api_client, signup.id)
         assert mocked.called is True
     assert_signup_fields_exist(response.data)
+    assert response.data["is_created_by_current_user"] == False
 
 
 @pytest.mark.django_db
@@ -162,6 +165,7 @@ def test_regular_created_user_can_get_signup(
 
     response = assert_get_detail(user_api_client, signup.id)
     assert_signup_fields_exist(response.data)
+    assert response.data["is_created_by_current_user"] == True
 
 
 @pytest.mark.django_db
@@ -183,6 +187,7 @@ def test_created_user_without_organization_can_get_signup(api_client, registrati
 
     response = assert_get_detail(api_client, signup.id)
     assert_signup_fields_exist(response.data)
+    assert response.data["is_created_by_current_user"] == True
 
 
 @pytest.mark.django_db
@@ -206,6 +211,7 @@ def test_api_key_with_organization_and_registration_permission_can_get_signup(
 
     response = assert_get_detail(api_client, signup.id)
     assert_signup_fields_exist(response.data)
+    assert response.data["is_created_by_current_user"] == False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
At the moment Linked Registration UI doesn't know is the signup or signup group created by the current user. This is information is needed to grant permissions to edit signup or signup group created by the current user. Add `is_created_by_current_user` field to signup and signup group serializers to provide that information

## Partial closes
[LINK-1687](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1687)

[LINK-1687]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ