### PR TITLE
LINK-1727 | Fix internal server error on image upload when external user sets an arbitrary publisher

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -615,7 +615,7 @@ class LinkedEventsSerializer(TranslatedModelSerializer, MPTTModelSerializer):
                     {
                         "data_source": _(
                             "Setting data_source to %(given)s "
-                            + " is not allowed for this user. The data_source"
+                            " is not allowed for this user. The data_source"
                             " must be left blank or set to %(required)s "
                         )
                         % {"given": str(value), "required": data_source}
@@ -633,7 +633,7 @@ class LinkedEventsSerializer(TranslatedModelSerializer, MPTTModelSerializer):
                 raise serializers.ValidationError(
                     _(
                         "Setting id to %(given)s "
-                        + "is not allowed for your organization. The id "
+                        "is not allowed for your organization. The id "
                         "must be left blank or set to %(data_source)s:desired_id"
                     )
                     % {"given": str(value), "data_source": data_source}
@@ -835,7 +835,7 @@ class KeywordSerializer(EditableLinkedEventsObjectSerializer):
                 raise serializers.ValidationError(
                     _(
                         "Setting id to %(given)s "
-                        + "is not allowed for your organization. The id "
+                        "is not allowed for your organization. The id "
                         "must be left blank or set to %(data_source)s:desired_id"
                     )
                     % {"given": str(value), "data_source": data_source}

--- a/events/api.py
+++ b/events/api.py
@@ -665,21 +665,19 @@ class LinkedEventsSerializer(TranslatedModelSerializer, MPTTModelSerializer):
                 )
             if value not in allowed_organizations:
                 publisher = self.context["publisher"]
+                publisher = publisher.replaced_by or publisher if publisher else None
+
                 raise serializers.ValidationError(
                     _(
                         "Setting %(field)s to %(given)s "
-                        + "is not allowed for this user. The %(field)s "
-                        + "must be left blank or set to %(required)s or any other organization"
-                        " the user belongs to."
+                        "is not allowed for this user. The %(field)s "
+                        "must be left blank or set to %(required)s or any other organization "
+                        "the user belongs to."
                     )
                     % {
                         "field": str(field),
                         "given": str(value),
-                        "required": str(
-                            publisher
-                            if not publisher.replaced_by
-                            else publisher.replaced_by
-                        ),
+                        "required": str(publisher),
                     }
                 )
             if value.replaced_by:


### PR DESCRIPTION
This PR fixes an internal server error being thrown instead of returning a validation error when an external user (a user which doesn't belong to an organization) sets an arbitrary organization. Since the user doesn't belong to any organization the publisher field should be left blank.