### PR TITLE
Start using conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
           linters: isort
           run: isort . --check-only --diff
 
+      - name: Check commitlint
+        uses: wagoid/commitlint-github-action@0d749a1a91d4770e983a7b8f83d4a3f0e7e0874e  # v5.4.4
+
       # With pytest-cov use: --cov=.
       # Some errors, skipping --doctest-modules for now
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Keep tool versions in sync with the versions in requirements-dev.txt
 default_language_version:
     python: python3
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -25,3 +27,9 @@ repos:
     hooks:
       - id: isort
         exclude: "migrations"
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.10.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg, manual]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
 
+## Commit message format
+
+New commit messages must adhere to the [Conventional Commits](https://www.conventionalcommits.org/)
+specification, and line length is limited to 72 characters.
+
+When [`pre-commit`](https://pre-commit.com/) is in use, [`commitlint`](https://github.com/conventional-changelog/commitlint)
+checks new commit messages for the correct format.
+
+
 ## Search
 
 Linkedevents uses Elasticsearch for generating results on the /search-endpoint. If you wish to use that functionality, proceed like so:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+const Configuration = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 72],
+    'body-leading-blank': [2, 'always'],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
From now on, all new commit messages must adhere to the [conventional commits spec](https://www.conventionalcommits.org/en/v1.0.0/) and their max line length is limited to 72 characters. The rules are enforced with [commitlint](https://commitlint.js.org/#/), which is run as a pre-commit hook and also as a stage in the GitHub CI pipeline.