### PR TITLE
feat: remove spammy debug logs from importers

### DIFF
--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -319,9 +319,6 @@ class Importer(object):
         deprecated ones.
         """
         changed = False
-        logger.debug(
-            f"Checking for deprecated keywords in attribute '{attr}' for event {obj}"
-        )
 
         for keyword in getattr(obj, attr).filter(deprecated=True):
             getattr(obj, attr).remove(keyword)

--- a/events/importer/utils.py
+++ b/events/importer/utils.py
@@ -81,7 +81,6 @@ def separate_scripts(text, scripts):
             language = last_language
         if language != last_language:
             # fix html paragraph breaks after language change
-            logger.debug("supported language detected: " + language)
             if last_paragraph in (r"</p><p>", r"</p>", r"<p>"):
                 separated[last_language] = re.sub(r"<p>$", "", separated[last_language])
                 separated[language] += r"<p>"


### PR DESCRIPTION
E.g. on an hourly cronjob, there were 14.7k lines of logs generated. These two logging lines generated approximately 13.7k lines. Which is about 93% of the total lines.

These aren't very informative either, so decided to remove them. It's a lot of noise.