### PR TITLE
build: remove build trigger from azure-pipelines-test.yml

### DIFF
--- a/azure-pipelines-test.yml
+++ b/azure-pipelines-test.yml
@@ -19,12 +19,13 @@ resources:
     - repository: linkedevents-pipelines
       type: git
       name: linkedevents/linkedevents-pipelines
-  pipelines:
-    - pipeline: build-linkedevents-api
-      source: build-linkedevents-api
-      trigger:
-        branches:
-          include:
-            - refs/heads/main
+#  pipelines:
+#    - pipeline: build-linkedevents-api
+#      source: build-linkedevents-api
+#      trigger:
+#        branches:
+#          include:
+#            - refs/heads/main
+
 extends:
   template: azure-pipelines-deploy-linkedevents-api-test.yml@linkedevents-pipelines


### PR DESCRIPTION
Build pipeline trigger dev and test deployments. This mess up deployments because of LATEST_BUILD_TAG