### PR TITLE
feat: make GDPR API to support Keycloak scopes

### DIFF
--- a/helevents/tests/conftest.py
+++ b/helevents/tests/conftest.py
@@ -33,10 +33,17 @@ def get_api_token_for_user_with_scopes(
         "sub": str(user_uuid),
         "iat": int(now.timestamp()),
         "exp": int(expire.timestamp()),
-        auth_field: scopes,
     }
+
+    if isinstance(auth_field, list):
+        for field in auth_field:
+            jwt_data[field] = scopes
+    elif isinstance(auth_field, str):
+        jwt_data[auth_field] = scopes
+
     if amr:
         jwt_data["amr"] = amr
+
     encoded_jwt = jwt.encode(
         jwt_data, key=rsa_key.private_key_pem, algorithm=rsa_key.jose_algorithm
     )

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -138,7 +138,10 @@ env = environ.Env(
     TOKEN_AUTH_ACCEPTED_AUDIENCE=(str, "https://api.hel.fi/auth/linkedevents"),
     TOKEN_AUTH_ACCEPTED_SCOPE_PREFIX=(str, "linkedevents"),
     TOKEN_AUTH_AUTHSERVER_URL=(str, "https://api.hel.fi/sso/openid"),
-    TOKEN_AUTH_FIELD_FOR_CONSENTS=(str, "https://api.hel.fi/auth"),
+    TOKEN_AUTH_FIELD_FOR_CONSENTS=(
+        list,
+        ["https://api.hel.fi/auth", "authorization.permissions.scopes"],
+    ),
     TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, True),
     TRUST_X_FORWARDED_HOST=(bool, False),
     WHITENOISE_STATIC_PREFIX=(str, "/static/"),


### PR DESCRIPTION
### Description
Adds support for the new Keycloak style token scope by appending the dot-notation field name to the default value of the setting `TOKEN_AUTH_FIELD_FOR_CONSENTS`.
### Closes
[LINK-1833](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1833)

[LINK-1833]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ