### PR TITLE
fix: whitelist web_store in the dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@
 !templates*
 !.prod
 !registrations
+!web_store
 
 #################################################
 # Whitelisted files


### PR DESCRIPTION
Fixes broken build due to the new `web_store` app not being mentioned in the `.dockerignore` file.