### PR TITLE
LINK-1728 | lower LargeResultsSetPagination.max_page_size

### DIFF
--- a/events/api_pagination.py
+++ b/events/api_pagination.py
@@ -24,5 +24,4 @@ class CustomPagination(pagination.PageNumberPagination):
 
 class LargeResultsSetPagination(CustomPagination):
     page_size = 1000
-    page_size_query_param = "page_size"
-    max_page_size = 10000
+    max_page_size = 1000


### PR DESCRIPTION
Large values seems to be unused so the page size for LargeResultsSetPagination is limited to the default page size.