### PR TITLE
LINK-1718 | Add email notification to contact persons on event cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Note that search tests will fail unless you configure [search](#search)
 
 
 ## Sending email
-The project uses [django-mailer](https://github.com/pinax/django-mailer) for queuing and sending email. When a normal Django email function like `send_mail` is called, the email will be stored into an email queue that exists in the database for later sending.
+The project uses [django-mailer](https://github.com/pinax/django-mailer) for queuing and sending email. When a normal Django email function like `send_mail` is called, the email will be stored into a queue that exists in the database for later sending.
 
-`django-mailer` comes with a number of management commands for interacting with the email queue. Out of those, the `send_mail` command is for us perhaps the most notable one as it is responsible for the actual sending of the queues messages.
+`django-mailer` comes with a number of management commands for interacting with the email queue. Out of those, the `send_mail` command is for us perhaps the most notable one as it is responsible for the actual sending of the queued messages.
 
 To send messages locally, you can run the `send_mail` command:
 `./manage.py send_mail`

--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ py.test events
 Note that search tests will fail unless you configure [search](#search)
 
 
+## Sending email
+The project uses [django-mailer](https://github.com/pinax/django-mailer) for queuing and sending email. When a normal Django email function like `send_mail` is called, the email will be stored into an email queue that exists in the database for later sending.
+
+`django-mailer` comes with a number of management commands for interacting with the email queue. Out of those, the `send_mail` command is for us perhaps the most notable one as it is responsible for the actual sending of the queues messages.
+
+To send messages locally, you can run the `send_mail` command:
+`./manage.py send_mail`
+
+For more information about `django-mailer` and the management commands, you can refer to the [usage documentation](https://github.com/pinax/django-mailer/blob/master/docs/usage.rst).
+
+
 ## Requirements
 
 Linked Events uses two files for requirements. The workflow is as follows.

--- a/events/signals.py
+++ b/events/signals.py
@@ -1,16 +1,7 @@
 import logging
 
-from django.contrib.auth import get_user_model
-from django.core.mail import send_mail
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-
-from notifications.models import (
-    NotificationTemplateException,
-    NotificationType,
-    render_notification_template,
-)
-from registrations.utils import get_email_noreply_address
 
 logger = logging.getLogger(__name__)
 
@@ -31,41 +22,3 @@ def organization_replaced(sender, instance, created, **kwargs):
 
         # update owned systems to new owner
         instance.owned_systems.update(owner=new_org)
-
-
-# TODO not in use anymore, remove altogether?
-def user_created_notification(sender, instance, created, **kwargs):
-    """Send a notification to superusers when a user gets created."""
-    if created:
-        user_model = get_user_model()
-        recipient_list = [
-            item
-            for item in user_model.objects.filter(is_superuser=True)
-            .exclude(email__exact="")
-            .values_list("email", flat=True)
-        ]
-        notification_type = NotificationType.USER_CREATED
-        context = {"user": instance}
-
-        if len(recipient_list) == 0:
-            logger.warning(
-                "No recipients for notification type '%s'" % notification_type,
-                extra={"user": instance.username},
-            )
-            return
-
-        try:
-            rendered_notification = render_notification_template(
-                notification_type, context
-            )
-        except NotificationTemplateException as e:
-            logger.error(e, exc_info=True)
-            return
-
-        send_mail(
-            rendered_notification["subject"],
-            rendered_notification["body"],
-            get_email_noreply_address(),
-            recipient_list,
-            html_message=rendered_notification["html_body"],
-        )

--- a/events/signals.py
+++ b/events/signals.py
@@ -1,5 +1,4 @@
 import logging
-from smtplib import SMTPException
 
 from django.contrib.auth import get_user_model
 from django.core.mail import send_mail
@@ -47,12 +46,14 @@ def user_created_notification(sender, instance, created, **kwargs):
         ]
         notification_type = NotificationType.USER_CREATED
         context = {"user": instance}
+
         if len(recipient_list) == 0:
             logger.warning(
                 "No recipients for notification type '%s'" % notification_type,
                 extra={"user": instance.username},
             )
             return
+
         try:
             rendered_notification = render_notification_template(
                 notification_type, context
@@ -60,13 +61,11 @@ def user_created_notification(sender, instance, created, **kwargs):
         except NotificationTemplateException as e:
             logger.error(e, exc_info=True)
             return
-        try:
-            send_mail(
-                rendered_notification["subject"],
-                rendered_notification["body"],
-                get_email_noreply_address(),
-                recipient_list,
-                html_message=rendered_notification["html_body"],
-            )
-        except SMTPException as e:
-            logger.error(e, exc_info=True, extra={"user": instance.username})
+
+        send_mail(
+            rendered_notification["subject"],
+            rendered_notification["body"],
+            get_email_noreply_address(),
+            recipient_list,
+            html_message=rendered_notification["html_body"],
+        )

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -57,21 +57,6 @@ def draft_posted_notification_template():
     return template
 
 
-@pytest.fixture
-def user_created_notification_template():
-    try:
-        NotificationTemplate.objects.get(type=NotificationType.USER_CREATED).delete()
-    except NotificationTemplate.DoesNotExist:
-        pass
-    template = NotificationTemplate.objects.create(
-        type=NotificationType.USER_CREATED,
-        subject="user created",
-        body="new user created - user email: {{ user.email }}",
-        html_body="<b>new user created</b> - user email: {{ user.email }}!",
-    )
-    return template
-
-
 @pytest.mark.django_db
 def test_draft_event_deleted(event_deleted_notification_template, user, event):
     event.created_by = user
@@ -204,22 +189,3 @@ def test_draft_notification_is_not_sent_when_using_api_key(
     )
 
     assert bool(mail.outbox) == expect_email
-
-
-# TODO user created notification is disabled ATM, remove this test if/when it is removed
-@pytest.mark.xfail
-@pytest.mark.django_db
-def test_user_created(user_created_notification_template, super_user):
-    user = get_user_model().objects.create(
-        username="created_user",
-        first_name="New",
-        last_name="Creature",
-        email="new@creature.com",
-    )
-    strings = [
-        "new user created - user email: %s" % user.email,
-    ]
-    html_body = "<b>new user created</b> - user email: %s!" % user.email
-    check_received_mail_exists(
-        "user created", super_user.email, strings, html_body=html_body
-    )

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -236,6 +236,7 @@ INSTALLED_APPS = [
     "django_orghierarchy",
     "admin_auto_filters",
     "encrypted_fields",
+    "mailer",
     # Local apps
     "linkedevents",
     "helevents",
@@ -529,19 +530,6 @@ AUTO_ENABLED_EXTENSIONS = env("AUTO_ENABLED_EXTENSIONS")
 # shown in the browsable API
 INSTANCE_NAME = env("INSTANCE_NAME")
 
-# local_settings.py can be used to override environment-specific settings
-# like database and email that differ between development and production.
-f = os.path.join(BASE_DIR, "local_settings.py")
-if os.path.exists(f):
-    import sys
-    import types
-
-    module_name = "%s.local_settings" % ROOT_URLCONF.split(".")[0]
-    module = types.ModuleType(module_name)
-    module.__file__ = f
-    sys.modules[module_name] = module
-    exec(open(f, "rb").read())
-
 # We generate a persistent SECRET_KEY if it is not defined. Note that
 # setting SECRET_KEY will override the persisted key
 if "SECRET_KEY" not in locals():
@@ -581,15 +569,17 @@ SUPPORT_EMAIL = env("SUPPORT_EMAIL")  # Email address used to send feedback form
 DEFAULT_FROM_EMAIL = env(
     "DEFAULT_FROM_EMAIL"
 )  # Email address used as default "from" email
+EMAIL_BACKEND = "mailer.backend.DbBackend"
+MAILER_EMAIL_MAX_RETRIES = 5
 if EMAIL_HOST and EMAIL_PORT:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    MAILER_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 else:
     if not DEBUG:
         print(
             "Warning: EMAIL_HOST and/or EMAIL_PORT not set, using console backend for sending "
             "emails"
         )
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+    MAILER_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Ongoing events will be cached forever
 ONGOING_EVENTS_CACHE_TIMEOUT = None
@@ -678,3 +668,16 @@ AUDIT_LOG_ORIGIN = "linkedevents"
 AUDIT_LOG_ENABLED = env("AUDIT_LOG_ENABLED")
 
 FULL_TEXT_WEIGHT_OVERRIDES = env("FULL_TEXT_WEIGHT_OVERRIDES")
+
+# local_settings.py can be used to override environment-specific settings
+# like database and email that differ between development and production.
+f = os.path.join(BASE_DIR, "local_settings.py")
+if os.path.exists(f):
+    import sys
+    import types
+
+    module_name = "%s.local_settings" % ROOT_URLCONF.split(".")[0]
+    module = types.ModuleType(module_name)
+    module.__file__ = f
+    sys.modules[module_name] = module
+    exec(open(f, "rb").read())

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-20 13:49+0000\n"
+"POT-Creation-Date: 2023-12-12 08:51+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,14 +60,14 @@ msgid ""
 "data_source must be left blank or set to %(required)s "
 msgstr ""
 
-#: events/api.py:635 events/api.py:837
+#: events/api.py:635 events/api.py:835
 #, python-format
 msgid ""
 "Setting id to %(given)s is not allowed for your organization. The id must be "
 "left blank or set to %(data_source)s:desired_id"
 msgstr ""
 
-#: events/api.py:670
+#: events/api.py:672
 #, python-format
 msgid ""
 "Setting %(field)s to %(given)s is not allowed for this user. The %(field)s "
@@ -75,123 +75,123 @@ msgid ""
 "belongs to."
 msgstr ""
 
-#: events/api.py:705
+#: events/api.py:703
 msgid "The name must be specified."
 msgstr "Nimi on pakollinen."
 
-#: events/api.py:770
+#: events/api.py:768
 msgid "An object with given id already exists."
 msgstr ""
 
-#: events/api.py:781 events/api.py:1032
+#: events/api.py:779 events/api.py:1030
 msgid "You may not change the id of an existing object."
 msgstr "Olemassa olevan objektin id-kenttää ei voi vaihtaa."
 
-#: events/api.py:790
+#: events/api.py:788
 msgid "You may not change the publisher of an existing object."
 msgstr "Olemassa olevan objektin julkaisija-kenttää ei voi vaihtaa."
 
-#: events/api.py:801 events/api.py:1052
+#: events/api.py:799 events/api.py:1050
 msgid "You may not change the data source of an existing object."
 msgstr "Olemassa olevan objektin tietolähde-kenttää ei voi vaihtaa."
 
-#: events/api.py:1041
+#: events/api.py:1039
 msgid "You may not change the organization of an existing object."
 msgstr "Olemassa olevan objektin organization-kenttää ei voi vaihtaa."
 
-#: events/api.py:1561
+#: events/api.py:1559
 msgid "User has no rights to this organization"
 msgstr "Käyttäjällä ei ole oikeuksia tähän organisaatioon"
 
-#: events/api.py:1937 events/api.py:2032
+#: events/api.py:1935 events/api.py:2030
 #, python-format
 msgid "Registration user access with email %(email)s already exists."
 msgstr ""
 
-#: events/api.py:1968 events/permissions.py:144
+#: events/api.py:1966 events/permissions.py:144
 msgid "Object data source does not match user data source"
 msgstr ""
 
-#: events/api.py:1980
+#: events/api.py:1978
 msgid "Event already has a registration."
 msgstr ""
 
-#: events/api.py:2221
+#: events/api.py:2219
 msgid "Deprecated keyword not allowed ({})"
 msgstr ""
 
-#: events/api.py:2271
+#: events/api.py:2269
 msgid "You have to set either user_email or user_phone_number."
 msgstr ""
 
-#: events/api.py:2280
+#: events/api.py:2278
 msgid "User consent is required if personal information fields are filled."
 msgstr ""
 
-#: events/api.py:2283
+#: events/api.py:2281
 msgid "This field must be specified before an event is published."
 msgstr "Kenttä on täytettävä ennen kuin tapahtuman voi julkaista."
 
-#: events/api.py:2297
+#: events/api.py:2295
 msgid "Short description length must be 160 characters or less"
 msgstr ""
 
-#: events/api.py:2313
+#: events/api.py:2311
 msgid "Price info must be specified before an event is published."
 msgstr ""
 
-#: events/api.py:2347
+#: events/api.py:2345
 msgid "End time cannot be in the past. Please set a future end time."
 msgstr ""
-"Päättymisaika ei voi olla menneisyydessä. Ole hyvä ja anna tulevaisuudessa oleva "
-"päättymisaika."
+"Päättymisaika ei voi olla menneisyydessä. Ole hyvä ja anna tulevaisuudessa "
+"oleva päättymisaika."
 
-#: events/api.py:2431
+#: events/api.py:2429
 msgid "Cannot edit a past event."
 msgstr ""
 
-#: events/api.py:2446
+#: events/api.py:2444
 msgid ""
 "POSTPONED and RESCHEDULED statuses cannot be set directly.Changing event "
 "start_time or marking start_time nullwill reschedule or postpone an event."
 msgstr ""
 
-#: events/api.py:2467
+#: events/api.py:2465
 msgid ""
 "Public events cannot be set back to SCHEDULED if theyhave already been "
 "CANCELLED, POSTPONED or RESCHEDULED."
 msgstr ""
 
-#: events/api.py:3038
+#: events/api.py:3027
 #, python-brace-format
 msgid "Event type can be of the following values: {event_types}"
 msgstr ""
 
-#: events/api.py:3066
+#: events/api.py:3055
 msgid "Error while parsing days."
 msgstr ""
 
-#: events/api.py:3068
+#: events/api.py:3057
 msgid "Days must be 1 or more."
 msgstr ""
 
-#: events/api.py:3072
+#: events/api.py:3061
 msgid "Start or end cannot be used with days."
 msgstr ""
 
-#: events/api.py:3528
+#: events/api.py:3517
 msgid "x_full_text supports the following languages: fi, en, sv"
 msgstr ""
 
-#: events/api.py:3946
+#: events/api.py:3938
 msgid "Must specify a location when fetching DOCX file."
 msgstr ""
 
-#: events/api.py:3950
+#: events/api.py:3942
 msgid "No events."
 msgstr "Ei tapahtumia."
 
-#: events/api.py:3952
+#: events/api.py:3944
 msgid "Only one location allowed."
 msgstr ""
 
@@ -204,11 +204,11 @@ msgstr ""
 
 #: events/models.py:78 events/models.py:189 events/models.py:206
 #: events/models.py:333 events/models.py:400 events/models.py:414
-#: events/models.py:1293 events/models.py:1309 events/models.py:1359
-#: registrations/exports.py:27
+#: events/models.py:1294 events/models.py:1310 events/models.py:1360
 #: venv/lib/python3.9/site-packages/munigeo/models.py:83
 #: venv/lib/python3.9/site-packages/munigeo/models.py:112
 #: venv/lib/python3.9/site-packages/munigeo/models.py:141
+#: registrations/exports.py:34
 msgid "Name"
 msgstr "Nimi"
 
@@ -267,7 +267,7 @@ msgstr "Rajaus"
 msgid "Photographer name"
 msgstr "Valokuvaajan nimi"
 
-#: events/models.py:260 events/models.py:1316
+#: events/models.py:260 events/models.py:1317
 msgid "Alt text"
 msgstr "Vaihtoehtoinen teksti"
 
@@ -338,8 +338,8 @@ msgstr "Paikan kotisivu"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: events/models.py:621 events/models.py:1360 registrations/exports.py:28
-#: registrations/models.py:367 registrations/models.py:500
+#: events/models.py:621 events/models.py:1361 registrations/exports.py:36
+#: registrations/models.py:406 registrations/models.py:670
 msgid "E-mail"
 msgstr "Sähköposti"
 
@@ -351,7 +351,7 @@ msgstr "Puhelinnumero"
 msgid "Contact type"
 msgstr "Yhteydtiedon tyyppi"
 
-#: events/models.py:629 registrations/models.py:47 registrations/models.py:544
+#: events/models.py:629 registrations/models.py:50 registrations/models.py:532
 msgid "Street address"
 msgstr "Katuosoite"
 
@@ -446,7 +446,7 @@ msgstr "Käyttäjän organisaatio"
 msgid "Event organizer information."
 msgstr "Tapahtuman järjestäjän tiedot."
 
-#: events/models.py:846 registrations/models.py:566
+#: events/models.py:846 registrations/models.py:554
 msgid "User consent"
 msgstr "Käyttäjän suostumus"
 
@@ -514,11 +514,11 @@ msgstr "Alkuaika"
 msgid "End time"
 msgstr "Loppuaika"
 
-#: events/models.py:937 registrations/models.py:121
+#: events/models.py:937 registrations/models.py:124
 msgid "Minimum recommended age"
 msgstr "Suositeltu vähimmäisikä"
 
-#: events/models.py:940 registrations/models.py:124
+#: events/models.py:940 registrations/models.py:127
 msgid "Maximum recommended age"
 msgstr "Suurin suositeltu ikä"
 
@@ -550,38 +550,38 @@ msgstr "tapahtuma"
 msgid "events"
 msgstr "tapahtumat"
 
-#: events/models.py:1019
+#: events/models.py:1020
 msgid ""
 "Trying to replace this event with an event that is replaced by this event. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements."
 msgstr ""
 
-#: events/models.py:1058
+#: events/models.py:1059
 msgid "The event end time cannot be earlier than the start time."
 msgstr "Tapahtuman päättymisaika ei voi olla aikaisempi kuin alkamisaika."
 
-#: events/models.py:1274
+#: events/models.py:1275
 msgid "Price"
 msgstr "Hinta"
 
-#: events/models.py:1276
+#: events/models.py:1277
 msgid "Web link to offer"
 msgstr "Linkki lipunmyyntiin"
 
-#: events/models.py:1279
+#: events/models.py:1280
 msgid "Offer description"
 msgstr "Hintatietojen kuvaus"
 
-#: events/models.py:1283
+#: events/models.py:1284
 msgid "Is free"
 msgstr "Vapaa pääsy"
 
-#: events/models.py:1361 notifications/models.py:47
+#: events/models.py:1362 notifications/models.py:47
 msgid "Subject"
 msgstr "Otsikko"
 
-#: events/models.py:1362 notifications/models.py:53
+#: events/models.py:1363 notifications/models.py:53
 msgid "Body"
 msgstr "Teksti"
 
@@ -666,16 +666,17 @@ msgstr "Osallistujalista-käyttäjät"
 msgid "Registration with signups cannot be deleted"
 msgstr "Ilmoittautumista, jolla on osallistujia ei voi poistaa"
 
-#: registrations/api.py:329
-msgid "Invalid registration ID(s) given."
-msgstr ""
-
-#: registrations/api.py:346
+#: registrations/api.py:173 registrations/api.py:379
 msgid "Only the admins of the registration organizations have access rights."
 msgstr "Vain ilmoittautumisten organisaatioiden admin-käyttäjillä on oikeudet."
 
-#: registrations/api.py:459
-msgid "Cannot delete the only responsible person of a group"
+#: registrations/api.py:206
+msgid ""
+"No contact persons with email addresses found for the given participants."
+msgstr ""
+
+#: registrations/api.py:358
+msgid "Invalid registration ID(s) given."
 msgstr ""
 
 #: registrations/exceptions.py:8
@@ -686,12 +687,11 @@ msgstr "Pyyntö on ristiriidassa kohderesurssin nykyisen tilan kanssa"
 msgid "Registered persons"
 msgstr "Ilmoittautuneet"
 
-#: registrations/exports.py:29 registrations/models.py:46
-#: registrations/models.py:510
+#: registrations/exports.py:42 registrations/models.py:674
 msgid "Phone number"
 msgstr "Puhelinnumero"
 
-#: registrations/exports.py:42
+#: registrations/exports.py:59
 msgid ""
 "This material is subject to data protection. This material must be processed "
 "in the manner required by data protection and only to verify \n"
@@ -703,163 +703,205 @@ msgstr ""
 "osallistujien varmistamiseen. Tämä lista tulee hävittää, kun tapahtuma on "
 "mennyt ja läsnäolijat merkitty järjestelmään."
 
-#: registrations/exports.py:54
+#: registrations/exports.py:71
 msgid ""
 "Please note that the participant and the participant's contact information "
 "may be the information of different persons."
 msgstr ""
-"Huomaathan, että osallistuja ja osallistujan yhteystiedot voivat olla eri henkilöiden tietoja."
+"Huomaathan, että osallistuja ja osallistujan yhteystiedot voivat olla eri "
+"henkilöiden tietoja."
 
-#: registrations/models.py:43 registrations/models.py:493
+#: registrations/models.py:47 registrations/models.py:518
 msgid "City"
 msgstr "Kaupunki"
 
-#: registrations/models.py:44 registrations/models.py:479
+#: registrations/models.py:48 registrations/models.py:504
+#: registrations/models.py:655
 msgid "First name"
 msgstr "Etunimi"
 
-#: registrations/models.py:45 registrations/models.py:486
+#: registrations/models.py:49 registrations/models.py:511
+#: registrations/models.py:662
 msgid "Last name"
 msgstr "Sukunimi"
 
-#: registrations/models.py:48 registrations/models.py:551
+#: registrations/models.py:51 registrations/models.py:539
 msgid "ZIP code"
 msgstr "Postinumero"
 
-#: registrations/models.py:80
+#: registrations/models.py:83
 msgid "Created at"
 msgstr "Luotu klo"
 
-#: registrations/models.py:86
+#: registrations/models.py:89
 msgid "Modified at"
 msgstr "Muokattu klo"
 
-#: registrations/models.py:128
+#: registrations/models.py:131
 msgid "Enrollment start time"
 msgstr "Ilmoittautumisen alkamisaika"
 
-#: registrations/models.py:131
+#: registrations/models.py:134
 msgid "Enrollment end time"
 msgstr "Ilmoittautumisen päättymisaika"
 
-#: registrations/models.py:135
+#: registrations/models.py:138
 msgid "Confirmation message"
 msgstr "Vahvistusviesti"
 
-#: registrations/models.py:138
+#: registrations/models.py:141
 msgid "Instructions"
 msgstr "Ohjeet"
 
-#: registrations/models.py:142
+#: registrations/models.py:145
 msgid "Maximum attendee capacity"
 msgstr "Paikkojen enimmäismäärä"
 
-#: registrations/models.py:145
+#: registrations/models.py:148
 msgid "Minimum attendee capacity"
 msgstr "Paikkojen vähimmäismäärä"
 
-#: registrations/models.py:148
+#: registrations/models.py:151
 msgid "Waiting list capacity"
 msgstr "Jonopaikkojen lukumäärä"
 
-#: registrations/models.py:151
+#: registrations/models.py:154
 msgid "Maximum group size"
 msgstr "Ryhmän enimmäiskoko"
 
-#: registrations/models.py:165
+#: registrations/models.py:168
 msgid "Mandatory fields"
 msgstr "Pakolliset kentät"
 
-#: registrations/models.py:346
+#: registrations/models.py:332 registrations/models.py:559
+msgid "Anonymization time"
+msgstr ""
+
+#: registrations/models.py:381
 msgid "Extra info"
 msgstr "Lisätiedot"
 
-#: registrations/models.py:413
+#: registrations/models.py:452
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
 
-#: registrations/models.py:439
+#: registrations/models.py:478
 msgid "Waitlisted"
 msgstr "Jonossa"
 
-#: registrations/models.py:440
+#: registrations/models.py:479
 msgid "Attending"
 msgstr "Osallistuu"
 
-#: registrations/models.py:450
-msgid "No Notification"
-msgstr "Ei ilmoituksia"
-
-#: registrations/models.py:451
-msgid "SMS"
-msgstr "Teksiviesti"
-
-#: registrations/models.py:452
-msgid "E-Mail"
-msgstr "Sähköposti"
-
-#: registrations/models.py:453
-msgid "Both SMS and email."
-msgstr "Tekstiviesti ja sähköposti"
-
-#: registrations/models.py:461
+#: registrations/models.py:487
 msgid "Not present"
 msgstr "Ei paikalla"
 
-#: registrations/models.py:462
+#: registrations/models.py:488
 msgid "Present"
 msgstr "Paikalla"
 
-#: registrations/models.py:503
-msgid "Membership number"
-msgstr "Jäsennumero"
-
-#: registrations/models.py:517
-msgid "Notification type"
-msgstr "Ilmoitusten tyyppi"
-
-#: registrations/models.py:523
+#: registrations/models.py:525
 msgid "Attendee status"
 msgstr "Osallistujan tila"
 
-#: registrations/models.py:559
+#: registrations/models.py:547
 msgid "Presence status"
 msgstr "Läsnäolotila"
 
-#: registrations/models.py:676
+#: registrations/models.py:623
 msgid "Date of birth"
 msgstr "Syntymäaika"
 
-#: registrations/models.py:690
+#: registrations/models.py:697
+msgid "Membership number"
+msgstr "Jäsennumero"
+
+#: registrations/models.py:705
+msgid "Notification type"
+msgstr "Ilmoitusten tyyppi"
+
+#: registrations/models.py:798
+msgid "You must provide either signup_group or signup."
+msgstr ""
+
+#: registrations/models.py:802
+msgid "You can only provide signup_group or signup, not both."
+msgstr ""
+
+#: registrations/models.py:818
 msgid "Number of seats"
 msgstr "Paikkojen lukumäärä"
 
-#: registrations/models.py:696
+#: registrations/models.py:824
 msgid "Seat reservation code"
 msgstr "Paikkavarauskoodi"
 
-#: registrations/models.py:699
+#: registrations/models.py:827
 msgid "Timestamp"
 msgstr "Aikaleima"
 
+#: registrations/notifications.py:17
+msgid "No Notification"
+msgstr "Ei ilmoituksia"
+
 #: registrations/notifications.py:18
+msgid "SMS"
+msgstr "Teksiviesti"
+
+#: registrations/notifications.py:19
+msgid "E-Mail"
+msgstr "Sähköposti"
+
+#: registrations/notifications.py:20
+msgid "Both SMS and email."
+msgstr "Tekstiviesti ja sähköposti"
+
+#: registrations/notifications.py:33
+msgid "Event cancelled - %(event_name)s"
+msgstr "Tapahtuma peruttu - %(event_name)s"
+
+#: registrations/notifications.py:34
+#, python-format
+msgid "Registration cancelled - %(event_name)s"
+msgstr "Ilmoittautuminen peruttu - %(event_name)s"
+
+#: registrations/notifications.py:36 registrations/notifications.py:42
+#, python-format
+msgid "Registration confirmation - %(event_name)s"
+msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
+
+#: registrations/notifications.py:39
+#, python-format
+msgid "Waiting list seat reserved - %(event_name)s"
+msgstr "Paikka jonotuslistalla varattu - %(event_name)s"
+
+#: registrations/notifications.py:49
+msgid "Event %(event_name)s has been cancelled"
+msgstr "Tapahtuma %(event_name)s on peruttu."
+
+#: registrations/notifications.py:50
+msgid "Thank you for your interest in the event."
+msgstr "Kiitos mielenkiinnosta tapahtumaa kohtaan."
+
+#: registrations/notifications.py:53
 msgid "Registration cancelled"
 msgstr "Ilmoittautuminen peruttu"
 
-#: registrations/notifications.py:21
+#: registrations/notifications.py:56
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen tapahtumaan %(event_name)s on peruttu."
 
-#: registrations/notifications.py:24
+#: registrations/notifications.py:59
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen kurssille %(event_name)s on peruttu."
 
-#: registrations/notifications.py:27
+#: registrations/notifications.py:62
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -868,7 +910,7 @@ msgstr ""
 "%(username)s, ilmoittautuminen vapaaehtoistehtävään %(event_name)s on "
 "peruttu."
 
-#: registrations/notifications.py:32
+#: registrations/notifications.py:67
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -877,7 +919,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:35
+#: registrations/notifications.py:70
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -886,7 +928,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:38
+#: registrations/notifications.py:73
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -895,27 +937,27 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:43 registrations/notifications.py:131
+#: registrations/notifications.py:78 registrations/notifications.py:166
 #, python-format
 msgid "Welcome %(username)s"
 msgstr "Tervetuloa %(username)s"
 
-#: registrations/notifications.py:46
+#: registrations/notifications.py:81
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Ilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:49
+#: registrations/notifications.py:84
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Ilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:52
+#: registrations/notifications.py:87
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:57
+#: registrations/notifications.py:92
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -924,7 +966,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:60
+#: registrations/notifications.py:95
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -933,7 +975,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:63
+#: registrations/notifications.py:98
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -942,31 +984,31 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:67
+#: registrations/notifications.py:102
 msgid "Welcome"
 msgstr "Tervetuloa"
 
-#: registrations/notifications.py:70
+#: registrations/notifications.py:105
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:73
+#: registrations/notifications.py:108
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:76
+#: registrations/notifications.py:111
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr ""
 "Ryhmäilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:82
+#: registrations/notifications.py:117
 msgid "Thank you for signing up for the waiting list"
 msgstr "Kiitos ilmoittautumisesta jonoon"
 
-#: registrations/notifications.py:85
+#: registrations/notifications.py:120
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -975,7 +1017,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:88
+#: registrations/notifications.py:123
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -984,7 +1026,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut kurssin <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:91
+#: registrations/notifications.py:126
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -993,7 +1035,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut vapaaehtoistehtävän "
 "<strong>%(event_name)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:131
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -1001,7 +1043,7 @@ msgstr ""
 "Sinut siirretään automaattisesti tapahtuman osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:134
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1009,7 +1051,7 @@ msgstr ""
 "Sinut siirretään automaattisesti kurssin osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:102
+#: registrations/notifications.py:137
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1017,7 +1059,7 @@ msgstr ""
 "Sinut siirretään automaattisesti vapaaehtoistehtävän osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:108
+#: registrations/notifications.py:143
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1026,7 +1068,7 @@ msgstr ""
 "Ilmoittautuminen tapahtuman <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:111
+#: registrations/notifications.py:146
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1035,7 +1077,7 @@ msgstr ""
 "Ilmoittautuminen kurssin <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:114
+#: registrations/notifications.py:149
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1044,7 +1086,7 @@ msgstr ""
 "Ilmoittautuminen vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalle onnistui."
 
-#: registrations/notifications.py:119
+#: registrations/notifications.py:154
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1052,7 +1094,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti tapahtuman osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:122
+#: registrations/notifications.py:157
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1060,7 +1102,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti kurssin osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:125
+#: registrations/notifications.py:160
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1068,7 +1110,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti vapaaehtoistehtävän "
 "osallistujaksi mikäli paikka vapautuu."
 
-#: registrations/notifications.py:134
+#: registrations/notifications.py:169
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1077,7 +1119,7 @@ msgstr ""
 "Sinut on siirretty tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:137
+#: registrations/notifications.py:172
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1086,7 +1128,7 @@ msgstr ""
 "Sinut on siirretty kurssin <strong>%(event_name)s</strong> jonotuslistalta "
 "osallistujaksi."
 
-#: registrations/notifications.py:140
+#: registrations/notifications.py:175
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1095,93 +1137,71 @@ msgstr ""
 "Sinut on siirretty vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:207
-#, python-format
-msgid "Registration cancelled - %(event_name)s"
-msgstr "Ilmoittautuminen peruttu - %(event_name)s"
-
-#: registrations/notifications.py:211 registrations/notifications.py:219
-#, python-format
-msgid "Registration confirmation - %(event_name)s"
-msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
-
-#: registrations/notifications.py:215
-#, python-format
-msgid "Waiting list seat reserved - %(event_name)s"
-msgstr "Paikka jonotuslistalla varattu - %(event_name)s"
-
-#: registrations/serializers.py:34
+#: registrations/serializers.py:36
 msgid "Enrolment is not yet open."
 msgstr "Ilmoittautuminen ei ole vielä auki."
 
-#: registrations/serializers.py:36
+#: registrations/serializers.py:38
 msgid "Enrolment is already closed."
 msgstr "Ilmoittautuminen on jo päättynyt."
 
-#: registrations/serializers.py:152 registrations/serializers.py:489
+#: registrations/serializers.py:197 registrations/serializers.py:544
 msgid "The waiting list is already full"
 msgstr "Jonotuslista on jo täynnä"
 
-#: registrations/serializers.py:162
+#: registrations/serializers.py:207
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Olemassa olevan objektin attendee_status-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:169 registrations/serializers.py:654
+#: registrations/serializers.py:214 registrations/serializers.py:758
 msgid "You may not change the registration of an existing object."
 msgstr "Olemassa olevan objektin registration-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:202 registrations/serializers.py:213
-#: registrations/serializers.py:744
+#: registrations/serializers.py:256 registrations/serializers.py:267
+#: registrations/serializers.py:852
 msgid "This field must be specified."
 msgstr "Kenttä on pakollinen."
 
-#: registrations/serializers.py:228
+#: registrations/serializers.py:282
 msgid "The participant is too young."
 msgstr "Osallistuja on liian nuori."
 
-#: registrations/serializers.py:233
+#: registrations/serializers.py:287
 msgid "The participant is too old."
 msgstr "Osallistuja on liian vanha."
 
-#: registrations/serializers.py:241
-msgid ""
-"Cannot set responsible_for_group to False for the only responsible person of "
-"a group"
-msgstr ""
-
-#: registrations/serializers.py:432
+#: registrations/serializers.py:480
 msgid "Reservation code doesn't exist."
 msgstr "Varauskoodia ei ole olemassa."
 
-#: registrations/serializers.py:454
+#: registrations/serializers.py:502
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Ilmoittautumisten määrä on suurempi kuin ryhmän enimmäiskoko: "
 "{max_group_size}."
 
-#: registrations/serializers.py:565
-msgid ""
-"A group must have at least one participant who is responsible for the group"
+#: registrations/serializers.py:635
+msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:747
+#: registrations/serializers.py:855
 msgid "The value doesn't match."
 msgstr "Arvo ei täsmää."
 
-#: registrations/serializers.py:765
+#: registrations/serializers.py:873
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
 
-#: registrations/serializers.py:790
+#: registrations/serializers.py:898
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Paikkoja ei ole riittävästi jäljellä. Paikkoja jäljellä: {capacity_left}."
 
-#: registrations/serializers.py:806
+#: registrations/serializers.py:914
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1189,7 +1209,7 @@ msgstr ""
 "Jonotuslistalle ei ole tarpeeksi paikkoja jäljellä. Paikkoja jäljellä "
 "jonotuslistalla: {capacity_left}."
 
-#: registrations/serializers.py:820
+#: registrations/serializers.py:928
 msgid "Cannot update expired seats reservation."
 msgstr "Vanhentunutta paikkavarausta ei voi päivittää."
 
@@ -1214,6 +1234,7 @@ msgid "All rights reserved."
 msgstr "Kaikki oikeudet pidätetään."
 
 #: registrations/templates/cancellation_confirmation.html:22
+#: registrations/templates/event_cancellation_confirmation.html:19
 msgid "More information from our customer service"
 msgstr "Lisätietoja asiakaspalvelustamme"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-20 13:49+0000\n"
+"POT-Creation-Date: 2023-12-12 08:51+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,14 +59,14 @@ msgid ""
 "data_source must be left blank or set to %(required)s "
 msgstr ""
 
-#: events/api.py:635 events/api.py:837
+#: events/api.py:635 events/api.py:835
 #, python-format
 msgid ""
 "Setting id to %(given)s is not allowed for your organization. The id must be "
 "left blank or set to %(data_source)s:desired_id"
 msgstr ""
 
-#: events/api.py:670
+#: events/api.py:672
 #, python-format
 msgid ""
 "Setting %(field)s to %(given)s is not allowed for this user. The %(field)s "
@@ -74,121 +74,121 @@ msgid ""
 "belongs to."
 msgstr ""
 
-#: events/api.py:705
+#: events/api.py:703
 msgid "The name must be specified."
 msgstr "Namn måste anges."
 
-#: events/api.py:770
+#: events/api.py:768
 msgid "An object with given id already exists."
 msgstr ""
 
-#: events/api.py:781 events/api.py:1032
+#: events/api.py:779 events/api.py:1030
 msgid "You may not change the id of an existing object."
 msgstr "Du får inte ändra id för ett befintligt objekt."
 
-#: events/api.py:790
+#: events/api.py:788
 msgid "You may not change the publisher of an existing object."
 msgstr "Du får inte ändra utgivare för ett befintligt objekt."
 
-#: events/api.py:801 events/api.py:1052
+#: events/api.py:799 events/api.py:1050
 msgid "You may not change the data source of an existing object."
 msgstr "Du får inte ändra datakälla för ett befintligt objekt."
 
-#: events/api.py:1041
+#: events/api.py:1039
 msgid "You may not change the organization of an existing object."
 msgstr "Du får inte ändra organisation för ett befintligt objekt."
 
-#: events/api.py:1561
+#: events/api.py:1559
 msgid "User has no rights to this organization"
 msgstr "Användaren har inga rättigheter till denna organisation"
 
-#: events/api.py:1937 events/api.py:2032
+#: events/api.py:1935 events/api.py:2030
 #, python-format
 msgid "Registration user access with email %(email)s already exists."
 msgstr ""
 
-#: events/api.py:1968 events/permissions.py:144
+#: events/api.py:1966 events/permissions.py:144
 msgid "Object data source does not match user data source"
 msgstr ""
 
-#: events/api.py:1980
+#: events/api.py:1978
 msgid "Event already has a registration."
 msgstr ""
 
-#: events/api.py:2221
+#: events/api.py:2219
 msgid "Deprecated keyword not allowed ({})"
 msgstr ""
 
-#: events/api.py:2271
+#: events/api.py:2269
 msgid "You have to set either user_email or user_phone_number."
 msgstr ""
 
-#: events/api.py:2280
+#: events/api.py:2278
 msgid "User consent is required if personal information fields are filled."
 msgstr ""
 
-#: events/api.py:2283
+#: events/api.py:2281
 msgid "This field must be specified before an event is published."
 msgstr "Detta fält måste anges innan ett evenemanget publiceras."
 
-#: events/api.py:2297
+#: events/api.py:2295
 msgid "Short description length must be 160 characters or less"
 msgstr ""
 
-#: events/api.py:2313
+#: events/api.py:2311
 msgid "Price info must be specified before an event is published."
 msgstr ""
 
-#: events/api.py:2347
+#: events/api.py:2345
 msgid "End time cannot be in the past. Please set a future end time."
 msgstr "Sluttiden kan inte ligga i det förflutna. Ange en framtida sluttid."
 
-#: events/api.py:2431
+#: events/api.py:2429
 msgid "Cannot edit a past event."
 msgstr ""
 
-#: events/api.py:2446
+#: events/api.py:2444
 msgid ""
 "POSTPONED and RESCHEDULED statuses cannot be set directly.Changing event "
 "start_time or marking start_time nullwill reschedule or postpone an event."
 msgstr ""
 
-#: events/api.py:2467
+#: events/api.py:2465
 msgid ""
 "Public events cannot be set back to SCHEDULED if theyhave already been "
 "CANCELLED, POSTPONED or RESCHEDULED."
 msgstr ""
 
-#: events/api.py:3038
+#: events/api.py:3027
 #, python-brace-format
 msgid "Event type can be of the following values: {event_types}"
 msgstr ""
 
-#: events/api.py:3066
+#: events/api.py:3055
 msgid "Error while parsing days."
 msgstr ""
 
-#: events/api.py:3068
+#: events/api.py:3057
 msgid "Days must be 1 or more."
 msgstr ""
 
-#: events/api.py:3072
+#: events/api.py:3061
 msgid "Start or end cannot be used with days."
 msgstr ""
 
-#: events/api.py:3528
+#: events/api.py:3517
 msgid "x_full_text supports the following languages: fi, en, sv"
 msgstr ""
 
-#: events/api.py:3946
+#: events/api.py:3938
 msgid "Must specify a location when fetching DOCX file."
 msgstr ""
 
-#: events/api.py:3950
+#: events/api.py:3942
 msgid "No events."
 msgstr "Inga evenemang."
 
-#: events/api.py:3952
+#: events/api.py:3944
 msgid "Only one location allowed."
 msgstr ""
 
@@ -201,11 +201,11 @@ msgstr ""
 
 #: events/models.py:78 events/models.py:189 events/models.py:206
 #: events/models.py:333 events/models.py:400 events/models.py:414
-#: events/models.py:1293 events/models.py:1309 events/models.py:1359
-#: registrations/exports.py:27
+#: events/models.py:1294 events/models.py:1310 events/models.py:1360
 #: venv/lib/python3.9/site-packages/munigeo/models.py:83
 #: venv/lib/python3.9/site-packages/munigeo/models.py:112
 #: venv/lib/python3.9/site-packages/munigeo/models.py:141
+#: registrations/exports.py:34
 msgid "Name"
 msgstr "Namn"
 
@@ -264,7 +264,7 @@ msgstr "Beskärning"
 msgid "Photographer name"
 msgstr "Fotografens namn"
 
-#: events/models.py:260 events/models.py:1316
+#: events/models.py:260 events/models.py:1317
 msgid "Alt text"
 msgstr "Alt text"
 
@@ -335,8 +335,8 @@ msgstr "Placera hemsida"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: events/models.py:621 events/models.py:1360 registrations/exports.py:28
-#: registrations/models.py:367 registrations/models.py:500
+#: events/models.py:621 events/models.py:1361 registrations/exports.py:36
+#: registrations/models.py:406 registrations/models.py:670
 msgid "E-mail"
 msgstr "E-post"
 
@@ -348,7 +348,7 @@ msgstr "Telefon"
 msgid "Contact type"
 msgstr "Kontakt typ"
 
-#: events/models.py:629 registrations/models.py:47 registrations/models.py:544
+#: events/models.py:629 registrations/models.py:50 registrations/models.py:532
 msgid "Street address"
 msgstr "Gatuadress"
 
@@ -443,7 +443,7 @@ msgstr "Användarens organisation"
 msgid "Event organizer information."
 msgstr "Event arrangör information."
 
-#: events/models.py:846 registrations/models.py:566
+#: events/models.py:846 registrations/models.py:554
 msgid "User consent"
 msgstr "Användarens samtycke"
 
@@ -511,11 +511,11 @@ msgstr "Starttid"
 msgid "End time"
 msgstr "Sluttid"
 
-#: events/models.py:937 registrations/models.py:121
+#: events/models.py:937 registrations/models.py:124
 msgid "Minimum recommended age"
 msgstr "Rekommenderad lägsta ålder"
 
-#: events/models.py:940 registrations/models.py:124
+#: events/models.py:940 registrations/models.py:127
 msgid "Maximum recommended age"
 msgstr "Högsta rekommenderade ålder"
 
@@ -547,38 +547,38 @@ msgstr "evenemang"
 msgid "events"
 msgstr "evenemang"
 
-#: events/models.py:1019
+#: events/models.py:1020
 msgid ""
 "Trying to replace this event with an event that is replaced by this event. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements."
 msgstr ""
 
-#: events/models.py:1058
+#: events/models.py:1059
 msgid "The event end time cannot be earlier than the start time."
 msgstr "Evenemangs sluttid kan inte vara tidigare än starttiden."
 
-#: events/models.py:1274
+#: events/models.py:1275
 msgid "Price"
 msgstr "Pris"
 
-#: events/models.py:1276
+#: events/models.py:1277
 msgid "Web link to offer"
 msgstr "Webblänk att erbjuda"
 
-#: events/models.py:1279
+#: events/models.py:1280
 msgid "Offer description"
 msgstr "Erbjudandebeskrivning"
 
-#: events/models.py:1283
+#: events/models.py:1284
 msgid "Is free"
 msgstr "Är gratis"
 
-#: events/models.py:1361 notifications/models.py:47
+#: events/models.py:1362 notifications/models.py:47
 msgid "Subject"
 msgstr "Ämne"
 
-#: events/models.py:1362 notifications/models.py:53
+#: events/models.py:1363 notifications/models.py:53
 msgid "Body"
 msgstr "Text"
 
@@ -662,16 +662,19 @@ msgstr "Deltagarlista användare"
 msgid "Registration with signups cannot be deleted"
 msgstr "Registrering med registreringar kan inte raderas"
 
-#: registrations/api.py:329
-msgid "Invalid registration ID(s) given."
+#: registrations/api.py:173 registrations/api.py:379
+msgid "Only the admins of the registration organizations have access rights."
+msgstr ""
+"Endast administratörerna för registreringsorganisationerna har "
+"åtkomsträttigheter."
+
+#: registrations/api.py:206
+msgid ""
+"No contact persons with email addresses found for the given participants."
 msgstr ""
 
-#: registrations/api.py:346
-msgid "Only the admins of the registration organizations have access rights."
-msgstr "Endast administratörerna för registreringsorganisationerna har åtkomsträttigheter."
-
-#: registrations/api.py:459
-msgid "Cannot delete the only responsible person of a group"
+#: registrations/api.py:358
+msgid "Invalid registration ID(s) given."
 msgstr ""
 
 #: registrations/exceptions.py:8
@@ -682,12 +685,11 @@ msgstr "Begärkonflikt med målresursens aktuella tillstånd"
 msgid "Registered persons"
 msgstr "Registrerade personer"
 
-#: registrations/exports.py:29 registrations/models.py:46
-#: registrations/models.py:510
+#: registrations/exports.py:42 registrations/models.py:674
 msgid "Phone number"
 msgstr "Telefonnummer"
 
-#: registrations/exports.py:42
+#: registrations/exports.py:59
 msgid ""
 "This material is subject to data protection. This material must be processed "
 "in the manner required by data protection and only to verify \n"
@@ -699,164 +701,205 @@ msgstr ""
 "deltagarna i evenemanget. Denna lista ska kasseras när evenemanget är över "
 "och deltagarna har lagts in i systemet."
 
-#: registrations/exports.py:54
+#: registrations/exports.py:71
 msgid ""
 "Please note that the participant and the participant's contact information "
 "may be the information of different persons."
 msgstr ""
-"Observera att deltagarens och deltagarens kontaktuppgifter kan vara information "
-"från olika personer."
+"Observera att deltagarens och deltagarens kontaktuppgifter kan vara "
+"information från olika personer."
 
-#: registrations/models.py:43 registrations/models.py:493
+#: registrations/models.py:47 registrations/models.py:518
 msgid "City"
 msgstr "Stad"
 
-#: registrations/models.py:44 registrations/models.py:479
+#: registrations/models.py:48 registrations/models.py:504
+#: registrations/models.py:655
 msgid "First name"
 msgstr "Förnamn"
 
-#: registrations/models.py:45 registrations/models.py:486
+#: registrations/models.py:49 registrations/models.py:511
+#: registrations/models.py:662
 msgid "Last name"
 msgstr "Efternamn"
 
-#: registrations/models.py:48 registrations/models.py:551
+#: registrations/models.py:51 registrations/models.py:539
 msgid "ZIP code"
 msgstr "Postnummer"
 
-#: registrations/models.py:80
+#: registrations/models.py:83
 msgid "Created at"
 msgstr "Skapad kl"
 
-#: registrations/models.py:86
+#: registrations/models.py:89
 msgid "Modified at"
 msgstr "Ändrad kl"
 
-#: registrations/models.py:128
+#: registrations/models.py:131
 msgid "Enrollment start time"
 msgstr "Starttid för anmälan"
 
-#: registrations/models.py:131
+#: registrations/models.py:134
 msgid "Enrollment end time"
 msgstr "Sluttid för anmälan"
 
-#: registrations/models.py:135
+#: registrations/models.py:138
 msgid "Confirmation message"
 msgstr "Bekräftelsemeddelande"
 
-#: registrations/models.py:138
+#: registrations/models.py:141
 msgid "Instructions"
 msgstr "Instruktioner"
 
-#: registrations/models.py:142
+#: registrations/models.py:145
 msgid "Maximum attendee capacity"
 msgstr "Maximal deltagarekapacitet"
 
-#: registrations/models.py:145
+#: registrations/models.py:148
 msgid "Minimum attendee capacity"
 msgstr "Minsta deltagarekapacitet"
 
-#: registrations/models.py:148
+#: registrations/models.py:151
 msgid "Waiting list capacity"
 msgstr "Väntelistans kapacitet"
 
-#: registrations/models.py:151
+#: registrations/models.py:154
 msgid "Maximum group size"
 msgstr "Maximal gruppstorlek"
 
-#: registrations/models.py:165
+#: registrations/models.py:168
 msgid "Mandatory fields"
 msgstr "Obligatoriska fält"
 
-#: registrations/models.py:346
+#: registrations/models.py:332 registrations/models.py:559
+msgid "Anonymization time"
+msgstr ""
+
+#: registrations/models.py:381
 msgid "Extra info"
 msgstr "Ytterligare info"
 
-#: registrations/models.py:413
+#: registrations/models.py:452
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Rättigheter tilldelade deltagarlistan - %(event_name)s"
 
-#: registrations/models.py:439
+#: registrations/models.py:478
 msgid "Waitlisted"
 msgstr "I kö"
 
-#: registrations/models.py:440
+#: registrations/models.py:479
 msgid "Attending"
 msgstr "Deltar"
 
-#: registrations/models.py:450
-msgid "No Notification"
-msgstr "Ingen anmälan"
-
-#: registrations/models.py:451
-msgid "SMS"
-msgstr "SMS"
-
-#: registrations/models.py:452
-msgid "E-Mail"
-msgstr "E-post"
-
-#: registrations/models.py:453
-msgid "Both SMS and email."
-msgstr "Både SMS och e-post."
-
-#: registrations/models.py:461
+#: registrations/models.py:487
 msgid "Not present"
 msgstr "Inte närvarande"
 
-#: registrations/models.py:462
+#: registrations/models.py:488
 msgid "Present"
 msgstr "Närvarande"
 
-#: registrations/models.py:503
-msgid "Membership number"
-msgstr "Medlemsnummer"
-
-#: registrations/models.py:517
-msgid "Notification type"
-msgstr "Aviseringstyp"
-
-#: registrations/models.py:523
+#: registrations/models.py:525
 msgid "Attendee status"
 msgstr "Deltagarstatus"
 
-#: registrations/models.py:559
+#: registrations/models.py:547
 msgid "Presence status"
 msgstr "Närvarostatus"
 
-#: registrations/models.py:676
+#: registrations/models.py:623
 msgid "Date of birth"
 msgstr "Födelsedatum"
 
-#: registrations/models.py:690
+#: registrations/models.py:697
+msgid "Membership number"
+msgstr "Medlemsnummer"
+
+#: registrations/models.py:705
+msgid "Notification type"
+msgstr "Aviseringstyp"
+
+#: registrations/models.py:798
+msgid "You must provide either signup_group or signup."
+msgstr ""
+
+#: registrations/models.py:802
+msgid "You can only provide signup_group or signup, not both."
+msgstr ""
+
+#: registrations/models.py:818
 msgid "Number of seats"
 msgstr "Antal platser"
 
-#: registrations/models.py:696
+#: registrations/models.py:824
 msgid "Seat reservation code"
 msgstr "Platsreservationskod"
 
-#: registrations/models.py:699
+#: registrations/models.py:827
 msgid "Timestamp"
 msgstr "Tidsstämpel"
 
+#: registrations/notifications.py:17
+msgid "No Notification"
+msgstr "Ingen anmälan"
+
 #: registrations/notifications.py:18
+msgid "SMS"
+msgstr "SMS"
+
+#: registrations/notifications.py:19
+msgid "E-Mail"
+msgstr "E-post"
+
+#: registrations/notifications.py:20
+msgid "Both SMS and email."
+msgstr "Både SMS och e-post."
+
+#: registrations/notifications.py:33
+msgid "Event cancelled - %(event_name)s"
+msgstr "Evenemanget inställt - %(event_name)s"
+
+#: registrations/notifications.py:34
+#, python-format
+msgid "Registration cancelled - %(event_name)s"
+msgstr "Registreringen avbruten - %(event_name)s"
+
+#: registrations/notifications.py:36 registrations/notifications.py:42
+#, python-format
+msgid "Registration confirmation - %(event_name)s"
+msgstr "Bekräftelse av registrering - %(event_name)s"
+
+#: registrations/notifications.py:39
+#, python-format
+msgid "Waiting list seat reserved - %(event_name)s"
+msgstr "Väntelista plats reserverad - %(event_name)s"
+
+#: registrations/notifications.py:49
+msgid "Event %(event_name)s has been cancelled"
+msgstr "Evenemanget %(event_name)s har ställts in."
+
+#: registrations/notifications.py:50
+msgid "Thank you for your interest in the event."
+msgstr "Tack för ditt intresse för evenemanget."
+
+#: registrations/notifications.py:53
 msgid "Registration cancelled"
 msgstr "Registreringen avbruten"
 
-#: registrations/notifications.py:21
+#: registrations/notifications.py:56
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:24
+#: registrations/notifications.py:59
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till kursen %(event_name)s har ställts in."
 
-#: registrations/notifications.py:27
+#: registrations/notifications.py:62
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -864,7 +907,7 @@ msgid ""
 msgstr ""
 "%(username)s, anmälan till volontärarbetet %(event_name)s har ställts in."
 
-#: registrations/notifications.py:32
+#: registrations/notifications.py:67
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -873,7 +916,7 @@ msgstr ""
 "Du har avbrutit din registrering till evenemanget <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:35
+#: registrations/notifications.py:70
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -881,7 +924,7 @@ msgid ""
 msgstr ""
 "Du har avbrutit din registrering till kursen <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:38
+#: registrations/notifications.py:73
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -890,27 +933,27 @@ msgstr ""
 "Du har avbrutit din registrering till volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:43 registrations/notifications.py:131
+#: registrations/notifications.py:78 registrations/notifications.py:166
 #, python-format
 msgid "Welcome %(username)s"
 msgstr "Välkommen %(username)s"
 
-#: registrations/notifications.py:46
+#: registrations/notifications.py:81
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Anmälan till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:49
+#: registrations/notifications.py:84
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Anmälan till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:52
+#: registrations/notifications.py:87
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Anmälan till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:57
+#: registrations/notifications.py:92
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -919,7 +962,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för evenemanget "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:60
+#: registrations/notifications.py:95
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -928,7 +971,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för kursen <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:63
+#: registrations/notifications.py:98
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -937,30 +980,30 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:67
+#: registrations/notifications.py:102
 msgid "Welcome"
 msgstr "Välkommen"
 
-#: registrations/notifications.py:70
+#: registrations/notifications.py:105
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Gruppregistrering till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:73
+#: registrations/notifications.py:108
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Gruppregistrering till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:76
+#: registrations/notifications.py:111
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr "Gruppregistrering till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:82
+#: registrations/notifications.py:117
 msgid "Thank you for signing up for the waiting list"
 msgstr "Tack för att du skrev upp dig på väntelistan"
 
-#: registrations/notifications.py:85
+#: registrations/notifications.py:120
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -969,7 +1012,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för evenemangets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:88
+#: registrations/notifications.py:123
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -978,7 +1021,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för kursen <strong>%(event_name)s</"
 "strong> väntelista."
 
-#: registrations/notifications.py:91
+#: registrations/notifications.py:126
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -987,7 +1030,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för volontärarbetets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:131
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -995,7 +1038,7 @@ msgstr ""
 "Du kommer automatiskt att överföras som evenemangsdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:134
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1003,7 +1046,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som kursdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:102
+#: registrations/notifications.py:137
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1011,7 +1054,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som evenemangsdeltagare om en plats "
 "blir ledig."
 
-#: registrations/notifications.py:108
+#: registrations/notifications.py:143
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1020,7 +1063,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "evenemanget lyckades."
 
-#: registrations/notifications.py:111
+#: registrations/notifications.py:146
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1029,7 +1072,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-kursen "
 "lyckades."
 
-#: registrations/notifications.py:114
+#: registrations/notifications.py:149
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1038,7 +1081,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "volontärarbetet lyckades."
 
-#: registrations/notifications.py:119
+#: registrations/notifications.py:154
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1046,7 +1089,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "evenemanget om en plats blir ledig."
 
-#: registrations/notifications.py:122
+#: registrations/notifications.py:157
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1054,7 +1097,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i kursen "
 "om en plats blir ledig."
 
-#: registrations/notifications.py:125
+#: registrations/notifications.py:160
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1062,7 +1105,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "volontärarbetet om en plats blir ledig."
 
-#: registrations/notifications.py:134
+#: registrations/notifications.py:169
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1071,7 +1114,7 @@ msgstr ""
 "Du har flyttats från väntelistan för evenemanget <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:137
+#: registrations/notifications.py:172
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1080,7 +1123,7 @@ msgstr ""
 "Du har flyttats från väntelistan för kursen <strong>%(event_name)s</strong> "
 "till en deltagare."
 
-#: registrations/notifications.py:140
+#: registrations/notifications.py:175
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1089,92 +1132,70 @@ msgstr ""
 "Du har flyttats från väntelistan för volontärarbetet <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:207
-#, python-format
-msgid "Registration cancelled - %(event_name)s"
-msgstr "Registreringen avbruten - %(event_name)s"
-
-#: registrations/notifications.py:211 registrations/notifications.py:219
-#, python-format
-msgid "Registration confirmation - %(event_name)s"
-msgstr "Bekräftelse av registrering - %(event_name)s"
-
-#: registrations/notifications.py:215
-#, python-format
-msgid "Waiting list seat reserved - %(event_name)s"
-msgstr "Väntelista plats reserverad - %(event_name)s"
-
-#: registrations/serializers.py:34
+#: registrations/serializers.py:36
 msgid "Enrolment is not yet open."
 msgstr "Anmälan är ännu inte öppen."
 
-#: registrations/serializers.py:36
+#: registrations/serializers.py:38
 msgid "Enrolment is already closed."
 msgstr "Anmälan är redan stängd"
 
-#: registrations/serializers.py:152 registrations/serializers.py:489
+#: registrations/serializers.py:197 registrations/serializers.py:544
 msgid "The waiting list is already full"
 msgstr "Väntelistan är redan full"
 
-#: registrations/serializers.py:162
+#: registrations/serializers.py:207
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Du får inte ändra attendee_status för ett befintligt objekt."
 
-#: registrations/serializers.py:169 registrations/serializers.py:654
+#: registrations/serializers.py:214 registrations/serializers.py:758
 msgid "You may not change the registration of an existing object."
 msgstr "Du får inte ändra registration för ett befintligt objekt."
 
-#: registrations/serializers.py:202 registrations/serializers.py:213
-#: registrations/serializers.py:744
+#: registrations/serializers.py:256 registrations/serializers.py:267
+#: registrations/serializers.py:852
 msgid "This field must be specified."
 msgstr "Detta fält måste anges."
 
-#: registrations/serializers.py:228
+#: registrations/serializers.py:282
 msgid "The participant is too young."
 msgstr "Deltagaren är för ung."
 
-#: registrations/serializers.py:233
+#: registrations/serializers.py:287
 msgid "The participant is too old."
 msgstr "Deltagaren är för gammal."
 
-#: registrations/serializers.py:241
-msgid ""
-"Cannot set responsible_for_group to False for the only responsible person of "
-"a group"
-msgstr ""
-
-#: registrations/serializers.py:432
+#: registrations/serializers.py:480
 msgid "Reservation code doesn't exist."
 msgstr "Bokningskoden finns inte."
 
-#: registrations/serializers.py:454
+#: registrations/serializers.py:502
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Antalet registreringar är större än den maximala gruppstorleken: "
 "{max_group_size}."
 
-#: registrations/serializers.py:565
-msgid ""
-"A group must have at least one participant who is responsible for the group"
+#: registrations/serializers.py:635
+msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:747
+#: registrations/serializers.py:855
 msgid "The value doesn't match."
 msgstr "Värdet stämmer inte överens."
 
-#: registrations/serializers.py:765
+#: registrations/serializers.py:873
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr "Antalet platser är större än maximal gruppstorlek: {max_group_size}."
 
-#: registrations/serializers.py:790
+#: registrations/serializers.py:898
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Inte tillräckligt med platser tillgängliga. Kapacitet kvar: {capacity_left}."
 
-#: registrations/serializers.py:806
+#: registrations/serializers.py:914
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1182,7 +1203,7 @@ msgstr ""
 "Inte tillräckligt med kapacitet på väntelistan. Kapacitet kvar: "
 "{capacity_left}."
 
-#: registrations/serializers.py:820
+#: registrations/serializers.py:928
 msgid "Cannot update expired seats reservation."
 msgstr "Kan inte uppdatera utgångna platsreservationer."
 
@@ -1207,6 +1228,7 @@ msgid "All rights reserved."
 msgstr "Alla rättigheter förbehållna."
 
 #: registrations/templates/cancellation_confirmation.html:22
+#: registrations/templates/event_cancellation_confirmation.html:19
 msgid "More information from our customer service"
 msgstr "Mer information om vår kundtjänst"
 

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -1,5 +1,4 @@
 import logging
-from smtplib import SMTPException
 
 import bleach
 import django_filters
@@ -211,16 +210,7 @@ class RegistrationViewSet(
         messages = self._get_messages(
             subject, cleaned_body, plain_text_body, message_contact_persons
         )
-
-        try:
-            send_mass_html_mail(messages, fail_silently=False)
-        except SMTPException as e:
-            logger.exception("Couldn't send mass HTML email.")
-
-            return Response(
-                str(e),
-                status=status.HTTP_409_CONFLICT,
-            )
+        send_mass_html_mail(messages, fail_silently=False)
 
         self._add_audit_logged_object_ids(message_contact_persons)
 

--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -1,9 +1,17 @@
 from typing import Union
 
-from django.db.models.signals import post_delete
+from django.db.models import Q
+from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 
-from registrations.models import SignUp, SignUpGroup, SignUpNotificationType
+from events.models import Event
+from registrations.models import (
+    Registration,
+    SignUp,
+    SignUpContactPerson,
+    SignUpGroup,
+    SignUpNotificationType,
+)
 
 
 def _signup_or_group_post_delete(instance: Union[SignUp, SignUpGroup]) -> None:
@@ -15,6 +23,22 @@ def _signup_or_group_post_delete(instance: Union[SignUp, SignUpGroup]) -> None:
     contact_person = getattr(instance, "contact_person", None)
     if contact_person:
         contact_person.send_notification(SignUpNotificationType.CANCELLATION)
+
+
+def _send_event_cancellation_notification(event):
+    registration_ids = Registration.objects.filter(event_id=event.pk).values_list(
+        "pk", flat=True
+    )
+
+    for contact_person in SignUpContactPerson.objects.filter(
+        Q(email__isnull=False)
+        & ~Q(email="")
+        & (
+            Q(signup__registration_id__in=registration_ids)
+            | Q(signup_group__registration_id__in=registration_ids)
+        )
+    ):
+        contact_person.send_notification(SignUpNotificationType.EVENT_CANCELLATION)
 
 
 @receiver(
@@ -36,3 +60,19 @@ def signup_group_post_delete(
     sender: type[SignUpGroup], instance: SignUpGroup, **kwargs: dict
 ) -> None:
     _signup_or_group_post_delete(instance)
+
+
+@receiver(
+    pre_save,
+    sender=Event,
+    dispatch_uid="notify_signups_on_event_cancellation_pre_save",
+)
+def notify_signups_on_event_cancellation_pre_save(
+    sender: type[Event], instance: Event, **kwargs: dict
+) -> None:
+    if not (instance.pk and instance.event_status == Event.Status.CANCELLED):
+        return
+
+    old_instance = Event.objects.filter(pk=instance.pk).first()
+    if old_instance and old_instance.event_status != instance.event_status:
+        _send_event_cancellation_notification(instance)

--- a/registrations/templates/event_cancellation_confirmation.html
+++ b/registrations/templates/event_cancellation_confirmation.html
@@ -1,0 +1,26 @@
+{% extends 'base_email.html' %}
+{% load i18n %}
+
+{% block content %}
+  <tr>
+    <td class="content-cell" style="padding:0;margin:0;text-align:left;">
+      <div class="content-container" style="padding:0 16px;">
+        <h1 style="color:#1a1a1a;font-size:36px;line-height:43px;font-weight:700;margin:0 0 12px;">
+          {{texts.heading}}
+        </h1>
+        <div class="divider" style="background:#0000bf;border-radius:0px;height:3px;width:100%;margin:24px 0;"></div>
+        <div style="margin: 56px 0px 24px">
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
+            {{texts.text}}
+          </p>
+        </div>
+        <div style="margin: 24px 0px 40px">
+          <p style="color:#1a1a1a;font-size:16px;font-weight:normal;line-height:24px;margin:0px;">
+            {% blocktranslate %}More information from our customer service{% endblocktranslate %}
+            <a href="mailto:linkedevents@hel.fi" class="link" style="color:#0000bf;font-size:16px;font-weight:500;">linkedevents@hel.fi</a>
+          </p>
+        </div>
+      </div>
+    </td>
+  </tr>
+{% endblock content %}

--- a/registrations/tests/test_event_cancellation_notification.py
+++ b/registrations/tests/test_event_cancellation_notification.py
@@ -1,0 +1,238 @@
+from unittest.mock import patch
+
+import pytest
+from django.core import mail
+from django.utils import translation
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from events.models import Event
+from events.tests.conftest import TEXT_EN, TEXT_FI, TEXT_SV
+from events.tests.factories import LanguageFactory, PlaceFactory
+from events.tests.utils import versioned_reverse as reverse
+from helevents.tests.factories import UserFactory
+from registrations.models import SignUpContactPerson
+from registrations.notifications import (
+    signup_email_texts,
+    signup_notification_subjects,
+    SignUpNotificationType,
+)
+from registrations.tests.factories import (
+    RegistrationFactory,
+    SignUpContactPersonFactory,
+    SignUpFactory,
+    SignUpGroupFactory,
+)
+
+
+@pytest.mark.usefixtures("make_complex_event_dict_class")
+class EventCancellationNotificationAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        registration = RegistrationFactory(
+            event__name_en=TEXT_EN,
+            event__name_sv=TEXT_SV,
+            event__name_fi=TEXT_FI,
+            event__data_source__user_editable_resources=True,
+        )
+
+        cls.event = registration.event
+        cls.event_detail_url = reverse("event-detail", kwargs={"pk": cls.event.pk})
+
+        cls.languages = [
+            LanguageFactory(id="fi", service_language=True),
+            LanguageFactory(id="sv", service_language=True),
+            LanguageFactory(id="en", service_language=True),
+        ]
+
+        place = PlaceFactory(
+            data_source=cls.event.data_source, publisher=cls.event.publisher
+        )
+        cls.location_id = reverse("place-detail", kwargs={"pk": place.pk})
+
+        cls.user = UserFactory()
+        cls.user.admin_organizations.add(cls.event.publisher)
+
+        signup = SignUpFactory(registration=registration)
+        SignUpContactPersonFactory(
+            signup=signup,
+            email="test-signup@test.com",
+            service_language=cls.languages[0],
+        )
+
+        signup2 = SignUpFactory(registration=registration)
+        SignUpContactPersonFactory(
+            signup=signup2,
+            email="test-signup2@test.com",
+            service_language=cls.languages[1],
+        )
+
+        signup_group = SignUpGroupFactory(registration=registration)
+        SignUpContactPersonFactory(
+            signup_group=signup_group,
+            email="test-group@test.com",
+            service_language=cls.languages[2],
+        )
+        SignUpFactory(registration=registration, signup_group=signup_group)
+        SignUpFactory(registration=registration, signup_group=signup_group)
+
+    def setUp(self):
+        self.client.force_authenticate(self.user)
+
+    def test_event_put_cancellation_email_sent_to_contact_persons(self):
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        response = self.client.put(
+            self.event_detail_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(len(mail.outbox), contact_person_count)
+
+        notification_subject = signup_notification_subjects[
+            SignUpNotificationType.EVENT_CANCELLATION
+        ]
+        notification_texts = signup_email_texts[
+            SignUpNotificationType.EVENT_CANCELLATION
+        ]
+
+        contact_persons = SignUpContactPerson.objects.all().order_by("-pk")
+        for index, contact_person in enumerate(contact_persons):
+            self.assertEqual(mail.outbox[index].to[0], contact_person.email)
+
+            with translation.override(contact_person.service_language.pk):
+                self.assertEqual(
+                    mail.outbox[index].subject,
+                    notification_subject % {"event_name": self.event.name},
+                )
+
+                html_message = str(mail.outbox[index].alternatives[0])
+                self.assertTrue(
+                    notification_texts["heading"] % {"event_name": self.event.name}
+                    in html_message
+                )
+                self.assertTrue(str(notification_texts["text"]) in html_message)
+
+    def test_event_put_cancellation_email_not_sent_to_contact_persons_if_cancelled_again(
+        self,
+    ):
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+
+        Event.objects.filter(pk=self.event.pk).update(
+            event_status=Event.Status.CANCELLED
+        )
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        response = self.client.put(
+            self.event_detail_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_put_cancellation_email_not_sent_to_contact_persons_if_transaction_rolled_back(
+        self,
+    ):
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+
+        Event.objects.filter(pk=self.event.pk).update(
+            event_status=Event.Status.CANCELLED
+        )
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with patch(
+            "django.db.models.signals.post_save.send"
+        ) as mocked_post_save_signal:
+            mocked_post_save_signal.side_effect = Exception
+
+            with self.assertRaises(Exception):
+                self.client.put(
+                    self.event_detail_url,
+                    complex_event_dict,
+                    format="json",
+                )
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_post_cancellation_email_not_sent_to_contact_persons(self):
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+
+        self.assertEqual(Event.objects.count(), 1)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+        del complex_event_dict["data_source"]
+
+        events_url = reverse("event-list")
+        response = self.client.post(
+            events_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Event.objects.count(), 2)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_get_cancellation_email_not_sent_to_contact_persons(self):
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+
+        response = self.client.get(
+            self.event_detail_url,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_delete_cancellation_email_not_sent_to_contact_persons(self):
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+
+        response = self.client.delete(
+            self.event_detail_url,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/registrations/tests/test_send_message.py
+++ b/registrations/tests/test_send_message.py
@@ -1,6 +1,4 @@
 from collections import Counter
-from smtplib import SMTPException
-from unittest.mock import patch
 
 import pytest
 from django.conf import settings
@@ -606,18 +604,6 @@ def test_send_message_no_contact_persons_found(user_api_client, registration):
 
     response = send_message(user_api_client, registration.id, send_message_data)
     assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-@pytest.mark.django_db
-def test_send_message_exception(user_api_client, registration):
-    signup = SignUpFactory(registration=registration)
-    SignUpContactPersonFactory(signup=signup, email="test@test.com")
-
-    send_message_data = {"subject": "Message subject", "body": "Message body"}
-
-    with patch("registrations.api.send_mass_html_mail", side_effect=SMTPException):
-        response = send_message(user_api_client, registration.id, send_message_data)
-    assert response.status_code == status.HTTP_409_CONFLICT
 
 
 @pytest.mark.django_db

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.core.mail import EmailMultiAlternatives, get_connection
+from django.core.mail import send_mail
 
 
 def code_validity_duration(seats):
@@ -45,25 +45,24 @@ def send_mass_html_mail(
     connection=None,
 ):
     """
-    django.core.mail.send_mass_mail doesn't support sending html mails,
-
-    This method duplicates send_mass_mail except requires html_message for each message
-    and adds html alternative to each mail
+    django.core.mail.send_mass_mail doesn't support sending html mails.
     """
-    connection = connection or get_connection(
-        username=auth_user,
-        password=auth_password,
-        fail_silently=fail_silently,
-    )
-    messages = []
-    for subject, message, html_message, from_email, recipient_list in datatuple:
-        mail = EmailMultiAlternatives(
-            subject, message, from_email, recipient_list, connection=connection
-        )
-        mail.attach_alternative(html_message, "text/html")
-        messages.append(mail)
+    num_messages = 0
 
-    return connection.send_messages(messages)
+    for subject, message, html_message, from_email, recipient_list in datatuple:
+        num_messages += send_mail(
+            subject,
+            message,
+            from_email,
+            recipient_list,
+            fail_silently=fail_silently,
+            auth_user=auth_user,
+            auth_password=auth_password,
+            connection=connection,
+            html_message=html_message,
+        )
+
+    return num_messages
 
 
 def get_email_noreply_address():

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ django-helusers
 django-image-cropping
 django-jinja
 django-leaflet
+django-mailer
 django-modeltranslation
 django-mptt
 django-munigeo

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ django==3.2.23
     #   django-jinja
     #   django-js-asset
     #   django-leaflet
+    #   django-mailer
     #   django-modeltranslation
     #   django-munigeo
     #   django-orghierarchy
@@ -100,6 +101,8 @@ django-jinja==2.11.0
 django-js-asset==2.1.0
     # via django-mptt
 django-leaflet==0.29.0
+    # via -r requirements.in
+django-mailer==2.3
     # via -r requirements.in
 django-modeltranslation==0.18.11
     # via -r requirements.in
@@ -177,6 +180,8 @@ jinja2==3.1.2
     #   django-jinja
 langdetect==1.0.9
     # via -r requirements.in
+lockfile==0.12.2
+    # via django-mailer
 lxml==4.9.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
### Description
When an event is cancelled (`Event.event_status` is set to `EventCancelled`), an email notification about the cancellation will be sent to the contact persons of all the related signups and signup groups.

Due to the possibility of large amounts of emails being sent in the worst case, the `django-mailer` package is added and taken into use to queue the emails for later sending (which can be easily further controlled in terms of sending delay and batch size, for example). Using `django-mailer` also allows non-blocking emailing so this should bring a general improvement too for code that uses the Django emailing functions.

Scheduling for the `django-mailer` management commands `send_mail` (send queued emails), `retry_deferred` (retry failed emails) and `purge_mail_log` (clean successfully sent and/or failed emails from DB) has it's own PR in DevOps: https://dev.azure.com/City-of-Helsinki/linkedevents/_git/linkedevents-pipelines/pullrequest/7082

### Closes
[LINK-1718](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1718)

[LINK-1718]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ