### PR TITLE
fix: disable file-based lock for django-mailer

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -577,6 +577,7 @@ DEFAULT_FROM_EMAIL = env(
     "DEFAULT_FROM_EMAIL"
 )  # Email address used as default "from" email
 EMAIL_BACKEND = "mailer.backend.DbBackend"
+MAILER_USE_FILE_LOCK = False
 MAILER_EMAIL_MAX_RETRIES = 5
 if EMAIL_HOST and EMAIL_PORT:
     MAILER_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
### Description
The `django-mailer` uses a lockfile to ensure that an email is not sent twice. By default, the path of that lockfile is the current working directory which seems to cause a permission issue with LE cron jobs that try to create the lockfile. Since `django-mailer` also has a DB-based lock that is more reliable than the file-based one when available, this PR disables the file-based lock completely.
### Closes
[LINK-1852](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1852)

[LINK-1852]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ