### PR TITLE
Disable user deletion through GDPR api

### DIFF
--- a/helevents/tests/test_gdpr_api_delete.py
+++ b/helevents/tests/test_gdpr_api_delete.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import pytest
 import requests_mock
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -101,6 +102,7 @@ def _assert_gdpr_delete(
 
 
 @pytest.mark.django_db
+@override_settings(GDPR_DISABLE_API_DELETION=False)
 def test_authenticated_user_can_delete_own_data(api_client, settings):
     user = UserFactory()
 
@@ -134,6 +136,7 @@ def test_authenticated_user_can_delete_own_data(api_client, settings):
 
 
 @pytest.mark.django_db
+@override_settings(GDPR_DISABLE_API_DELETION=False)
 def test_authenticated_user_can_delete_own_data_event_user_details_not_nulled(
     api_client, settings
 ):

--- a/helevents/utils.py
+++ b/helevents/utils.py
@@ -1,4 +1,7 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.response import Response
 
 
 def get_user_for_gdpr_api(user: get_user_model()) -> get_user_model():
@@ -18,9 +21,15 @@ def delete_user_and_gdpr_data(user: get_user_model(), dry_run: bool) -> None:
     Function used by the Helsinki Profile GDPR API to delete all GDPR data collected of the user.
     The GDPR API package will run this within a transaction.
 
+    **Note!**: Disabled the deletion for now until the two service problem is solved.
+
     :param  user: the User instance to be deleted along with related GDPR data
     :param dry_run: a boolean telling if this is a dry run of the function or not
     """
+
+    if settings.GDPR_DISABLE_API_DELETION:
+        # Delete user is disabled. Returns 403 FORBIDDEN so that the GDPR view handles it correctly.
+        return Response(status=status.HTTP_403_FORBIDDEN)
 
     for signup in user.signup_created_by.filter(signup_group_id__isnull=True):
         signup._individually_deleted = (

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -103,6 +103,7 @@ env = environ.Env(
     FULL_TEXT_WEIGHT_OVERRIDES=(dict, {}),
     GDPR_API_QUERY_SCOPE=(str, ""),
     GDPR_API_DELETE_SCOPE=(str, ""),
+    GDPR_DISABLE_API_DELETION=(bool, True),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
     INSTANCE_NAME=(str, "Linked Events"),
     INTERNAL_IPS=(list, []),
@@ -657,6 +658,7 @@ GDPR_API_USER_PROVIDER = "helevents.utils.get_user_for_gdpr_api"
 GDPR_API_DELETER = "helevents.utils.delete_user_and_gdpr_data"
 GDPR_API_QUERY_SCOPE = env("GDPR_API_QUERY_SCOPE")
 GDPR_API_DELETE_SCOPE = env("GDPR_API_DELETE_SCOPE")
+GDPR_DISABLE_API_DELETION = env("GDPR_DISABLE_API_DELETION")
 
 # A list of hex-encoded 32 byte keys used for encrypting sensitive data
 FIELD_ENCRYPTION_KEYS = env("FIELD_ENCRYPTION_KEYS")


### PR DESCRIPTION
The user deletion through the gdpr api deletes user from the database and its data. This is problematic since the users are shared by two services (events and registrations).
This disables the user data deletion for now via the api to avoid unwanted user deletions.
Deletion request returns 403 (forbidden).
