### PR TITLE
LINK-1382 | feat: support keycloak in User.token_amr_claim

### DIFF
--- a/helevents/models.py
+++ b/helevents/models.py
@@ -21,7 +21,7 @@ class UserModelPermissionMixin:
     """
 
     @property
-    def token_amr_claim(self) -> str:
+    def token_amr_claim(self) -> list[str]:
         claim = getattr(self, "_token_amr_claim", None)
         if claim is None:
             logger.warning(
@@ -30,6 +30,13 @@ class UserModelPermissionMixin:
                 stacklevel=2,
             )
 
+        if not claim:
+            return []
+
+        if not isinstance(claim, list):
+            # Tunnistamo returns amr-claim as string instead of list as it should
+            # be according to the spec. This is a workaround for that.
+            claim = [claim]
         return claim
 
     @token_amr_claim.setter
@@ -39,9 +46,10 @@ class UserModelPermissionMixin:
     @property
     def is_strongly_identified(self):
         """Check if the user is strongly identified"""
-        return (
-            self.token_amr_claim
-            in settings.STRONG_IDENTIFICATION_AUTHENTICATION_METHODS
+
+        return any(
+            login_method in settings.STRONG_IDENTIFICATION_AUTHENTICATION_METHODS
+            for login_method in self.token_amr_claim
         )
 
     @property
@@ -300,7 +308,10 @@ class User(AbstractUser, UserModelPermissionMixin, SerializableMixin):
 
     @cached_property
     def is_external(self):
-        if self.token_amr_claim in settings.NON_EXTERNAL_AUTHENTICATION_METHODS:
+        if any(
+            login_method in settings.NON_EXTERNAL_AUTHENTICATION_METHODS
+            for login_method in self.token_amr_claim
+        ):
             return False
 
         return (

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -117,7 +117,11 @@ env = environ.Env(
     MEDIA_URL=(str, "/media/"),
     # "helsinki_adfs" = Tunnistamo auth_backends.adfs.helsinki.HelsinkiADFS
     # "helsinkiazuread" = Tunnistamo auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2
-    NON_EXTERNAL_AUTHENTICATION_METHODS=(list, ["helsinki_adfs", "helsinkiazuread"]),
+    # "helsinkiad" Helsinki Keycloak AD authentication
+    NON_EXTERNAL_AUTHENTICATION_METHODS=(
+        list,
+        ["helsinki_adfs", "helsinkiazuread", "helsinkiad"],
+    ),
     ANONYMIZATION_THRESHOLD_DAYS=(int, 30),
     STRONG_IDENTIFICATION_AUTHENTICATION_METHODS=(list, ["heltunnistussuomifi"]),
     REDIS_SENTINELS=(list, []),

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -193,7 +193,7 @@ def test_registration_user_access_user_can_see_if_he_has_access(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = get_detail_and_assert_registration(user_api_client, registration.id)
         assert mocked.called is True
@@ -378,7 +378,7 @@ def test_registration_user_access_can_include_signups_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = get_detail_and_assert_registration(
             user_api_client, registration.id, include_signups_query
@@ -398,7 +398,7 @@ def test_registration_user_access_cannot_include_signups_when_not_strongly_ident
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = get_detail_and_assert_registration(
             user_api_client, registration.id, include_signups_query

--- a/registrations/tests/test_signup_get.py
+++ b/registrations/tests/test_signup_get.py
@@ -150,7 +150,7 @@ def test_registration_user_access_can_get_signup_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = assert_get_detail(user_api_client, signup.id)
         assert mocked.called is True
@@ -168,7 +168,7 @@ def test_registration_user_access_cannot_get_signup_when_not_strongly_identified
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = get_detail(user_api_client, signup.id)
         assert mocked.called is True
@@ -374,7 +374,7 @@ def test_registration_user_access_can_get_signup_list_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         get_list_and_assert_signups(
             user_api_client, f"registration={registration.id}", [signup, signup2]
@@ -392,7 +392,7 @@ def test_registration_user_access_cannot_get_signup_list_when_not_strongly_ident
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = get_list(user_api_client, f"registration={registration.id}")
         assert mocked.called is True
@@ -460,7 +460,7 @@ def test_get_all_signups_to_which_user_has_admin_role(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         get_list_and_assert_signups(user_api_client, "", [])
         assert mocked.called is True
@@ -469,7 +469,7 @@ def test_get_all_signups_to_which_user_has_admin_role(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         get_list_and_assert_signups(user_api_client, "", [signup, signup2])
         assert mocked.called is True

--- a/registrations/tests/test_signup_group_get.py
+++ b/registrations/tests/test_signup_group_get.py
@@ -119,7 +119,7 @@ def test_registration_user_access_can_get_signup_group_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = assert_get_detail(user_api_client, signup_group.id)
         assert mocked.called is True
@@ -138,7 +138,7 @@ def test_registration_user_access_cannot_get_signup_group_when_not_strongly_iden
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = get_detail(user_api_client, signup_group.id)
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -375,7 +375,7 @@ def test_registration_user_access_can_get_signup_group_list_when_strongly_identi
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         get_list_and_assert_signup_groups(
             user_api_client,
@@ -398,7 +398,7 @@ def test_registration_user_access_cannot_get_signup_group_list_when_not_strongly
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = get_list(user_api_client, f"registration={registration.id}")
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/registrations/tests/test_signup_group_patch.py
+++ b/registrations/tests/test_signup_group_patch.py
@@ -196,7 +196,7 @@ def test_registration_user_who_created_signup_group_can_patch_signups_data(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         assert_patch_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True
@@ -297,7 +297,7 @@ def test_registration_user_can_patch_signups_presence_status_if_strongly_identif
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         assert_patch_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True
@@ -335,7 +335,7 @@ def test_registration_user_cannot_patch_signups_presence_status_if_not_strongly_
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = patch_signup_group(api_client, signup_group.id, signup_group_data)
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/registrations/tests/test_signup_group_put.py
+++ b/registrations/tests/test_signup_group_put.py
@@ -256,7 +256,7 @@ def test_registration_user_access_cannot_update_signup_group(api_client, registr
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = update_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True
@@ -281,7 +281,7 @@ def test_registration_user_who_created_signup_group_can_update_signup_group(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         assert_update_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -203,7 +203,7 @@ def test_registration_user_who_created_signup_can_patch_presence_status(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         assert_patch_signup(api_client, signup.id, signup_data)
         assert mocked.called is True
@@ -212,7 +212,13 @@ def test_registration_user_who_created_signup_can_patch_presence_status(
     assert signup.presence_status == SignUp.PresenceStatus.PRESENT
 
 
-@pytest.mark.parametrize("identification_method", ["heltunnistussuomifi", None])
+@pytest.mark.parametrize(
+    "identification_method",
+    [
+        pytest.param(["heltunnistussuomifi"], id="strong"),
+        pytest.param([], id="not-strong"),
+    ],
+)
 @freeze_time("2023-03-14 03:30:00+02:00")
 @pytest.mark.django_db
 def test_registration_user_can_patch_signup_presence_status_based_on_identification_method(
@@ -241,7 +247,7 @@ def test_registration_user_can_patch_signup_presence_status_based_on_identificat
 
     signup.refresh_from_db()
 
-    if identification_method is None:
+    if not identification_method:
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert signup.presence_status == SignUp.PresenceStatus.NOT_PRESENT
     else:

--- a/registrations/tests/test_signup_put.py
+++ b/registrations/tests/test_signup_put.py
@@ -426,7 +426,7 @@ def test_registration_user_access_cannot_update_signup(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         response = update_signup(api_client, signup.id, signup_data)
         assert mocked.called is True
@@ -458,7 +458,7 @@ def test_registration_user_access_who_created_signup_can_update(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         assert_update_signup(api_client, signup.id, signup_data)
         assert mocked.called is True

--- a/registrations/tests/test_signups_export.py
+++ b/registrations/tests/test_signups_export.py
@@ -143,7 +143,7 @@ def test_signups_export_forbidden_for_weakly_identified_registration_user(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=None,
+        return_value=[],
     ) as mocked:
         response = _get_signups_export(api_client, registration.id, file_format="xlsx")
 
@@ -310,7 +310,7 @@ def test_signups_export_allowed_for_strongly_identified_registration_user(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value="heltunnistussuomifi",
+        return_value=["heltunnistussuomifi"],
     ) as mocked:
         _assert_get_signups_export(api_client, registration.id, file_format="xlsx")
 


### PR DESCRIPTION
Tunnistamo returns amr-claim as a string. Keycloak return the claim as a list of strings, which is according to specification. This changes the logic in linked events to expect a list for User.token_amr_claim.