### PR TITLE
LINK-1790 | Update django-heluser package

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -396,7 +396,7 @@ SESSION_COOKIE_NAME = "%s-sessionid" % env("COOKIE_PREFIX")
 
 TEMPLATES = [
     {
-        "BACKEND": "django_jinja.backend.Jinja2",
+        "BACKEND": "django_jinja.jinja2.Jinja2",
         "APP_DIRS": True,
         "OPTIONS": {
             "extensions": DEFAULT_EXTENSIONS + ["jinja2.ext.i18n"],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ black==23.11.0
     # via -r requirements-dev.in
 build==1.0.3
     # via pip-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c requirements.txt
     #   requests
@@ -36,7 +36,7 @@ coverage[toml]==7.3.2
     # via
     #   coverage
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -c requirements.txt
     #   django-anymail
@@ -56,7 +56,7 @@ ecdsa==0.18.0
     # via
     #   -c requirements.txt
     #   python-jose
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   -c requirements.txt
     #   pytest
@@ -64,24 +64,24 @@ factory-boy==3.3.0
     # via
     #   -r requirements-dev.in
     #   pytest-factoryboy
-faker==19.13.0
+faker==20.1.0
     # via factory-boy
 flake8==6.1.0
     # via
     #   -r requirements-dev.in
     #   flake8-bugbear
     #   pep8-naming
-flake8-bugbear==23.9.16
+flake8-bugbear==23.12.2
     # via -r requirements-dev.in
-freezegun==1.2.2
+freezegun==1.3.1
     # via
     #   -r requirements-dev.in
     #   pytest-freezer
-idna==3.4
+idna==3.6
     # via
     #   -c requirements.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -c requirements.txt
     #   build
@@ -111,13 +111,13 @@ pep8-naming==0.13.3
     # via -r requirements-dev.in
 pip-tools==7.3.0
     # via -r requirements-dev.in
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   -c requirements.txt
     #   black
 pluggy==1.3.0
     # via pytest
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   -c requirements.txt
     #   python-jose
@@ -177,7 +177,7 @@ six==1.16.0
     #   ecdsa
     #   python-dateutil
     #   requests-mock
-snakemd==2.1.0
+snakemd==2.2.0
     # via -r requirements-dev.in
 sqlparse==0.4.4
     # via
@@ -205,7 +205,7 @@ urllib3==1.26.18
     #   requests
 werkzeug==3.0.1
     # via -r requirements-dev.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
 zipp==3.17.0
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ django~=3.2
 djangorestframework
 djangorestframework-bulk
 djangorestframework-gis
-drf-oidc-auth==0.10.0
+drf-oidc-auth
 easy_thumbnails
 elasticsearch<8
 helsinki-profile-gdpr-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile requirements.in
 #
 asgiref==3.7.2
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 asttokens==2.4.1
     # via stack-data
 async-timeout==4.0.3
@@ -15,15 +17,17 @@ attrs==23.1.0
     #   -r requirements.in
     #   cattrs
     #   requests-cache
+authlib==1.2.1
+    # via drf-oidc-auth
 beautifulsoup4==4.12.2
     # via -r requirements.in
 bleach==6.1.0
     # via -r requirements.in
 cachetools==5.3.2
     # via django-helusers
-cattrs==23.1.2
+cattrs==23.2.3
     # via requests-cache
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   elasticsearch
     #   requests
@@ -32,8 +36,11 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.5
-    # via social-auth-core
+cryptography==41.0.7
+    # via
+    #   authlib
+    #   drf-oidc-auth
+    #   social-auth-core
 decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
@@ -67,21 +74,22 @@ django==3.2.23
     #   drf-oidc-auth
     #   easy-thumbnails
     #   helsinki-profile-gdpr-api
+    #   social-auth-app-django
 django-admin-autocomplete-filter==0.7.1
     # via -r requirements.in
-django-appconf==1.0.5
+django-appconf==1.0.6
     # via django-image-cropping
 django-cleanup==8.0.0
     # via -r requirements.in
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements.in
 django-environ==0.11.2
     # via -r requirements.in
-django-filter==23.3
+django-filter==23.5
     # via -r requirements.in
 django-haystack==3.2.1
     # via -r requirements.in
-django-helusers==0.7.1
+django-helusers==0.9.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
@@ -129,7 +137,7 @@ djangorestframework-bulk==0.2.1
     # via -r requirements.in
 djangorestframework-gis==1.0
     # via -r requirements.in
-drf-oidc-auth==0.10.0
+drf-oidc-auth==3.0.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
@@ -139,25 +147,23 @@ ecdsa==0.18.0
     # via python-jose
 elasticsearch==7.17.9
     # via -r requirements.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via
     #   cattrs
     #   ipython
 executing==2.0.1
     # via stack-data
-future==0.18.3
-    # via pyjwkest
 helsinki-profile-gdpr-api==0.2.0
     # via -r requirements.in
 httmock==1.4.0
     # via -r requirements.in
 icalendar==5.0.11
     # via -r requirements.in
-idna==3.4
+idna==3.6
     # via requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via markdown
-ipython==8.17.2
+ipython==8.18.1
     # via -r requirements.in
 isodate==0.6.1
     # via
@@ -189,15 +195,15 @@ packaging==23.2
     # via deprecation
 parso==0.8.3
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pillow==10.1.0
     # via
     #   -r requirements.in
     #   easy-thumbnails
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via requests-cache
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 psycopg2==2.9.9
     # via -r requirements.in
@@ -205,7 +211,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   python-jose
     #   rsa
@@ -213,12 +219,8 @@ pycparser==2.21
     # via cffi
 pycryptodome==3.19.0
     # via django-searchable-encrypted-fields
-pycryptodomex==3.19.0
-    # via pyjwkest
-pygments==2.16.1
+pygments==2.17.2
     # via ipython
-pyjwkest==1.4.2
-    # via drf-oidc-auth
 pyjwt==2.8.0
     # via social-auth-core
 pyparsing==3.1.1
@@ -255,12 +257,12 @@ requests==2.31.0
     #   django-helusers
     #   django-munigeo
     #   django-orghierarchy
+    #   drf-oidc-auth
     #   httmock
-    #   pyjwkest
     #   requests-cache
     #   requests-oauthlib
     #   social-auth-core
-requests-cache==1.1.0
+requests-cache==1.1.1
     # via
     #   -r requirements.in
     #   django-munigeo
@@ -268,7 +270,7 @@ requests-oauthlib==1.3.1
     # via social-auth-core
 rsa==4.9
     # via python-jose
-sentry-sdk==1.34.0
+sentry-sdk==1.38.0
     # via -r requirements.in
 six==1.16.0
     # via
@@ -278,13 +280,11 @@ six==1.16.0
     #   ecdsa
     #   isodate
     #   langdetect
-    #   pyjwkest
     #   python-dateutil
-    #   social-auth-app-django
     #   url-normalize
-social-auth-app-django==4.0.0
+social-auth-app-django==5.4.0
     # via -r requirements.in
-social-auth-core==4.0.3
+social-auth-core==4.5.1
     # via
     #   -r requirements.in
     #   social-auth-app-django
@@ -296,7 +296,7 @@ stack-data==0.6.3
     # via ipython
 swapper==1.3.0
     # via django-orghierarchy
-traitlets==5.13.0
+traitlets==5.14.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -317,7 +317,7 @@ urllib3==1.26.18
     #   requests
     #   requests-cache
     #   sentry-sdk
-wcwidth==0.2.9
+wcwidth==0.2.12
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach


### PR DESCRIPTION
Bump django-heluser. Also bump all other libraries as well and remove pinned restriction from `drf-oidc-auth`.