### PR TITLE
Disable user created email notification

### DIFF
--- a/events/signals.py
+++ b/events/signals.py
@@ -34,7 +34,7 @@ def organization_replaced(sender, instance, created, **kwargs):
         instance.owned_systems.update(owner=new_org)
 
 
-@receiver(post_save, sender=get_user_model(), dispatch_uid="user_created_notification")
+# TODO not in use anymore, remove altogether?
 def user_created_notification(sender, instance, created, **kwargs):
     """Send a notification to superusers when a user gets created."""
     if created:

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -206,6 +206,8 @@ def test_draft_notification_is_not_sent_when_using_api_key(
     assert bool(mail.outbox) == expect_email
 
 
+# TODO user created notification is disabled ATM, remove this test if/when it is removed
+@pytest.mark.xfail
 @pytest.mark.django_db
 def test_user_created(user_created_notification_template, super_user):
     user = get_user_model().objects.create(


### PR DESCRIPTION
Currently an email notification is sent to all superusers about every new user. Now that we have outside users and registration users, we most probably don't want to be sending those notifications anymore. The notification is just disabled for now, but should be completely removed later if there is no use for it.