### PR TITLE
fix: use the correct value for KeyCloak suomi.fi method

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -123,7 +123,10 @@ env = environ.Env(
         ["helsinki_adfs", "helsinkiazuread", "helsinkiad"],
     ),
     ANONYMIZATION_THRESHOLD_DAYS=(int, 30),
-    STRONG_IDENTIFICATION_AUTHENTICATION_METHODS=(list, ["heltunnistussuomifi"]),
+    STRONG_IDENTIFICATION_AUTHENTICATION_METHODS=(
+        list,
+        ["suomi_fi", "heltunnistussuomifi"],
+    ),
     REDIS_SENTINELS=(list, []),
     REDIS_URL=(str, None),
     REDIS_PASSWORD=(str, None),

--- a/registrations/tests/test_registration_get.py
+++ b/registrations/tests/test_registration_get.py
@@ -193,7 +193,7 @@ def test_registration_user_access_user_can_see_if_he_has_access(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = get_detail_and_assert_registration(user_api_client, registration.id)
         assert mocked.called is True
@@ -378,7 +378,7 @@ def test_registration_user_access_can_include_signups_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = get_detail_and_assert_registration(
             user_api_client, registration.id, include_signups_query

--- a/registrations/tests/test_signup_get.py
+++ b/registrations/tests/test_signup_get.py
@@ -150,7 +150,7 @@ def test_registration_user_access_can_get_signup_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = assert_get_detail(user_api_client, signup.id)
         assert mocked.called is True
@@ -374,7 +374,7 @@ def test_registration_user_access_can_get_signup_list_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         get_list_and_assert_signups(
             user_api_client, f"registration={registration.id}", [signup, signup2]
@@ -469,7 +469,7 @@ def test_get_all_signups_to_which_user_has_admin_role(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         get_list_and_assert_signups(user_api_client, "", [signup, signup2])
         assert mocked.called is True

--- a/registrations/tests/test_signup_group_get.py
+++ b/registrations/tests/test_signup_group_get.py
@@ -119,7 +119,7 @@ def test_registration_user_access_can_get_signup_group_when_strongly_identified(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = assert_get_detail(user_api_client, signup_group.id)
         assert mocked.called is True
@@ -375,7 +375,7 @@ def test_registration_user_access_can_get_signup_group_list_when_strongly_identi
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         get_list_and_assert_signup_groups(
             user_api_client,

--- a/registrations/tests/test_signup_group_patch.py
+++ b/registrations/tests/test_signup_group_patch.py
@@ -196,7 +196,7 @@ def test_registration_user_who_created_signup_group_can_patch_signups_data(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         assert_patch_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True
@@ -297,7 +297,7 @@ def test_registration_user_can_patch_signups_presence_status_if_strongly_identif
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         assert_patch_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True

--- a/registrations/tests/test_signup_group_put.py
+++ b/registrations/tests/test_signup_group_put.py
@@ -256,7 +256,7 @@ def test_registration_user_access_cannot_update_signup_group(api_client, registr
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = update_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True
@@ -281,7 +281,7 @@ def test_registration_user_who_created_signup_group_can_update_signup_group(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         assert_update_signup_group(api_client, signup_group.id, signup_group_data)
         assert mocked.called is True

--- a/registrations/tests/test_signup_patch.py
+++ b/registrations/tests/test_signup_patch.py
@@ -203,7 +203,7 @@ def test_registration_user_who_created_signup_can_patch_presence_status(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         assert_patch_signup(api_client, signup.id, signup_data)
         assert mocked.called is True
@@ -215,7 +215,7 @@ def test_registration_user_who_created_signup_can_patch_presence_status(
 @pytest.mark.parametrize(
     "identification_method",
     [
-        pytest.param(["heltunnistussuomifi"], id="strong"),
+        pytest.param(["suomi_fi"], id="strong"),
         pytest.param([], id="not-strong"),
     ],
 )

--- a/registrations/tests/test_signup_put.py
+++ b/registrations/tests/test_signup_put.py
@@ -426,7 +426,7 @@ def test_registration_user_access_cannot_update_signup(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         response = update_signup(api_client, signup.id, signup_data)
         assert mocked.called is True
@@ -458,7 +458,7 @@ def test_registration_user_access_who_created_signup_can_update(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         assert_update_signup(api_client, signup.id, signup_data)
         assert mocked.called is True

--- a/registrations/tests/test_signups_export.py
+++ b/registrations/tests/test_signups_export.py
@@ -310,7 +310,7 @@ def test_signups_export_allowed_for_strongly_identified_registration_user(
     with patch(
         "helevents.models.UserModelPermissionMixin.token_amr_claim",
         new_callable=PropertyMock,
-        return_value=["heltunnistussuomifi"],
+        return_value=["suomi_fi"],
     ) as mocked:
         _assert_get_signups_export(api_client, registration.id, file_format="xlsx")
 


### PR DESCRIPTION
### Description
KeyCloak uses "suomi_fi" in the amr claim value instead of the current default "heltunnistussuomifi". This PR changes the default value to enable strong identification to work with the KeyCloak authentication with the default setting.
### Closes
[LINK-1851](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1851)

[LINK-1851]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ