### PR TITLE
LINK-1741 | Organization admins can manage registrations & signups created by them

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -298,6 +298,10 @@ class SignUpMixin:
         return (
             user.is_superuser
             or user.is_registration_admin_of(self.publisher)
+            or (
+                user.is_admin_of(self.publisher)
+                and self.registration.created_by_id == user.id
+            )
             or user.is_registration_user_access_user_of(
                 self.registration.registration_user_accesses
             )
@@ -309,6 +313,10 @@ class SignUpMixin:
         return (
             user.is_superuser
             or user.is_registration_admin_of(self.publisher)
+            or (
+                user.is_admin_of(self.publisher)
+                and self.registration.created_by_id == user.id
+            )
             or user.id == self.created_by_id
         )
 

--- a/registrations/permissions.py
+++ b/registrations/permissions.py
@@ -71,6 +71,7 @@ class CanAccessRegistrationSignups(
         return (
             user.is_superuser
             or user.is_registration_admin_of(obj.publisher)
+            or (user.is_admin_of(obj.publisher) and obj.created_by_id == user.id)
             or user.is_registration_user_access_user_of(obj.registration_user_accesses)
         )
 
@@ -81,8 +82,13 @@ class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
 
     @staticmethod
     def _has_object_update_permission(request: Request, obj: SignUp) -> bool:
-        if request.user.is_superuser or request.user.is_registration_admin_of(
-            obj.publisher
+        if (
+            request.user.is_superuser
+            or request.user.is_registration_admin_of(obj.publisher)
+            or (
+                request.user.is_admin_of(obj.publisher)
+                and obj.registration.created_by_id == request.user.id
+            )
         ):
             return True
 
@@ -125,8 +131,13 @@ class CanAccessSignup(UserDataFromRequestMixin, permissions.BasePermission):
 class CanAccessSignupGroup(CanAccessSignup):
     @staticmethod
     def _has_object_update_permission(request: Request, obj: SignUpGroup) -> bool:
-        if request.user.is_superuser or request.user.is_registration_admin_of(
-            obj.publisher
+        if (
+            request.user.is_superuser
+            or request.user.is_registration_admin_of(obj.publisher)
+            or (
+                request.user.is_admin_of(obj.publisher)
+                and obj.registration.created_by_id == request.user.id
+            )
         ):
             return True
 

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -435,6 +435,7 @@ class RegistrationBaseSerializer(CreatedModifiedBaseSerializer):
             "mandatory_fields",
             "confirmation_message",
             "instructions",
+            "is_created_by_current_user",
         )
         model = Registration
 

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -70,8 +70,23 @@ def assert_delete_signup_failed(
 
 
 @pytest.mark.django_db
-def test_admin_cannot_delete_signup(signup, user_api_client):
+def test_registration_non_created_admin_cannot_delete_signup(
+    registration, signup, user2, user_api_client
+):
+    registration.created_by = user2
+    registration.save(update_fields=["created_by"])
+
     assert_delete_signup_failed(user_api_client, signup.id)
+
+
+@pytest.mark.django_db
+def test_registration_created_admin_can_delete_signup(
+    registration, signup, user, user_api_client
+):
+    registration.created_by = user
+    registration.save(update_fields=["created_by"])
+
+    assert_delete_signup(user_api_client, signup.id)
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -85,13 +85,33 @@ def test_registration_admin_can_delete_signup_group(
 
 
 @pytest.mark.django_db
-def test_admin_cannot_delete_signup_group(user_api_client, registration, user):
+def test_registration_non_created_admin_cannot_delete_signup_group(
+    user_api_client, registration, user2
+):
+    registration.created_by = user2
+    registration.save(update_fields=["created_by"])
+
     signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(signup_group=signup_group, registration=registration)
     SignUpFactory(signup_group=signup_group, registration=registration)
     SignUpContactPersonFactory(signup_group=signup_group)
 
     assert_delete_signup_group_failed(user_api_client, signup_group.pk)
+
+
+@pytest.mark.django_db
+def test_registration_created_admin_can_delete_signup_group(
+    user_api_client, registration, user
+):
+    registration.created_by = user
+    registration.save(update_fields=["created_by"])
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    SignUpFactory(signup_group=signup_group, registration=registration)
+    SignUpFactory(signup_group=signup_group, registration=registration)
+    SignUpContactPersonFactory(signup_group=signup_group)
+
+    assert_delete_signup_group(user_api_client, signup_group.pk)
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_signups_export.py
+++ b/registrations/tests/test_signups_export.py
@@ -268,6 +268,20 @@ def test_signups_export_allowed_for_registration_admin(registration, api_client)
 
 
 @pytest.mark.django_db
+def test_signups_export_allowed_for_created_by_admin(registration, api_client):
+    user = UserFactory()
+    user.admin_organizations.add(registration.publisher)
+    api_client.force_authenticate(user)
+
+    registration.created_by = user
+    registration.save(update_fields=["created_by"])
+
+    _create_default_signups_data(registration)
+
+    _assert_get_signups_export(api_client, registration.id, file_format="xlsx")
+
+
+@pytest.mark.django_db
 def test_signups_export_allowed_for_strongly_identified_registration_user(
     registration, api_client
 ):


### PR DESCRIPTION
### Description
Allows organization admins (also known as event admins or regular admins) to view, edit and delete registrations and signups if the registration is created by them.

Creation of new registrations and signups has already been possible for them, and no changes have been done for that functionality.

### Closes
[LINK-1741](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1741)

[LINK-1741]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ