### PR TITLE
Upgrade django-munigeo to 0.3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ django-mptt==0.14.0
     #   -r requirements.in
     #   django-munigeo
     #   django-orghierarchy
-django-munigeo==0.3.9
+django-munigeo==0.3.10
     # via -r requirements.in
 django-orghierarchy==0.3.0
     # via -r requirements.in


### PR DESCRIPTION
Helsinki address importer is currently failing. This has been fixed in [django-munigeo 0.3.10](https://github.com/City-of-Helsinki/django-munigeo/releases/tag/release-0.3.10).