### PR TITLE
LINK-1695 | Log affected object IDs into audit log

### DIFF
--- a/audit_log/mixins.py
+++ b/audit_log/mixins.py
@@ -1,0 +1,55 @@
+from django.db.models import QuerySet
+
+
+class AuditLogApiViewMixin:
+    def _add_audit_logged_object_ids(self, instances):
+        request = getattr(self.request, "_request", self.request)
+        audit_logged_object_ids = set()
+
+        def add_instance(instance):
+            if not hasattr(instance, "pk") or not instance.pk:
+                return
+
+            audit_logged_object_ids.add(instance.pk)
+
+        if isinstance(instances, QuerySet) or isinstance(instances, list):
+            for instance in instances:
+                add_instance(instance)
+        else:
+            add_instance(instances)
+
+        if hasattr(request, "_audit_logged_object_ids"):
+            request._audit_logged_object_ids.update(audit_logged_object_ids)
+        else:
+            request._audit_logged_object_ids = audit_logged_object_ids
+
+    def get_object(self, skip_log_ids=False):
+        instance = super().get_object()
+
+        if not skip_log_ids:
+            self._add_audit_logged_object_ids(instance)
+
+        return instance
+
+    def paginate_queryset(self, queryset):
+        page = super().paginate_queryset(queryset)
+
+        logged_objects = page if page is not None else queryset
+        self._add_audit_logged_object_ids(logged_objects)
+
+        return page
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+
+        self._add_audit_logged_object_ids(serializer.instance)
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+
+        self._add_audit_logged_object_ids(serializer.instance)
+
+    def perform_destroy(self, instance):
+        self._add_audit_logged_object_ids(instance)
+
+        super().perform_destroy(instance)

--- a/audit_log/utils.py
+++ b/audit_log/utils.py
@@ -84,6 +84,17 @@ def _get_actor_data(request):
     }
 
 
+def _get_target(request):
+    audit_logged_object_ids = getattr(request, "_audit_logged_object_ids", set())
+
+    target = {"path": request.path, "object_ids": list(audit_logged_object_ids)}
+
+    if hasattr(request, "_audit_logged_object_ids"):
+        delattr(request, "_audit_logged_object_ids")
+
+    return target
+
+
 def commit_to_audit_log(request, response):
     current_time = timezone.now()
     iso_8601_datetime = f"{current_time.replace(tzinfo=None).isoformat(sep='T', timespec='milliseconds')}Z"
@@ -96,7 +107,7 @@ def commit_to_audit_log(request, response):
             "date_time": iso_8601_datetime,
             "actor": _get_actor_data(request),
             "operation": _get_operation_name(request),
-            "target": request.path,
+            "target": _get_target(request),
         }
     }
 

--- a/events/api.py
+++ b/events/api.py
@@ -69,6 +69,7 @@ from rest_framework_bulk import (
     BulkSerializerMixin,
 )
 
+from audit_log.mixins import AuditLogApiViewMixin
 from events import utils
 from events.api_pagination import LargeResultsSetPagination
 from events.auth import ApiKeyUser
@@ -855,6 +856,7 @@ class KeywordSerializer(EditableLinkedEventsObjectSerializer):
 class KeywordViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
+    AuditLogApiViewMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,
@@ -901,6 +903,7 @@ class KeywordDeprecatedException(APIException):
 class KeywordListViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
+    AuditLogApiViewMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
@@ -1059,7 +1062,10 @@ class KeywordSetSerializer(LinkedEventsSerializer):
 
 
 class KeywordSetViewSet(
-    UserDataSourceAndOrganizationMixin, JSONAPIViewMixin, viewsets.ModelViewSet
+    UserDataSourceAndOrganizationMixin,
+    JSONAPIViewMixin,
+    AuditLogApiViewMixin,
+    viewsets.ModelViewSet,
 ):
     queryset = KeywordSet.objects.all()
     serializer_class = KeywordSetSerializer
@@ -1254,6 +1260,7 @@ class PlaceRetrieveViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
     GeoModelAPIView,
+    AuditLogApiViewMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,
@@ -1303,6 +1310,7 @@ class PlaceListViewSet(
     UserDataSourceAndOrganizationMixin,
     GeoModelAPIView,
     JSONAPIViewMixin,
+    AuditLogApiViewMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
@@ -1407,7 +1415,9 @@ class LanguageSerializer(LinkedEventsSerializer):
         return obj.id in utils.get_fixed_lang_codes()
 
 
-class LanguageViewSet(JSONAPIViewMixin, viewsets.ReadOnlyModelViewSet):
+class LanguageViewSet(
+    JSONAPIViewMixin, AuditLogApiViewMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = Language.objects.all()
     serializer_class = LanguageSerializer
     filterset_fields = ("service_language",)
@@ -1607,6 +1617,7 @@ class OrganizationDetailSerializer(OrganizationListSerializer):
 class OrganizationViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
+    AuditLogApiViewMixin,
     viewsets.ModelViewSet,
 ):
     queryset = Organization.objects.all()
@@ -1666,7 +1677,9 @@ class DataSourceSerializer(LinkedEventsSerializer):
         exclude = ["api_key"]
 
 
-class DataSourceViewSet(JSONAPIViewMixin, viewsets.ReadOnlyModelViewSet):
+class DataSourceViewSet(
+    JSONAPIViewMixin, AuditLogApiViewMixin, viewsets.ReadOnlyModelViewSet
+):
     queryset = DataSource.objects.all()
     serializer_class = DataSourceSerializer
     permission_classes = [GuestRetrieve | UserIsAdminInAnyOrganization]
@@ -1683,7 +1696,11 @@ class OrganizationClassSerializer(LinkedEventsSerializer):
         fields = "__all__"
 
 
-class OrganizationClassViewSet(JSONAPIViewMixin, viewsets.ReadOnlyModelViewSet):
+class OrganizationClassViewSet(
+    JSONAPIViewMixin,
+    AuditLogApiViewMixin,
+    viewsets.ReadOnlyModelViewSet,
+):
     queryset = OrganizationClass.objects.all()
     serializer_class = OrganizationClassSerializer
     permission_classes = [GuestRetrieve | UserIsAdminInAnyOrganization]
@@ -1748,7 +1765,10 @@ class ImageSerializer(EditableLinkedEventsObjectSerializer):
 
 
 class ImageViewSet(
-    UserDataSourceAndOrganizationMixin, JSONAPIViewMixin, viewsets.ModelViewSet
+    UserDataSourceAndOrganizationMixin,
+    JSONAPIViewMixin,
+    AuditLogApiViewMixin,
+    viewsets.ModelViewSet,
 ):
     queryset = Image.objects.all().select_related(
         "publisher", "data_source", "created_by", "last_modified_by", "license"
@@ -3537,6 +3557,7 @@ class EventDeletedException(APIException):
 class EventViewSet(
     UserDataSourceAndOrganizationMixin,
     JSONAPIViewMixin,
+    AuditLogApiViewMixin,
     BulkModelViewSet,
     viewsets.ModelViewSet,
 ):
@@ -3629,7 +3650,7 @@ class EventViewSet(
             )
         return queryset
 
-    def get_object(self):
+    def get_object(self, skip_log_ids=False):
         event = super().get_object()
         if (
             event.publication_status == PublicationStatus.PUBLIC
@@ -3952,7 +3973,11 @@ DATE_DECAY_SCALE = "30d"
 
 
 class SearchViewSet(
-    JSONAPIViewMixin, GeoModelAPIView, viewsets.ViewSetMixin, generics.ListAPIView
+    JSONAPIViewMixin,
+    GeoModelAPIView,
+    viewsets.ViewSetMixin,
+    AuditLogApiViewMixin,
+    generics.ListAPIView,
 ):
     def get_serializer_class(self):
         if self.request.version == "v0.1":
@@ -4062,14 +4087,18 @@ class FeedbackSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class FeedbackViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
+class FeedbackViewSet(
+    AuditLogApiViewMixin, mixins.CreateModelMixin, viewsets.GenericViewSet
+):
     serializer_class = FeedbackSerializer
 
 
 register_view(FeedbackViewSet, "feedback", base_name="feedback")
 
 
-class GuestFeedbackViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
+class GuestFeedbackViewSet(
+    AuditLogApiViewMixin, mixins.CreateModelMixin, viewsets.GenericViewSet
+):
     serializer_class = FeedbackSerializer
     permission_classes = (GuestPost,)
 

--- a/events/tests/test_event_get_v0_1.py
+++ b/events/tests/test_event_get_v0_1.py
@@ -1,4 +1,9 @@
+from collections import Counter
+
 import pytest
+from rest_framework import status
+
+from audit_log.models import AuditLogEntry
 
 from .test_event_get import get_detail, get_list
 
@@ -13,6 +18,26 @@ def test__get_event_list_check_fields_exist(api_client, event):
     """
     response = get_list(api_client, version="v0.1")
     assert not response.data["data"][0]["image"]
+
+
+@pytest.mark.django_db
+def test_event_id_is_audit_logged_on_get_detail_v0_1(api_client, event):
+    response = get_detail(api_client, event.pk, version="v0.1")
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [event.pk]
+
+
+@pytest.mark.django_db
+def test_event_id_is_audit_logged_on_get_list_v0_1(api_client, event, event2):
+    response = get_list(api_client, version="v0.1")
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert Counter(
+        audit_log_entry.message["audit_event"]["target"]["object_ids"]
+    ) == Counter([event.pk, event2.pk])
 
 
 @pytest.mark.django_db

--- a/events/tests/test_image_delete.py
+++ b/events/tests/test_image_delete.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.models import Image
 
 from .test_event_images_v1 import create_uploaded_image
@@ -51,6 +52,14 @@ def test__delete_an_image(api_client, data_source, user, organization):
     # check that the image file is deleted
     image_path = get_image_path(existing_image)
     assert not os.path.isfile(image_path)
+
+
+@pytest.mark.django_db
+def test_image_id_is_audit_logged_on_delete(user_api_client, image):
+    assert_delete_image(user_api_client, image)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [image.pk]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_keyword_delete.py
+++ b/events/tests/test_keyword_delete.py
@@ -1,5 +1,7 @@
 import pytest
 
+from audit_log.models import AuditLogEntry
+
 from .utils import versioned_reverse as reverse
 
 
@@ -12,6 +14,19 @@ def test_keyword_delete(api_client, user, keyword):
 
     response = api_client.get(reverse("keyword-detail", kwargs={"pk": keyword.id}))
     assert response.status_code == 410
+
+
+@pytest.mark.django_db
+def test_keyword_id_is_audit_logged_on_delete(user_api_client, keyword):
+    response = user_api_client.delete(
+        reverse("keyword-detail", kwargs={"pk": keyword.id})
+    )
+    assert response.status_code == 204
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        keyword.pk
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_keyword_post.py
+++ b/events/tests/test_keyword_post.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 
+from audit_log.models import AuditLogEntry
 from events.auth import ApiKeyUser
 from events.tests.utils import assert_keyword_data_is_equal
 
@@ -33,6 +34,16 @@ def test__create_keyword_with_post(api_client, keyword_dict, user):
     api_client.force_authenticate(user=user)
     response = create_with_post(api_client, keyword_dict)
     assert_keyword_data_is_equal(keyword_dict, response.data)
+
+
+@pytest.mark.django_db
+def test_keyword_id_is_audit_logged_on_post(user_api_client, keyword_dict):
+    response = create_with_post(user_api_client, keyword_dict)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        response.data["id"]
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_keyword_put.py
+++ b/events/tests/test_keyword_put.py
@@ -1,5 +1,7 @@
 import pytest
+from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.auth import ApiKeyUser
 from events.tests.test_keyword_post import create_with_post
 from events.tests.utils import assert_keyword_data_is_equal
@@ -38,6 +40,19 @@ def test__update_a_keyword_with_put(api_client, keyword_dict, user):
     response2 = update_with_put(api_client, kw_id, data2)
     # assert
     assert_keyword_data_is_equal(data2, response2.data)
+
+
+@pytest.mark.django_db
+def test_keyword_id_is_audit_logged_on_put(user_api_client, keyword, keyword_dict):
+    detail_url = reverse("keyword-detail", kwargs={"pk": keyword.pk})
+
+    response = update_with_put(user_api_client, detail_url, keyword_dict)
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        keyword.pk
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_keywordset_post.py
+++ b/events/tests/test_keywordset_post.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
+from audit_log.models import AuditLogEntry
 from events.tests.utils import assert_keyword_set_data_is_equal
 from events.tests.utils import versioned_reverse as reverse
 
@@ -37,6 +38,16 @@ def test_create_keywordset_with_post(user, api_client, keyword_set_dict):
     api_client.force_authenticate(user)
 
     assert_create_keyword_set(api_client, keyword_set_dict)
+
+
+@pytest.mark.django_db
+def test_keyword_set_id_is_audit_logged_on_post(user_api_client, keyword_set_dict):
+    response = assert_create_keyword_set(user_api_client, keyword_set_dict)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        response.data["id"]
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_keywordset_put.py
+++ b/events/tests/test_keywordset_put.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.tests.test_keywordset_post import create_keyword_set
 from events.tests.utils import versioned_reverse as reverse
 
@@ -43,6 +44,16 @@ def test__update_keywordset(api_client, keyword_set_dict, user):
     response = update_keyword_set(api_client, kw_id, keyword_set_data)
     assert response.status_code == status.HTTP_200_OK
     assert response.data["name"]["fi"] == keyword_set_data["name"]["fi"]
+
+
+@pytest.mark.django_db
+def test_keyword_set_id_is_audit_logged_on_put(user_api_client, keyword_set):
+    assert_update_keyword_set(user_api_client, keyword_set)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        keyword_set.pk
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_organizationclass_get.py
+++ b/events/tests/test_organizationclass_get.py
@@ -1,6 +1,7 @@
 import pytest
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.tests.utils import versioned_reverse as reverse
 
 
@@ -42,6 +43,32 @@ def test_admin_user_can_get_organization_classes(
     api_client.force_authenticate(user)
 
     get_list_and_assert_organization_classes(api_client, [organization_class])
+
+
+@pytest.mark.django_db
+def test_organization_class_id_is_audit_logged_get_detail(
+    user_api_client, organization_class
+):
+    response = get_detail(user_api_client, organization_class.pk)
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        organization_class.pk
+    ]
+
+
+@pytest.mark.django_db
+def test_organization_class_id_is_audit_logged_get_list(
+    user_api_client, organization, organization_class
+):
+    response = get_list(user_api_client)
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        organization_class.pk
+    ]
 
 
 @pytest.mark.django_db

--- a/events/tests/test_place_post.py
+++ b/events/tests/test_place_post.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 
+from audit_log.models import AuditLogEntry
 from events.auth import ApiKeyUser
 from events.tests.utils import assert_place_data_is_equal
 
@@ -33,6 +34,16 @@ def test__create_place_with_post(api_client, place_dict, user):
     api_client.force_authenticate(user=user)
     response = create_with_post(api_client, place_dict)
     assert_place_data_is_equal(place_dict, response.data)
+
+
+@pytest.mark.django_db
+def test_place_id_is_audit_logged_on_post(user_api_client, place_dict):
+    response = create_with_post(user_api_client, place_dict)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        response.data["id"]
+    ]
 
 
 @pytest.mark.django_db

--- a/helevents/api.py
+++ b/helevents/api.py
@@ -1,11 +1,12 @@
 from django.contrib.auth import get_user_model
 from rest_framework import generics, permissions, viewsets
 
+from audit_log.mixins import AuditLogApiViewMixin
 from helevents.serializers import UserSerializer
 from linkedevents.registry import register_view
 
 
-class UserViewSet(viewsets.ReadOnlyModelViewSet):
+class UserViewSet(AuditLogApiViewMixin, viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         user = self.request.user
         if user.is_superuser:
@@ -14,13 +15,16 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
             # id is used because pk seems to give a string for ApiKeyUser
             return self.queryset.filter(pk=user.id)
 
-    def get_object(self):
+    def get_object(self, skip_log_ids=False):
         username = self.kwargs.get("username", None)
         if username:
             qs = self.get_queryset()
             obj = generics.get_object_or_404(qs, username=username)
         else:
             obj = self.request.user
+
+        self._add_audit_logged_object_ids(obj)
+
         return obj
 
     permission_classes = [permissions.IsAuthenticated]

--- a/helevents/tests/test_user_get.py
+++ b/helevents/tests/test_user_get.py
@@ -1,5 +1,9 @@
-import pytest
+from collections import Counter
 
+import pytest
+from rest_framework import status
+
+from audit_log.models import AuditLogEntry
 from events.tests.utils import assert_fields_exist, get
 from events.tests.utils import versioned_reverse as reverse
 from helevents.tests.factories import UserFactory
@@ -67,3 +71,28 @@ def test__get_user_list(api_client, user, organization, is_admin):
     else:
         assert len(data) == 1
         assert uuids == {str(user.uuid)}
+
+
+@pytest.mark.django_db
+def test_user_id_is_audit_logged_on_get_detail(user_api_client, user):
+    response = get_detail(user_api_client, user.pk)
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [user.pk]
+
+
+@pytest.mark.django_db
+def test_user_id_is_audit_logged_on_get_list(api_client):
+    user = UserFactory(is_superuser=True)
+    api_client.force_authenticate(user)
+
+    other_user = UserFactory()
+
+    response = get_list(api_client)
+    assert response.status_code == status.HTTP_200_OK
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert Counter(
+        audit_log_entry.message["audit_event"]["target"]["object_ids"]
+    ) == Counter([user.pk, other_user.pk])

--- a/registrations/tests/test_seatsreservation_put.py
+++ b/registrations/tests/test_seatsreservation_put.py
@@ -4,6 +4,7 @@ import pytest
 from django.utils.timezone import localtime
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.tests.utils import versioned_reverse as reverse
 from helevents.tests.factories import UserFactory
 from registrations.tests.factories import SeatReservationCodeFactory
@@ -284,3 +285,23 @@ def test_cannot_reserve_seats_waiting_list_if_there_are_not_enough_seats_availab
         response.data["seats"][0]
         == "Not enough capacity in the waiting list. Capacity left: 2."
     )
+
+
+@pytest.mark.django_db
+def test_seatreservation_id_is_audit_logged_on_put(registration, user_api_client):
+    registration.maximum_attendee_capacity = 2
+    registration.save(update_fields=["maximum_attendee_capacity"])
+
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    reservation_data = {
+        "seats": 2,
+        "registration": registration.id,
+        "code": reservation.code,
+    }
+
+    assert_update_seats_reservation(user_api_client, reservation.id, reservation_data)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [
+        reservation.pk
+    ]

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -1,9 +1,12 @@
+from collections import Counter
+
 import pytest
 from django.conf import settings
 from django.core import mail
 from django.utils import translation
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.models import Language
 from events.tests.utils import versioned_reverse as reverse
 from registrations.models import SignUp
@@ -529,3 +532,19 @@ def test_registration_admin_can_send_message_regardless_of_non_user_editable_res
     send_message_data = {"subject": "Message subject", "body": "Message body"}
 
     assert_send_message(user_api_client, registration.id, send_message_data, [signup])
+
+
+@pytest.mark.django_db
+def test_signup_ids_are_audit_logged_on_send_message(
+    user_api_client, registration, signup, signup2
+):
+    send_message_data = {"subject": "Message subject", "body": "Message body"}
+
+    assert_send_message(
+        user_api_client, registration.id, send_message_data, [signup, signup2]
+    )
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert Counter(
+        audit_log_entry.message["audit_event"]["target"]["object_ids"]
+    ) == Counter([signup.pk, signup2.pk])

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -4,6 +4,7 @@ import pytest
 from freezegun import freeze_time
 from rest_framework import status
 
+from audit_log.models import AuditLogEntry
 from events.tests.utils import versioned_reverse as reverse
 from helevents.tests.factories import UserFactory
 from registrations.models import SignUp
@@ -238,3 +239,19 @@ def test_cannot_remove_only_responsible_person_from_group_through_patch(
     assert response.data["responsible_for_group"][0] == (
         "Cannot set responsible_for_group to False for the only responsible person of a group"
     )
+
+
+@pytest.mark.django_db
+def test_signup_id_is_audit_logged_on_patch(api_client, signup):
+    user = UserFactory()
+    user.registration_admin_organizations.add(signup.publisher)
+    api_client.force_authenticate(user)
+
+    signup_data = {
+        "presence_status": SignUp.PresenceStatus.PRESENT,
+    }
+
+    assert_patch_signup(api_client, signup.pk, signup_data)
+
+    audit_log_entry = AuditLogEntry.objects.first()
+    assert audit_log_entry.message["audit_event"]["target"]["object_ids"] == [signup.pk]


### PR DESCRIPTION
### Description
Logs the IDs of the affected objects as part of the `target` value in the `AuditLogEntry.message` dictionary.
### Closes
[LINK-1695](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1695)

[LINK-1695]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ