### PR TITLE
LINK-1811 | Email Notifications for Recurring Event Signups

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -49,6 +49,7 @@ from notifications.models import (
     NotificationType,
     render_notification_template,
 )
+from notifications.utils import format_date, format_datetime
 from registrations.utils import get_email_noreply_address
 
 logger = logging.getLogger(__name__)
@@ -1319,6 +1320,25 @@ class Event(
         except ApiKeyUser.DoesNotExist:
             pass
         return False
+
+    def get_start_and_end_time_display(self, lang="fi", date_only=False) -> str:
+        if date_only:
+            formatter_func = format_date
+        else:
+            formatter_func = format_datetime
+
+        if self.start_time and self.end_time:
+            return (
+                f"{formatter_func(self.start_time, lang)}"
+                if self.start_time.date() == self.end_time.date() and date_only
+                else f"{formatter_func(self.start_time, lang)} - {formatter_func(self.end_time, lang)}"
+            )
+        elif self.start_time:
+            return f"{formatter_func(self.start_time, lang)} -"
+        elif self.end_time:
+            return f"- {formatter_func(self.end_time, lang)}"
+
+        return ""
 
 
 reversion.register(Event)

--- a/events/tests/test_notifications.py
+++ b/events/tests/test_notifications.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.auth import get_user_model
 from django.core import mail
 
 from helevents.tests.factories import UserFactory

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-02 11:18+0000\n"
+"POT-Creation-Date: 2024-02-06 13:13+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -176,385 +176,385 @@ msgid ""
 "for POSTing your events."
 msgstr ""
 
-#: events/models.py:79 events/models.py:208 events/models.py:227
-#: events/models.py:354 events/models.py:426 events/models.py:445
-#: events/models.py:1396 events/models.py:1414 events/models.py:1464
+#: events/models.py:80 events/models.py:209 events/models.py:228
+#: events/models.py:355 events/models.py:427 events/models.py:446
+#: events/models.py:1416 events/models.py:1434 events/models.py:1484
 #: registrations/exports.py:35
 msgid "Name"
 msgstr "Nimi"
 
-#: events/models.py:89
+#: events/models.py:90
 msgid "Resources may be edited by users"
 msgstr "Käyttäjät voivat muokata resursseja"
 
-#: events/models.py:92
+#: events/models.py:93
 msgid "Organizations may be edited by users"
 msgstr "Käyttäjät voivat muokata organisaatioita"
 
-#: events/models.py:96
+#: events/models.py:97
 msgid "Owner organization's registrations may be edited by users"
 msgstr "Käyttäjät voivat muokata organisaation ilmoittautumisia."
 
-#: events/models.py:101
+#: events/models.py:102
 msgid "Owner organization's registration price groups may be edited by users"
 msgstr "Käyttäjät voivat muokata organisaation asiakasryhmiä."
 
-#: events/models.py:105
+#: events/models.py:106
 msgid "Past events may be edited using API"
 msgstr "Menneitä tapahtumia voidaan muokata API:n kautta"
 
-#: events/models.py:108
+#: events/models.py:109
 msgid "Past events may be created using API"
 msgstr "Menneitä tapahtumia voidaan luoda API:n kautta"
 
-#: events/models.py:112
+#: events/models.py:113
 msgid "Do not show events created by this data_source by default."
 msgstr "Älä näytä tämän datalähteen luomia tapahtumia oletuksena."
 
-#: events/models.py:209
+#: events/models.py:210
 msgid "Url"
 msgstr "Url"
 
-#: events/models.py:212 events/models.py:272
+#: events/models.py:213 events/models.py:273
 msgid "License"
 msgstr "Lisenssi"
 
-#: events/models.py:213
+#: events/models.py:214
 msgid "Licenses"
 msgstr "Lisenssit"
 
-#: events/models.py:240 events/models.py:480 events/models.py:668
-#: events/models.py:986 registrations/models.py:182
+#: events/models.py:241 events/models.py:481 events/models.py:669
+#: events/models.py:987 registrations/models.py:182
 msgid "Publisher"
 msgstr "Julkaisija"
 
-#: events/models.py:266 events/models.py:335
+#: events/models.py:267 events/models.py:336
 msgid "Image"
 msgstr "Kuva"
 
-#: events/models.py:268
+#: events/models.py:269
 msgid "Cropping"
 msgstr "Rajaus"
 
-#: events/models.py:278
+#: events/models.py:279
 msgid "Photographer name"
 msgstr "Valokuvaajan nimi"
 
-#: events/models.py:281 events/models.py:1421
+#: events/models.py:282 events/models.py:1441
 msgid "Alt text"
 msgstr "Vaihtoehtoinen teksti"
 
-#: events/models.py:292
+#: events/models.py:293
 msgid "You must provide either image or url."
 msgstr ""
 
-#: events/models.py:294
+#: events/models.py:295
 msgid "You can only provide image or url, not both."
 msgstr ""
 
-#: events/models.py:357
+#: events/models.py:358
 msgid "Origin ID"
 msgstr "Lähdetunniste"
 
-#: events/models.py:428
+#: events/models.py:429
 msgid "Can be used as registration service language"
 msgstr "Voidaan käyttää ilmoittautumisen palvelukielenä"
 
-#: events/models.py:435
+#: events/models.py:436
 msgid "language"
 msgstr "kieli"
 
-#: events/models.py:436
+#: events/models.py:437
 msgid "languages"
 msgstr "kielet"
 
-#: events/models.py:493 events/models.py:723
+#: events/models.py:494 events/models.py:724
 msgid "event count"
 msgstr "tapahtumien lukumäärä"
 
-#: events/models.py:494
+#: events/models.py:495
 msgid "number of events with this keyword"
 msgstr "tapahtumien määrä tällä avainsanalla"
 
-#: events/models.py:536
+#: events/models.py:537
 msgid ""
 "Trying to replace this keyword with a keyword that is replaced by this "
 "keyword. Please refrain from creating circular replacements andremove one of "
 "the replacements."
 msgstr ""
 
-#: events/models.py:585
+#: events/models.py:586
 msgid "keyword"
 msgstr "Avainsana"
 
-#: events/models.py:586
+#: events/models.py:587
 msgid "keywords"
 msgstr "Avainsanat"
 
-#: events/models.py:612
+#: events/models.py:613
 msgid "Intended keyword usage"
 msgstr "Avainsanan suunniteltu käyttötarkoitus"
 
-#: events/models.py:617
+#: events/models.py:618
 msgid "Organization which uses this set"
 msgstr "Organisaatio, joka käyttää tätä avainsanaryhmää"
 
-#: events/models.py:630
+#: events/models.py:631
 msgid "KeywordSet can't have deprecated keywords"
 msgstr "Avainsanaryhmässä ei voi olla käytöstä poistettuja avainsanoja"
 
-#: events/models.py:672
+#: events/models.py:673
 msgid "Place home page"
 msgstr "Paikan kotisivu"
 
-#: events/models.py:674 events/models.py:955
+#: events/models.py:675 events/models.py:956
 msgid "Description"
 msgstr "Kuvaus"
 
-#: events/models.py:681 events/models.py:1465 registrations/models.py:662
+#: events/models.py:682 events/models.py:1485 registrations/models.py:662
 #: registrations/models.py:932
 msgid "E-mail"
 msgstr "Sähköposti"
 
-#: events/models.py:683
+#: events/models.py:684
 msgid "Telephone"
 msgstr "Puhelinnumero"
 
-#: events/models.py:686
+#: events/models.py:687
 msgid "Contact type"
 msgstr "Yhteydtiedon tyyppi"
 
-#: events/models.py:689 registrations/models.py:57 registrations/models.py:780
+#: events/models.py:690 registrations/models.py:57 registrations/models.py:780
 msgid "Street address"
 msgstr "Katuosoite"
 
-#: events/models.py:692
+#: events/models.py:693
 msgid "Address locality"
 msgstr "Osoitteen paikkakunta"
 
-#: events/models.py:695
+#: events/models.py:696
 msgid "Address region"
 msgstr "Osoitteen paikkakunta"
 
-#: events/models.py:698
+#: events/models.py:699
 msgid "Postal code"
 msgstr "Postinumero"
 
-#: events/models.py:701
+#: events/models.py:702
 msgid "PO BOX"
 msgstr "Postilokero"
 
-#: events/models.py:704
+#: events/models.py:705
 msgid "Country"
 msgstr "Maa"
 
-#: events/models.py:707
+#: events/models.py:708
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: events/models.py:717
+#: events/models.py:718
 msgid "Divisions"
 msgstr ""
 
-#: events/models.py:724
+#: events/models.py:725
 msgid "number of events in this location"
 msgstr "tapahtumien määrä tässä paikassa"
 
-#: events/models.py:732
+#: events/models.py:733
 msgid "place"
 msgstr "paikka"
 
-#: events/models.py:733
+#: events/models.py:734
 msgid "places"
 msgstr "paikat"
 
-#: events/models.py:747
+#: events/models.py:748
 msgid ""
 "Trying to replace this place with a place that is replaced by this place. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements. We don't want homeless events."
 msgstr ""
 
-#: events/models.py:837
+#: events/models.py:838
 msgid "opening hour specification"
 msgstr "aukioloaika"
 
-#: events/models.py:838
+#: events/models.py:839
 msgid "opening hour specifications"
 msgstr "aukioloajat"
 
-#: events/models.py:908
+#: events/models.py:909
 msgid "Recurring"
 msgstr "Toistuva tapahtuma"
 
-#: events/models.py:909
+#: events/models.py:910
 msgid "Umbrella event"
 msgstr "Kattotapahtuma"
 
-#: events/models.py:924
+#: events/models.py:925
 msgid "Outdoors"
 msgstr "Ulkona"
 
-#: events/models.py:925
+#: events/models.py:926
 msgid "Indoors"
 msgstr "Sisällä"
 
-#: events/models.py:929
+#: events/models.py:930
 msgid "User name"
 msgstr "Käyttäjän nimi"
 
-#: events/models.py:931
+#: events/models.py:932
 msgid "User e-mail"
 msgstr "Käyttäjän sähköpostiosoite"
 
-#: events/models.py:933
+#: events/models.py:934
 msgid "User phone number"
 msgstr "Käyttäjän puhelinnumero"
 
-#: events/models.py:939
+#: events/models.py:940
 msgid "User organization"
 msgstr "Käyttäjän organisaatio"
 
-#: events/models.py:940
+#: events/models.py:941
 msgid "Event organizer information."
 msgstr "Tapahtuman järjestäjän tiedot."
 
-#: events/models.py:946 registrations/models.py:802
+#: events/models.py:947 registrations/models.py:802
 msgid "User consent"
 msgstr "Käyttäjän suostumus"
 
-#: events/models.py:947
+#: events/models.py:948
 msgid "I consent to the processing of my personal data?"
 msgstr "Hyväksynkö henkilötietojeni käsittelyn?"
 
-#: events/models.py:953
+#: events/models.py:954
 msgid "Event home page"
 msgstr "Tapahtuman kotisivu"
 
-#: events/models.py:957
+#: events/models.py:958
 msgid "Short description"
 msgstr "Lyhyt kuvaus"
 
-#: events/models.py:962
+#: events/models.py:963
 msgid "Date published"
 msgstr "Julkaisupäivämäärä"
 
-#: events/models.py:972
+#: events/models.py:973
 msgid "Headline"
 msgstr "Otsikko"
 
-#: events/models.py:975
+#: events/models.py:976
 msgid "Secondary headline"
 msgstr "Toissijainen otsikko"
 
-#: events/models.py:977
+#: events/models.py:978
 msgid "Provider"
 msgstr "Palveluntarjoaja"
 
-#: events/models.py:979
+#: events/models.py:980
 msgid "Provider's contact info"
 msgstr "Palveluntarjoajan yhteystiedot"
 
-#: events/models.py:992
+#: events/models.py:993
 msgid "Environmental certificate"
 msgstr "Ympäristösertifikaatti"
 
-#: events/models.py:1000
+#: events/models.py:1001
 msgid "Event status"
 msgstr "Tapahtuman tila"
 
-#: events/models.py:1007
+#: events/models.py:1008
 msgid "Event data publication status"
 msgstr "Tapahtumatietojen julkaisun tila"
 
-#: events/models.py:1016
+#: events/models.py:1017
 msgid "Location extra info"
 msgstr "Paikan lisätiedot"
 
-#: events/models.py:1019
+#: events/models.py:1020
 msgid "Event environment"
 msgstr "Tapahtuman ympäristö"
 
-#: events/models.py:1020
+#: events/models.py:1021
 msgid "Will the event be held outdoors?"
 msgstr "Pidetäänkö tapahtuma ulkona?"
 
-#: events/models.py:1028
+#: events/models.py:1029
 msgid "Start time"
 msgstr "Alkuaika"
 
-#: events/models.py:1031
+#: events/models.py:1032
 msgid "End time"
 msgstr "Loppuaika"
 
-#: events/models.py:1037 registrations/models.py:247
+#: events/models.py:1038 registrations/models.py:247
 msgid "Minimum recommended age"
 msgstr "Suositeltu vähimmäisikä"
 
-#: events/models.py:1040 registrations/models.py:250
+#: events/models.py:1041 registrations/models.py:250
 msgid "Maximum recommended age"
 msgstr "Suurin suositeltu ikä"
 
-#: events/models.py:1065
+#: events/models.py:1066
 msgid "In language"
 msgstr "kielellä"
 
-#: events/models.py:1081
+#: events/models.py:1082
 msgid "maximum attendee capacity"
 msgstr "Paikkojen enimmäismäärä"
 
-#: events/models.py:1087
+#: events/models.py:1088
 msgid "minimum attendee capacity"
 msgstr "Paikkojen vähimmäismäärä"
 
-#: events/models.py:1090
+#: events/models.py:1091
 msgid "enrolment start time"
 msgstr "Ilmoittautumisen alkamisaika"
 
-#: events/models.py:1093
+#: events/models.py:1094
 msgid "enrolment end time"
 msgstr "Ilmoittautumisen päättymisaika"
 
-#: events/models.py:1109
+#: events/models.py:1110
 msgid "event"
 msgstr "tapahtuma"
 
-#: events/models.py:1110
+#: events/models.py:1111
 msgid "events"
 msgstr "tapahtumat"
 
-#: events/models.py:1120
+#: events/models.py:1121
 msgid ""
 "Trying to replace this event with an event that is replaced by this event. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements."
 msgstr ""
 
-#: events/models.py:1159
+#: events/models.py:1160
 msgid "The event end time cannot be earlier than the start time."
 msgstr "Tapahtuman päättymisaika ei voi olla aikaisempi kuin alkamisaika."
 
-#: events/models.py:1377
+#: events/models.py:1397
 msgid "Price"
 msgstr "Hinta"
 
-#: events/models.py:1379
+#: events/models.py:1399
 msgid "Web link to offer"
 msgstr "Linkki lipunmyyntiin"
 
-#: events/models.py:1382
+#: events/models.py:1402
 msgid "Offer description"
 msgstr "Hintatietojen kuvaus"
 
-#: events/models.py:1386
+#: events/models.py:1406
 msgid "Is free"
 msgstr "Vapaa pääsy"
 
-#: events/models.py:1466 notifications/models.py:47
+#: events/models.py:1486 notifications/models.py:41
 msgid "Subject"
 msgstr "Otsikko"
 
-#: events/models.py:1467 notifications/models.py:53
+#: events/models.py:1487 notifications/models.py:47
 msgid "Body"
 msgstr "Teksti"
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1495
+#: linkedevents/fields.py:69 registrations/serializers.py:1493
 msgid "This field is required."
 msgstr "Kenttä on pakollinen."
 
@@ -619,43 +619,43 @@ msgstr "Nimi on pakollinen."
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#: notifications/models.py:32
+#: notifications/models.py:26
 msgid "Unpublished event deleted"
 msgstr "Julkaisematon tapahtuma poistettu"
 
-#: notifications/models.py:33
+#: notifications/models.py:27
 msgid "Event published"
 msgstr "Tapahtuman julkaisupäivämäärä"
 
-#: notifications/models.py:34
+#: notifications/models.py:28
 msgid "Draft posted"
 msgstr "Luonnos lähetetty"
 
-#: notifications/models.py:35
+#: notifications/models.py:29
 msgid "User created"
 msgstr "Käyttäjä luotu"
 
-#: notifications/models.py:39
+#: notifications/models.py:33
 msgid "Type"
 msgstr "Tyyppi"
 
-#: notifications/models.py:54
+#: notifications/models.py:48
 msgid "Text body for email notifications"
 msgstr "Sähköposti-ilmoitusten tekstiosa"
 
-#: notifications/models.py:59
+#: notifications/models.py:53
 msgid "HTML Body"
 msgstr "HTML-teksti"
 
-#: notifications/models.py:60
+#: notifications/models.py:54
 msgid "HTML body for email notifications"
 msgstr "Sähköposti-ilmoitusten HTML-teksti"
 
-#: notifications/models.py:65
+#: notifications/models.py:59
 msgid "Notification template"
 msgstr "Ilmoituspohja"
 
-#: notifications/models.py:66
+#: notifications/models.py:60
 msgid "Notification templates"
 msgstr "Ilmoituspohjat"
 
@@ -708,7 +708,7 @@ msgid ""
 "No contact persons with email addresses found for the given participants."
 msgstr ""
 
-#: registrations/api.py:386
+#: registrations/api.py:385
 msgid "The signup does not have a price group."
 msgstr ""
 
@@ -914,112 +914,130 @@ msgstr "Ilmoitusten tyyppi"
 msgid "Access code"
 msgstr ""
 
-#: registrations/models.py:1132
+#: registrations/models.py:1144
 msgid "Number of seats"
 msgstr "Paikkojen lukumäärä"
 
-#: registrations/models.py:1138
+#: registrations/models.py:1150
 msgid "Seat reservation code"
 msgstr "Paikkavarauskoodi"
 
-#: registrations/models.py:1141
+#: registrations/models.py:1153
 msgid "Timestamp"
 msgstr "Aikaleima"
 
-#: registrations/models.py:1181
+#: registrations/models.py:1193
 msgid "pcs"
 msgstr "kpl"
 
-#: registrations/models.py:1203
+#: registrations/models.py:1215
 msgid "Created"
 msgstr "Luotu"
 
-#: registrations/models.py:1204
+#: registrations/models.py:1216
 msgid "Paid"
 msgstr "Maksettu"
 
-#: registrations/models.py:1205
+#: registrations/models.py:1217
 msgid "Cancelled"
 msgstr "Peruttu"
 
-#: registrations/models.py:1206
+#: registrations/models.py:1218
 msgid "Refunded"
 msgstr "Hyvitety"
 
-#: registrations/models.py:1207
+#: registrations/models.py:1219
 msgid "Expired"
 msgstr "Vanhentunut"
 
-#: registrations/models.py:1231
+#: registrations/models.py:1243
 msgid "Payment status"
 msgstr "Maksun tila"
 
-#: registrations/models.py:1245
+#: registrations/models.py:1257
 msgid "Expires at"
 msgstr "Vanhenee"
 
-#: registrations/notifications.py:17
+#: registrations/notifications.py:8
+#, python-format
+msgid "Welcome %(username)s"
+msgstr "Tervetuloa %(username)s"
+
+#: registrations/notifications.py:9
+msgid "Welcome"
+msgstr "Tervetuloa"
+
+#: registrations/notifications.py:10
+msgid "Thank you for signing up for the waiting list"
+msgstr "Kiitos ilmoittautumisesta jonoon"
+
+#: registrations/notifications.py:11
+msgid "Thank you for your interest in the event."
+msgstr "Kiitos mielenkiinnosta tapahtumaa kohtaan."
+
+#: registrations/notifications.py:12
+msgid "Registration cancelled"
+msgstr "Ilmoittautuminen peruttu"
+
+#: registrations/notifications.py:23
 msgid "No Notification"
 msgstr "Ei ilmoituksia"
 
-#: registrations/notifications.py:18
+#: registrations/notifications.py:24
 msgid "SMS"
 msgstr "Teksiviesti"
 
-#: registrations/notifications.py:19
+#: registrations/notifications.py:25
 msgid "E-Mail"
 msgstr "Sähköposti"
 
-#: registrations/notifications.py:20
+#: registrations/notifications.py:26
 msgid "Both SMS and email."
 msgstr "Tekstiviesti ja sähköposti"
 
-#: registrations/notifications.py:33
+#: registrations/notifications.py:39
 #, python-format
 msgid "Event cancelled - %(event_name)s"
 msgstr "Tapahtuma peruttu - %(event_name)s"
 
-#: registrations/notifications.py:34
+#: registrations/notifications.py:40
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Ilmoittautuminen peruttu - %(event_name)s"
 
-#: registrations/notifications.py:36 registrations/notifications.py:42
+#: registrations/notifications.py:42 registrations/notifications.py:48
 #, python-format
 msgid "Registration confirmation - %(event_name)s"
 msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
 
-#: registrations/notifications.py:39
+#: registrations/notifications.py:45
 #, python-format
 msgid "Waiting list seat reserved - %(event_name)s"
 msgstr "Paikka jonotuslistalla varattu - %(event_name)s"
 
-#: registrations/notifications.py:49
+#: registrations/notifications.py:55
 #, python-format
 msgid "Event %(event_name)s has been cancelled"
 msgstr "Tapahtuma %(event_name)s on peruttu."
 
-#: registrations/notifications.py:50
-msgid "Thank you for your interest in the event."
-msgstr "Kiitos mielenkiinnosta tapahtumaa kohtaan."
+#: registrations/notifications.py:58
+#, python-format
+msgid "Event %(event_name)s %(event_period)s has been cancelled"
+msgstr "Tapahtuma %(event_name)s %(event_period)s on peruttu."
 
-#: registrations/notifications.py:53
-msgid "Registration cancelled"
-msgstr "Ilmoittautuminen peruttu"
-
-#: registrations/notifications.py:56
+#: registrations/notifications.py:65
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen tapahtumaan %(event_name)s on peruttu."
 
-#: registrations/notifications.py:59
+#: registrations/notifications.py:68
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen kurssille %(event_name)s on peruttu."
 
-#: registrations/notifications.py:62
+#: registrations/notifications.py:71
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -1028,22 +1046,22 @@ msgstr ""
 "%(username)s, ilmoittautuminen vapaaehtoistehtävään %(event_name)s on "
 "peruttu."
 
-#: registrations/notifications.py:67
+#: registrations/notifications.py:76
 #, python-format
 msgid "Registration to the event %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen tapahtumaan %(event_name)s on peruttu."
 
-#: registrations/notifications.py:70
+#: registrations/notifications.py:79
 #, python-format
 msgid "Registration to the course %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen kurssille %(event_name)s on peruttu."
 
-#: registrations/notifications.py:73
+#: registrations/notifications.py:82
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on peruttu."
 
-#: registrations/notifications.py:78
+#: registrations/notifications.py:87
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -1052,7 +1070,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:81
+#: registrations/notifications.py:90
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -1061,7 +1079,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:84
+#: registrations/notifications.py:93
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -1070,32 +1088,22 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:89 registrations/notifications.py:178
-#, python-format
-msgid "Welcome %(username)s"
-msgstr "Tervetuloa %(username)s"
-
-#: registrations/notifications.py:90 registrations/notifications.py:114
-#: registrations/notifications.py:179
-msgid "Welcome"
-msgstr "Tervetuloa"
-
-#: registrations/notifications.py:93
+#: registrations/notifications.py:102
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Ilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:105
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Ilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:108
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:104
+#: registrations/notifications.py:113
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -1104,7 +1112,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:107
+#: registrations/notifications.py:116
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -1113,7 +1121,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:110
+#: registrations/notifications.py:119
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -1122,27 +1130,23 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:117
+#: registrations/notifications.py:126
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:120
+#: registrations/notifications.py:129
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:123
+#: registrations/notifications.py:132
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr ""
 "Ryhmäilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:129
-msgid "Thank you for signing up for the waiting list"
-msgstr "Kiitos ilmoittautumisesta jonoon"
-
-#: registrations/notifications.py:132
+#: registrations/notifications.py:141
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1151,7 +1155,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:135
+#: registrations/notifications.py:144
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -1160,7 +1164,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut kurssin <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:138
+#: registrations/notifications.py:147
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -1169,7 +1173,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut vapaaehtoistehtävän "
 "<strong>%(event_name)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:143
+#: registrations/notifications.py:152
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -1177,7 +1181,7 @@ msgstr ""
 "Sinut siirretään automaattisesti tapahtuman osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:146
+#: registrations/notifications.py:155
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1185,7 +1189,7 @@ msgstr ""
 "Sinut siirretään automaattisesti kurssin osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:149
+#: registrations/notifications.py:158
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1193,7 +1197,7 @@ msgstr ""
 "Sinut siirretään automaattisesti vapaaehtoistehtävän osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:155
+#: registrations/notifications.py:164
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1202,7 +1206,7 @@ msgstr ""
 "Ilmoittautuminen tapahtuman <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:158
+#: registrations/notifications.py:167
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1211,7 +1215,7 @@ msgstr ""
 "Ilmoittautuminen kurssin <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:161
+#: registrations/notifications.py:170
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1220,7 +1224,7 @@ msgstr ""
 "Ilmoittautuminen vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalle onnistui."
 
-#: registrations/notifications.py:166
+#: registrations/notifications.py:175
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1228,7 +1232,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti tapahtuman osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:169
+#: registrations/notifications.py:178
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1236,7 +1240,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti kurssin osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:172
+#: registrations/notifications.py:181
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1244,7 +1248,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti vapaaehtoistehtävän "
 "osallistujaksi mikäli paikka vapautuu."
 
-#: registrations/notifications.py:182
+#: registrations/notifications.py:191
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1253,7 +1257,7 @@ msgstr ""
 "Sinut on siirretty tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:185
+#: registrations/notifications.py:194
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1262,7 +1266,7 @@ msgstr ""
 "Sinut on siirretty kurssin <strong>%(event_name)s</strong> jonotuslistalta "
 "osallistujaksi."
 
-#: registrations/notifications.py:188
+#: registrations/notifications.py:197
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1271,17 +1275,283 @@ msgstr ""
 "Sinut on siirretty vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:197
+#: registrations/notifications.py:206
+#, python-format
+msgid "Event cancelled - Recurring: %(event_name)s"
+msgstr "Tapahtuma peruttu - Sarja: %(event_name)s"
+
+#: registrations/notifications.py:209
+#, python-format
+msgid "Registration cancelled - Recurring: %(event_name)s"
+msgstr "Ilmoittautuminen peruttu - Sarja: %(event_name)s"
+
+#: registrations/notifications.py:212 registrations/notifications.py:218
+#, python-format
+msgid "Registration confirmation - Recurring: %(event_name)s"
+msgstr "Vahvistus ilmoittautumisesta - Sarja: %(event_name)s"
+
+#: registrations/notifications.py:215
+#, python-format
+msgid "Waiting list seat reserved - Recurring: %(event_name)s"
+msgstr "Paikka jonotuslistalla varattu - Sarja: %(event_name)s"
+
+#: registrations/notifications.py:226
+#, python-format
+msgid "Recurring event %(event_name)s %(event_period)s has been cancelled"
+msgstr "Sarjatapahtuma %(event_name)s %(event_period)s on peruttu."
+
+#: registrations/notifications.py:234
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring event %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, ilmoittautuminen sarjatapahtumaan %(event_name)s "
+"%(event_period)s on peruttu."
+
+#: registrations/notifications.py:238
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring course %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, ilmoittautuminen sarjakurssille %(event_name)s "
+"%(event_period)s on peruttu."
+
+#: registrations/notifications.py:242
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring volunteering %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s "
+"%(event_period)s on peruttu."
+
+#: registrations/notifications.py:248
+#, python-format
+msgid ""
+"Registration to the recurring event %(event_name)s %(event_period)s has been "
+"cancelled."
+msgstr ""
+"Ilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on peruttu."
+
+#: registrations/notifications.py:252
+#, python-format
+msgid ""
+"Registration to the recurring course %(event_name)s %(event_period)s has "
+"been cancelled."
+msgstr ""
+"Ilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on peruttu."
+
+#: registrations/notifications.py:256
+#, python-format
+msgid ""
+"Registration to the recurring volunteering %(event_name)s %(event_period)s "
+"has been cancelled."
+msgstr ""
+"Ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s %(event_period)s "
+"on peruttu."
+
+#: registrations/notifications.py:262
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Olet onnistuneesti peruuttanut ilmoittautumisesi sarjatapahtumaan "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:266
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Olet onnistuneesti peruuttanut ilmoittautumisesi sarjakurssille "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:270
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Olet onnistuneesti peruuttanut ilmoittautumisesi sarjavapaaehtoistehtävään "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:280
+#, python-format
+msgid ""
+"Registration to the recurring event %(event_name)s %(event_period)s has been "
+"saved."
+msgstr ""
+"Ilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on "
+"tallennettu."
+
+#: registrations/notifications.py:284
+#, python-format
+msgid ""
+"Registration to the recurring course %(event_name)s %(event_period)s has "
+"been saved."
+msgstr ""
+"Ilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on "
+"tallennettu."
+
+#: registrations/notifications.py:288
+#, python-format
+msgid ""
+"Registration to the recurring volunteering %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s %(event_period)s "
+"on tallennettu."
+
+#: registrations/notifications.py:294
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Onnittelut! Ilmoittautumisesi on vahvistettu sarjatapahtumaan "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:298
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Onnittelut! Ilmoittautumisesi on vahvistettu sarjakurssille "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:302
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Onnittelut! Ilmoittautumisesi on vahvistettu sarjavapaaehtoistehtävään "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:310
+#, python-format
+msgid ""
+"Group registration to the recurring event %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Ryhmäilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on "
+"tallennettu."
+
+#: registrations/notifications.py:314
+#, python-format
+msgid ""
+"Group registration to the recurring course %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Ryhmäilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on "
+"tallennettu."
+
+#: registrations/notifications.py:318
+#, python-format
+msgid ""
+"Group registration to the recurring volunteering %(event_name)s "
+"%(event_period)s has been saved."
+msgstr ""
+"Ryhmäilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s "
+"%(event_period)s on tallennettu."
+
+#: registrations/notifications.py:328
+#, python-format
+msgid ""
+"You have successfully registered for the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut sarjatapahtuman <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalle."
+
+#: registrations/notifications.py:332
+#, python-format
+msgid ""
+"You have successfully registered for the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut sarjakurssin <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalle."
+
+#: registrations/notifications.py:336
+#, python-format
+msgid ""
+"You have successfully registered for the recurring volunteering "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Olet onnistuneesti ilmoittautunut sarjavapaaehtoistehtävän "
+"<strong>%(event_name)s %(event_period)s</strong> jonotuslistalle."
+
+#: registrations/notifications.py:346
+#, python-format
+msgid ""
+"The registration for the recurring event <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Ilmoittautuminen sarjatapahtuman <strong>%(event_name)s %(event_period)s</"
+"strong> jonotuslistalle onnistui."
+
+#: registrations/notifications.py:350
+#, python-format
+msgid ""
+"The registration for the recurring course <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Ilmoittautuminen sarjakurssin <strong>%(event_name)s %(event_period)s</"
+"strong> jonotuslistalle onnistui."
+
+#: registrations/notifications.py:354
+#, python-format
+msgid ""
+"The registration for the recurring volunteering <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Ilmoittautuminen sarjavapaaehtoistehtävän <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalle onnistui."
+
+#: registrations/notifications.py:368
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Sinut on siirretty sarjatapahtuman <strong>%(event_name)s %(event_period)s</"
+"strong> jonotuslistalta osallistujaksi."
+
+#: registrations/notifications.py:372
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Sinut on siirretty sarjakurssin <strong>%(event_name)s %(event_period)s</"
+"strong> jonotuslistalta osallistujaksi."
+
+#: registrations/notifications.py:376
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring volunteering "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Sinut on siirretty sarjavapaaehtoistehtävän <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalta osallistujaksi."
+
+#: registrations/notifications.py:386
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
 
-#: registrations/notifications.py:200
+#: registrations/notifications.py:389
 #, python-format
 msgid "Rights granted to the registration - %(event_name)s"
 msgstr "Oikeudet myönnetty ilmoittautumiseen - %(event_name)s"
 
-#: registrations/notifications.py:209
+#: registrations/notifications.py:398
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1290,7 +1560,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "tapahtuman <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:212
+#: registrations/notifications.py:401
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1299,7 +1569,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "kurssin <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:215
+#: registrations/notifications.py:404
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1309,7 +1579,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "vapaaehtoistehtävän <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:222
+#: registrations/notifications.py:411
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1318,7 +1588,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty sijaisen "
 "käyttöoikeudet tapahtuman <strong>%(event_name)s</strong> ilmoittautumiselle."
 
-#: registrations/notifications.py:225
+#: registrations/notifications.py:414
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1328,7 +1598,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty sijaisen "
 "käyttöoikeudet kurssin <strong>%(event_name)s</strong> ilmoittautumiselle."
 
-#: registrations/notifications.py:228
+#: registrations/notifications.py:417
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1369,95 +1639,95 @@ msgstr ""
 msgid "Talpa web store API error"
 msgstr ""
 
-#: registrations/serializers.py:457 registrations/serializers.py:1002
+#: registrations/serializers.py:455 registrations/serializers.py:1000
 msgid "The waiting list is already full"
 msgstr "Jonotuslista on jo täynnä"
 
-#: registrations/serializers.py:467
+#: registrations/serializers.py:465
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Olemassa olevan objektin attendee_status-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:474 registrations/serializers.py:1246
+#: registrations/serializers.py:472 registrations/serializers.py:1244
 msgid "You may not change the registration of an existing object."
 msgstr "Olemassa olevan objektin registration-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:523 registrations/serializers.py:534
-#: registrations/serializers.py:1337
+#: registrations/serializers.py:521 registrations/serializers.py:532
+#: registrations/serializers.py:1335
 msgid "This field must be specified."
 msgstr "Kenttä on pakollinen."
 
-#: registrations/serializers.py:556
+#: registrations/serializers.py:554
 msgid "The participant is too young."
 msgstr "Osallistuja on liian nuori."
 
-#: registrations/serializers.py:561
+#: registrations/serializers.py:559
 msgid "The participant is too old."
 msgstr "Osallistuja on liian vanha."
 
-#: registrations/serializers.py:567
+#: registrations/serializers.py:565
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:578
+#: registrations/serializers.py:576
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:587
+#: registrations/serializers.py:585
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:655
+#: registrations/serializers.py:653
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:720
+#: registrations/serializers.py:718
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:727
+#: registrations/serializers.py:725
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:913
+#: registrations/serializers.py:911
 msgid "Reservation code doesn't exist."
 msgstr "Varauskoodia ei ole olemassa."
 
-#: registrations/serializers.py:935
+#: registrations/serializers.py:933
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Ilmoittautumisten määrä on suurempi kuin ryhmän enimmäiskoko: "
 "{max_group_size}."
 
-#: registrations/serializers.py:957
+#: registrations/serializers.py:955
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1108
+#: registrations/serializers.py:1106
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1340
+#: registrations/serializers.py:1338
 msgid "The value doesn't match."
 msgstr "Arvo ei täsmää."
 
-#: registrations/serializers.py:1358
+#: registrations/serializers.py:1356
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
 
-#: registrations/serializers.py:1383
+#: registrations/serializers.py:1381
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Paikkoja ei ole riittävästi jäljellä. Paikkoja jäljellä: {capacity_left}."
 
-#: registrations/serializers.py:1399
+#: registrations/serializers.py:1397
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1465,7 +1735,7 @@ msgstr ""
 "Jonotuslistalle ei ole tarpeeksi paikkoja jäljellä. Paikkoja jäljellä "
 "jonotuslistalla: {capacity_left}."
 
-#: registrations/serializers.py:1413
+#: registrations/serializers.py:1411
 msgid "Cannot update expired seats reservation."
 msgstr "Vanhentunutta paikkavarausta ei voi päivittää."
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-02 11:18+0000\n"
+"POT-Creation-Date: 2024-02-06 13:13+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -173,385 +173,385 @@ msgid ""
 "for POSTing your events."
 msgstr ""
 
-#: events/models.py:79 events/models.py:208 events/models.py:227
-#: events/models.py:354 events/models.py:426 events/models.py:445
-#: events/models.py:1396 events/models.py:1414 events/models.py:1464
+#: events/models.py:80 events/models.py:209 events/models.py:228
+#: events/models.py:355 events/models.py:427 events/models.py:446
+#: events/models.py:1416 events/models.py:1434 events/models.py:1484
 #: registrations/exports.py:35
 msgid "Name"
 msgstr "Namn"
 
-#: events/models.py:89
+#: events/models.py:90
 msgid "Resources may be edited by users"
 msgstr "Resurser kan redigeras av användare"
 
-#: events/models.py:92
+#: events/models.py:93
 msgid "Organizations may be edited by users"
 msgstr "Organisationer kan redigeras av användare"
 
-#: events/models.py:96
+#: events/models.py:97
 msgid "Owner organization's registrations may be edited by users"
 msgstr "Användare kan redigera organisationens registreringar."
 
-#: events/models.py:101
+#: events/models.py:102
 msgid "Owner organization's registration price groups may be edited by users"
 msgstr "Användare kan redigera organisationens registreringskundgrupper."
 
-#: events/models.py:105
+#: events/models.py:106
 msgid "Past events may be edited using API"
 msgstr "Tidigare evenemang kan redigeras med API"
 
-#: events/models.py:108
+#: events/models.py:109
 msgid "Past events may be created using API"
 msgstr "Tidigare evenemang kan skapas med API"
 
-#: events/models.py:112
+#: events/models.py:113
 msgid "Do not show events created by this data_source by default."
 msgstr "Visa inte evenemang som skapats av denna datakälla som standard."
 
-#: events/models.py:209
+#: events/models.py:210
 msgid "Url"
 msgstr "Url"
 
-#: events/models.py:212 events/models.py:272
+#: events/models.py:213 events/models.py:273
 msgid "License"
 msgstr "Licens"
 
-#: events/models.py:213
+#: events/models.py:214
 msgid "Licenses"
 msgstr "Licenser"
 
-#: events/models.py:240 events/models.py:480 events/models.py:668
-#: events/models.py:986 registrations/models.py:182
+#: events/models.py:241 events/models.py:481 events/models.py:669
+#: events/models.py:987 registrations/models.py:182
 msgid "Publisher"
 msgstr "Utgivare"
 
-#: events/models.py:266 events/models.py:335
+#: events/models.py:267 events/models.py:336
 msgid "Image"
 msgstr "Bild"
 
-#: events/models.py:268
+#: events/models.py:269
 msgid "Cropping"
 msgstr "Beskärning"
 
-#: events/models.py:278
+#: events/models.py:279
 msgid "Photographer name"
 msgstr "Fotografens namn"
 
-#: events/models.py:281 events/models.py:1421
+#: events/models.py:282 events/models.py:1441
 msgid "Alt text"
 msgstr "Alt text"
 
-#: events/models.py:292
+#: events/models.py:293
 msgid "You must provide either image or url."
 msgstr ""
 
-#: events/models.py:294
+#: events/models.py:295
 msgid "You can only provide image or url, not both."
 msgstr ""
 
-#: events/models.py:357
+#: events/models.py:358
 msgid "Origin ID"
 msgstr "Ursprungs-ID"
 
-#: events/models.py:428
+#: events/models.py:429
 msgid "Can be used as registration service language"
 msgstr "Kan användas som servicespråk för registrering"
 
-#: events/models.py:435
+#: events/models.py:436
 msgid "language"
 msgstr "språk"
 
-#: events/models.py:436
+#: events/models.py:437
 msgid "languages"
 msgstr "språk"
 
-#: events/models.py:493 events/models.py:723
+#: events/models.py:494 events/models.py:724
 msgid "event count"
 msgstr "antal evenemang"
 
-#: events/models.py:494
+#: events/models.py:495
 msgid "number of events with this keyword"
 msgstr "antal evenemang med detta sökord"
 
-#: events/models.py:536
+#: events/models.py:537
 msgid ""
 "Trying to replace this keyword with a keyword that is replaced by this "
 "keyword. Please refrain from creating circular replacements andremove one of "
 "the replacements."
 msgstr ""
 
-#: events/models.py:585
+#: events/models.py:586
 msgid "keyword"
 msgstr "nyckelord"
 
-#: events/models.py:586
+#: events/models.py:587
 msgid "keywords"
 msgstr "nyckelord"
 
-#: events/models.py:612
+#: events/models.py:613
 msgid "Intended keyword usage"
 msgstr "Avsedd nyckelordsanvändning"
 
-#: events/models.py:617
+#: events/models.py:618
 msgid "Organization which uses this set"
 msgstr "Organisation som använder denna sökordsuppsättning"
 
-#: events/models.py:630
+#: events/models.py:631
 msgid "KeywordSet can't have deprecated keywords"
 msgstr "Sökordsuppsättningen kan inte ha föråldrade sökord"
 
-#: events/models.py:672
+#: events/models.py:673
 msgid "Place home page"
 msgstr "Placera hemsida"
 
-#: events/models.py:674 events/models.py:955
+#: events/models.py:675 events/models.py:956
 msgid "Description"
 msgstr "Beskrivning"
 
-#: events/models.py:681 events/models.py:1465 registrations/models.py:662
+#: events/models.py:682 events/models.py:1485 registrations/models.py:662
 #: registrations/models.py:932
 msgid "E-mail"
 msgstr "E-post"
 
-#: events/models.py:683
+#: events/models.py:684
 msgid "Telephone"
 msgstr "Telefon"
 
-#: events/models.py:686
+#: events/models.py:687
 msgid "Contact type"
 msgstr "Kontakt typ"
 
-#: events/models.py:689 registrations/models.py:57 registrations/models.py:780
+#: events/models.py:690 registrations/models.py:57 registrations/models.py:780
 msgid "Street address"
 msgstr "Gatuadress"
 
-#: events/models.py:692
+#: events/models.py:693
 msgid "Address locality"
 msgstr "Adressort"
 
-#: events/models.py:695
+#: events/models.py:696
 msgid "Address region"
 msgstr "Adressort"
 
-#: events/models.py:698
+#: events/models.py:699
 msgid "Postal code"
 msgstr "Postnummer"
 
-#: events/models.py:701
+#: events/models.py:702
 msgid "PO BOX"
 msgstr "PO Box"
 
-#: events/models.py:704
+#: events/models.py:705
 msgid "Country"
 msgstr "Land"
 
-#: events/models.py:707
+#: events/models.py:708
 msgid "Deleted"
 msgstr "Raderade"
 
-#: events/models.py:717
+#: events/models.py:718
 msgid "Divisions"
 msgstr ""
 
-#: events/models.py:724
+#: events/models.py:725
 msgid "number of events in this location"
 msgstr "antal evenemang på denna plats"
 
-#: events/models.py:732
+#: events/models.py:733
 msgid "place"
 msgstr "plats"
 
-#: events/models.py:733
+#: events/models.py:734
 msgid "places"
 msgstr "platser"
 
-#: events/models.py:747
+#: events/models.py:748
 msgid ""
 "Trying to replace this place with a place that is replaced by this place. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements. We don't want homeless events."
 msgstr ""
 
-#: events/models.py:837
+#: events/models.py:838
 msgid "opening hour specification"
 msgstr "specifikation för öppettider"
 
-#: events/models.py:838
+#: events/models.py:839
 msgid "opening hour specifications"
 msgstr "specifikationer för öppettider"
 
-#: events/models.py:908
+#: events/models.py:909
 msgid "Recurring"
 msgstr "Återkommande evenemang"
 
-#: events/models.py:909
+#: events/models.py:910
 msgid "Umbrella event"
 msgstr "Paraplyevenemang"
 
-#: events/models.py:924
+#: events/models.py:925
 msgid "Outdoors"
 msgstr "Utomhus"
 
-#: events/models.py:925
+#: events/models.py:926
 msgid "Indoors"
 msgstr "Inomhus"
 
-#: events/models.py:929
+#: events/models.py:930
 msgid "User name"
 msgstr "Användarens name"
 
-#: events/models.py:931
+#: events/models.py:932
 msgid "User e-mail"
 msgstr "Användarens e-post"
 
-#: events/models.py:933
+#: events/models.py:934
 msgid "User phone number"
 msgstr "Användarens telefonnummer"
 
-#: events/models.py:939
+#: events/models.py:940
 msgid "User organization"
 msgstr "Användarens organisation"
 
-#: events/models.py:940
+#: events/models.py:941
 msgid "Event organizer information."
 msgstr "Event arrangör information."
 
-#: events/models.py:946 registrations/models.py:802
+#: events/models.py:947 registrations/models.py:802
 msgid "User consent"
 msgstr "Användarens samtycke"
 
-#: events/models.py:947
+#: events/models.py:948
 msgid "I consent to the processing of my personal data?"
 msgstr "Jag samtycker till behandlingen av mina personuppgifter?"
 
-#: events/models.py:953
+#: events/models.py:954
 msgid "Event home page"
 msgstr "Hemsidan för evenemanget"
 
-#: events/models.py:957
+#: events/models.py:958
 msgid "Short description"
 msgstr "Kort beskrivning"
 
-#: events/models.py:962
+#: events/models.py:963
 msgid "Date published"
 msgstr "Publiceringsdatum"
 
-#: events/models.py:972
+#: events/models.py:973
 msgid "Headline"
 msgstr "Rubrik"
 
-#: events/models.py:975
+#: events/models.py:976
 msgid "Secondary headline"
 msgstr "Sekundär rubrik"
 
-#: events/models.py:977
+#: events/models.py:978
 msgid "Provider"
 msgstr "Leverantör"
 
-#: events/models.py:979
+#: events/models.py:980
 msgid "Provider's contact info"
 msgstr "Leverantörens kontaktuppgifter"
 
-#: events/models.py:992
+#: events/models.py:993
 msgid "Environmental certificate"
 msgstr "Miljöcertifikat"
 
-#: events/models.py:1000
+#: events/models.py:1001
 msgid "Event status"
 msgstr "Evenemangstatus"
 
-#: events/models.py:1007
+#: events/models.py:1008
 msgid "Event data publication status"
 msgstr "Publiceringsstatus för evenemangdata"
 
-#: events/models.py:1016
+#: events/models.py:1017
 msgid "Location extra info"
 msgstr "Plats ytterligare info"
 
-#: events/models.py:1019
+#: events/models.py:1020
 msgid "Event environment"
 msgstr "Evenemangmiljö"
 
-#: events/models.py:1020
+#: events/models.py:1021
 msgid "Will the event be held outdoors?"
 msgstr "Kommer evenemanget att hållas utomhus?"
 
-#: events/models.py:1028
+#: events/models.py:1029
 msgid "Start time"
 msgstr "Starttid"
 
-#: events/models.py:1031
+#: events/models.py:1032
 msgid "End time"
 msgstr "Sluttid"
 
-#: events/models.py:1037 registrations/models.py:247
+#: events/models.py:1038 registrations/models.py:247
 msgid "Minimum recommended age"
 msgstr "Rekommenderad lägsta ålder"
 
-#: events/models.py:1040 registrations/models.py:250
+#: events/models.py:1041 registrations/models.py:250
 msgid "Maximum recommended age"
 msgstr "Högsta rekommenderade ålder"
 
-#: events/models.py:1065
+#: events/models.py:1066
 msgid "In language"
 msgstr "språk"
 
-#: events/models.py:1081
+#: events/models.py:1082
 msgid "maximum attendee capacity"
 msgstr "Maximal deltagarekapacitet"
 
-#: events/models.py:1087
+#: events/models.py:1088
 msgid "minimum attendee capacity"
 msgstr "Minsta deltagarekapacitet"
 
-#: events/models.py:1090
+#: events/models.py:1091
 msgid "enrolment start time"
 msgstr "Starttid för anmälan"
 
-#: events/models.py:1093
+#: events/models.py:1094
 msgid "enrolment end time"
 msgstr "Sluttid för anmälan"
 
-#: events/models.py:1109
+#: events/models.py:1110
 msgid "event"
 msgstr "evenemang"
 
-#: events/models.py:1110
+#: events/models.py:1111
 msgid "events"
 msgstr "evenemang"
 
-#: events/models.py:1120
+#: events/models.py:1121
 msgid ""
 "Trying to replace this event with an event that is replaced by this event. "
 "Please refrain from creating circular replacements and remove one of the "
 "replacements."
 msgstr ""
 
-#: events/models.py:1159
+#: events/models.py:1160
 msgid "The event end time cannot be earlier than the start time."
 msgstr "Evenemangs sluttid kan inte vara tidigare än starttiden."
 
-#: events/models.py:1377
+#: events/models.py:1397
 msgid "Price"
 msgstr "Pris"
 
-#: events/models.py:1379
+#: events/models.py:1399
 msgid "Web link to offer"
 msgstr "Webblänk att erbjuda"
 
-#: events/models.py:1382
+#: events/models.py:1402
 msgid "Offer description"
 msgstr "Erbjudandebeskrivning"
 
-#: events/models.py:1386
+#: events/models.py:1406
 msgid "Is free"
 msgstr "Är gratis"
 
-#: events/models.py:1466 notifications/models.py:47
+#: events/models.py:1486 notifications/models.py:41
 msgid "Subject"
 msgstr "Ämne"
 
-#: events/models.py:1467 notifications/models.py:53
+#: events/models.py:1487 notifications/models.py:47
 msgid "Body"
 msgstr "Text"
 
@@ -588,7 +588,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1495
+#: linkedevents/fields.py:69 registrations/serializers.py:1493
 msgid "This field is required."
 msgstr "Detta fält måste anges."
 
@@ -615,43 +615,43 @@ msgstr "Namn måste anges."
 msgid "Notifications"
 msgstr "Aviseringar"
 
-#: notifications/models.py:32
+#: notifications/models.py:26
 msgid "Unpublished event deleted"
 msgstr "Opublicerad evenemang raderad"
 
-#: notifications/models.py:33
+#: notifications/models.py:27
 msgid "Event published"
 msgstr "Evenemang publicerad"
 
-#: notifications/models.py:34
+#: notifications/models.py:28
 msgid "Draft posted"
 msgstr "Utkast upplagt"
 
-#: notifications/models.py:35
+#: notifications/models.py:29
 msgid "User created"
 msgstr "Användare skapad"
 
-#: notifications/models.py:39
+#: notifications/models.py:33
 msgid "Type"
 msgstr "Typ"
 
-#: notifications/models.py:54
+#: notifications/models.py:48
 msgid "Text body for email notifications"
 msgstr "Texttext för e-postmeddelanden"
 
-#: notifications/models.py:59
+#: notifications/models.py:53
 msgid "HTML Body"
 msgstr "HTML Body"
 
-#: notifications/models.py:60
+#: notifications/models.py:54
 msgid "HTML body for email notifications"
 msgstr "HTML Body för e-postmeddelanden"
 
-#: notifications/models.py:65
+#: notifications/models.py:59
 msgid "Notification template"
 msgstr "Aviseringsmall"
 
-#: notifications/models.py:66
+#: notifications/models.py:60
 msgid "Notification templates"
 msgstr "Aviseringsmallar"
 
@@ -706,7 +706,7 @@ msgid ""
 "No contact persons with email addresses found for the given participants."
 msgstr ""
 
-#: registrations/api.py:386
+#: registrations/api.py:385
 msgid "The signup does not have a price group."
 msgstr ""
 
@@ -913,112 +913,130 @@ msgstr "Aviseringstyp"
 msgid "Access code"
 msgstr ""
 
-#: registrations/models.py:1132
+#: registrations/models.py:1144
 msgid "Number of seats"
 msgstr "Antal platser"
 
-#: registrations/models.py:1138
+#: registrations/models.py:1150
 msgid "Seat reservation code"
 msgstr "Platsreservationskod"
 
-#: registrations/models.py:1141
+#: registrations/models.py:1153
 msgid "Timestamp"
 msgstr "Tidsstämpel"
 
-#: registrations/models.py:1181
+#: registrations/models.py:1193
 msgid "pcs"
 msgstr "st"
 
-#: registrations/models.py:1203
+#: registrations/models.py:1215
 msgid "Created"
 msgstr "Skapad"
 
-#: registrations/models.py:1204
+#: registrations/models.py:1216
 msgid "Paid"
 msgstr "Betalt"
 
-#: registrations/models.py:1205
+#: registrations/models.py:1217
 msgid "Cancelled"
 msgstr "Inställt"
 
-#: registrations/models.py:1206
+#: registrations/models.py:1218
 msgid "Refunded"
 msgstr "Återbetalat"
 
-#: registrations/models.py:1207
+#: registrations/models.py:1219
 msgid "Expired"
 msgstr "Utgått"
 
-#: registrations/models.py:1231
+#: registrations/models.py:1243
 msgid "Payment status"
 msgstr "Betalningens status"
 
-#: registrations/models.py:1245
+#: registrations/models.py:1257
 msgid "Expires at"
 msgstr "Utgår på"
 
-#: registrations/notifications.py:17
+#: registrations/notifications.py:8
+#, python-format
+msgid "Welcome %(username)s"
+msgstr "Välkommen %(username)s"
+
+#: registrations/notifications.py:9
+msgid "Welcome"
+msgstr "Välkommen"
+
+#: registrations/notifications.py:10
+msgid "Thank you for signing up for the waiting list"
+msgstr "Tack för att du skrev upp dig på väntelistan"
+
+#: registrations/notifications.py:11
+msgid "Thank you for your interest in the event."
+msgstr "Tack för ditt intresse för evenemanget."
+
+#: registrations/notifications.py:12
+msgid "Registration cancelled"
+msgstr "Registreringen avbruten"
+
+#: registrations/notifications.py:23
 msgid "No Notification"
 msgstr "Ingen anmälan"
 
-#: registrations/notifications.py:18
+#: registrations/notifications.py:24
 msgid "SMS"
 msgstr "SMS"
 
-#: registrations/notifications.py:19
+#: registrations/notifications.py:25
 msgid "E-Mail"
 msgstr "E-post"
 
-#: registrations/notifications.py:20
+#: registrations/notifications.py:26
 msgid "Both SMS and email."
 msgstr "Både SMS och e-post."
 
-#: registrations/notifications.py:33
+#: registrations/notifications.py:39
 #, python-format
 msgid "Event cancelled - %(event_name)s"
 msgstr "Evenemanget inställt - %(event_name)s"
 
-#: registrations/notifications.py:34
+#: registrations/notifications.py:40
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Registreringen avbruten - %(event_name)s"
 
-#: registrations/notifications.py:36 registrations/notifications.py:42
+#: registrations/notifications.py:42 registrations/notifications.py:48
 #, python-format
 msgid "Registration confirmation - %(event_name)s"
 msgstr "Bekräftelse av registrering - %(event_name)s"
 
-#: registrations/notifications.py:39
+#: registrations/notifications.py:45
 #, python-format
 msgid "Waiting list seat reserved - %(event_name)s"
 msgstr "Väntelista plats reserverad - %(event_name)s"
 
-#: registrations/notifications.py:49
+#: registrations/notifications.py:55
 #, python-format
 msgid "Event %(event_name)s has been cancelled"
 msgstr "Evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:50
-msgid "Thank you for your interest in the event."
-msgstr "Tack för ditt intresse för evenemanget."
+#: registrations/notifications.py:58
+#, python-format
+msgid "Event %(event_name)s %(event_period)s has been cancelled"
+msgstr "Evenemanget %(event_name)s %(event_period)s har ställts in."
 
-#: registrations/notifications.py:53
-msgid "Registration cancelled"
-msgstr "Registreringen avbruten"
-
-#: registrations/notifications.py:56
+#: registrations/notifications.py:65
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:59
+#: registrations/notifications.py:68
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till kursen %(event_name)s har ställts in."
 
-#: registrations/notifications.py:62
+#: registrations/notifications.py:71
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -1026,22 +1044,22 @@ msgid ""
 msgstr ""
 "%(username)s, anmälan till volontärarbetet %(event_name)s har ställts in."
 
-#: registrations/notifications.py:67
+#: registrations/notifications.py:76
 #, python-format
 msgid "Registration to the event %(event_name)s has been cancelled."
 msgstr "Anmälan till evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:70
+#: registrations/notifications.py:79
 #, python-format
 msgid "Registration to the course %(event_name)s has been cancelled."
 msgstr "Anmälan till kursen %(event_name)s har ställts in."
 
-#: registrations/notifications.py:73
+#: registrations/notifications.py:82
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been cancelled."
 msgstr "Anmälan till volontärarbetet %(event_name)s har ställts in."
 
-#: registrations/notifications.py:78
+#: registrations/notifications.py:87
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -1050,7 +1068,7 @@ msgstr ""
 "Du har avbrutit din registrering till evenemanget <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:81
+#: registrations/notifications.py:90
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -1058,7 +1076,7 @@ msgid ""
 msgstr ""
 "Du har avbrutit din registrering till kursen <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:84
+#: registrations/notifications.py:93
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -1067,32 +1085,22 @@ msgstr ""
 "Du har avbrutit din registrering till volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:89 registrations/notifications.py:178
-#, python-format
-msgid "Welcome %(username)s"
-msgstr "Välkommen %(username)s"
-
-#: registrations/notifications.py:90 registrations/notifications.py:114
-#: registrations/notifications.py:179
-msgid "Welcome"
-msgstr "Välkommen"
-
-#: registrations/notifications.py:93
+#: registrations/notifications.py:102
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Anmälan till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:105
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Anmälan till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:108
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Anmälan till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:104
+#: registrations/notifications.py:113
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -1101,7 +1109,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för evenemanget "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:107
+#: registrations/notifications.py:116
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -1110,7 +1118,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för kursen <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:110
+#: registrations/notifications.py:119
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -1119,26 +1127,22 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:117
+#: registrations/notifications.py:126
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Gruppregistrering till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:120
+#: registrations/notifications.py:129
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Gruppregistrering till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:123
+#: registrations/notifications.py:132
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr "Gruppregistrering till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:129
-msgid "Thank you for signing up for the waiting list"
-msgstr "Tack för att du skrev upp dig på väntelistan"
-
-#: registrations/notifications.py:132
+#: registrations/notifications.py:141
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1147,7 +1151,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för evenemangets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:135
+#: registrations/notifications.py:144
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -1156,7 +1160,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för kursen <strong>%(event_name)s</"
 "strong> väntelista."
 
-#: registrations/notifications.py:138
+#: registrations/notifications.py:147
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -1165,7 +1169,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för volontärarbetets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:143
+#: registrations/notifications.py:152
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -1173,7 +1177,7 @@ msgstr ""
 "Du kommer automatiskt att överföras som evenemangsdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:146
+#: registrations/notifications.py:155
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1181,7 +1185,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som kursdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:149
+#: registrations/notifications.py:158
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1189,7 +1193,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som evenemangsdeltagare om en plats "
 "blir ledig."
 
-#: registrations/notifications.py:155
+#: registrations/notifications.py:164
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1198,7 +1202,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "evenemanget lyckades."
 
-#: registrations/notifications.py:158
+#: registrations/notifications.py:167
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1207,7 +1211,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-kursen "
 "lyckades."
 
-#: registrations/notifications.py:161
+#: registrations/notifications.py:170
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1216,7 +1220,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "volontärarbetet lyckades."
 
-#: registrations/notifications.py:166
+#: registrations/notifications.py:175
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1224,7 +1228,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "evenemanget om en plats blir ledig."
 
-#: registrations/notifications.py:169
+#: registrations/notifications.py:178
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1232,7 +1236,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i kursen "
 "om en plats blir ledig."
 
-#: registrations/notifications.py:172
+#: registrations/notifications.py:181
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1240,7 +1244,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "volontärarbetet om en plats blir ledig."
 
-#: registrations/notifications.py:182
+#: registrations/notifications.py:191
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1249,7 +1253,7 @@ msgstr ""
 "Du har flyttats från väntelistan för evenemanget <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:185
+#: registrations/notifications.py:194
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1258,7 +1262,7 @@ msgstr ""
 "Du har flyttats från väntelistan för kursen <strong>%(event_name)s</strong> "
 "till en deltagare."
 
-#: registrations/notifications.py:188
+#: registrations/notifications.py:197
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1267,17 +1271,280 @@ msgstr ""
 "Du har flyttats från väntelistan för volontärarbetet <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:197
+#: registrations/notifications.py:206
+#, python-format
+msgid "Event cancelled - Recurring: %(event_name)s"
+msgstr "Evenemanget inställt - Serie: %(event_name)s"
+
+#: registrations/notifications.py:209
+#, python-format
+msgid "Registration cancelled - Recurring: %(event_name)s"
+msgstr "Registreringen avbruten - Serie: %(event_name)s"
+
+#: registrations/notifications.py:212 registrations/notifications.py:218
+#, python-format
+msgid "Registration confirmation - Recurring: %(event_name)s"
+msgstr "Bekräftelse av registrering - Serie: %(event_name)s"
+
+#: registrations/notifications.py:215
+#, python-format
+msgid "Waiting list seat reserved - Recurring: %(event_name)s"
+msgstr "Väntelista plats reserverad - Serie: %(event_name)s"
+
+#: registrations/notifications.py:226
+#, python-format
+msgid "Recurring event %(event_name)s %(event_period)s has been cancelled"
+msgstr "Serieevenemanget %(event_name)s %(event_period)s har ställts in."
+
+#: registrations/notifications.py:234
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring event %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, anmälan till serieevenemanget %(event_name)s %(event_period)s "
+"har ställts in."
+
+#: registrations/notifications.py:238
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring course %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, anmälan till seriekursen %(event_name)s %(event_period)s har "
+"ställts in."
+
+#: registrations/notifications.py:242
+#, python-format
+msgid ""
+"%(username)s, registration to the recurring volunteering %(event_name)s "
+"%(event_period)s has been cancelled."
+msgstr ""
+"%(username)s, anmälan till serievolontärarbetet %(event_name)s "
+"%(event_period)s har ställts in."
+
+#: registrations/notifications.py:248
+#, python-format
+msgid ""
+"Registration to the recurring event %(event_name)s %(event_period)s has been "
+"cancelled."
+msgstr ""
+"Anmälan till serieevenemanget %(event_name)s %(event_period)s har ställts in."
+
+#: registrations/notifications.py:252
+#, python-format
+msgid ""
+"Registration to the recurring course %(event_name)s %(event_period)s has "
+"been cancelled."
+msgstr ""
+"Anmälan till seriekursen %(event_name)s %(event_period)s har ställts in."
+
+#: registrations/notifications.py:256
+#, python-format
+msgid ""
+"Registration to the recurring volunteering %(event_name)s %(event_period)s "
+"has been cancelled."
+msgstr ""
+"Anmälan till serievolontärarbetet %(event_name)s %(event_period)s har "
+"ställts in."
+
+#: registrations/notifications.py:262
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till serieevenemanget "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:266
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till seriekursen <strong>%(event_name)s "
+"%(event_period)s</strong>."
+
+#: registrations/notifications.py:270
+#, python-format
+msgid ""
+"You have successfully cancelled your registration to the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Du har avbrutit din registrering till serievolontärarbetet "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:280
+#, python-format
+msgid ""
+"Registration to the recurring event %(event_name)s %(event_period)s has been "
+"saved."
+msgstr ""
+"Anmälan till serieevenemanget %(event_name)s %(event_period)s har sparats."
+
+#: registrations/notifications.py:284
+#, python-format
+msgid ""
+"Registration to the recurring course %(event_name)s %(event_period)s has "
+"been saved."
+msgstr "Anmälan till seriekursen %(event_name)s %(event_period)s har sparats."
+
+#: registrations/notifications.py:288
+#, python-format
+msgid ""
+"Registration to the recurring volunteering %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Anmälan till serievolontärarbetet %(event_name)s %(event_period)s har "
+"sparats."
+
+#: registrations/notifications.py:294
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Grattis! Din registrering har bekräftats för serieevenemanget "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:298
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Grattis! Din registrering har bekräftats för seriekursen "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:302
+#, python-format
+msgid ""
+"Congratulations! Your registration has been confirmed for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Grattis! Din registrering har bekräftats för serievolontärarbetet "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:310
+#, python-format
+msgid ""
+"Group registration to the recurring event %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Gruppregistrering till serieevenemanget %(event_name)s %(event_period)s har "
+"sparats."
+
+#: registrations/notifications.py:314
+#, python-format
+msgid ""
+"Group registration to the recurring course %(event_name)s %(event_period)s "
+"has been saved."
+msgstr ""
+"Gruppregistrering till seriekursen %(event_name)s %(event_period)s har "
+"sparats."
+
+#: registrations/notifications.py:318
+#, python-format
+msgid ""
+"Group registration to the recurring volunteering %(event_name)s "
+"%(event_period)s has been saved."
+msgstr ""
+"Gruppregistrering till serievolontärarbetet %(event_name)s %(event_period)s "
+"har sparats."
+
+#: registrations/notifications.py:328
+#, python-format
+msgid ""
+"You have successfully registered for the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för serieevenemangets "
+"<strong>%(event_name)s %(event_period)s</strong> väntelista."
+
+#: registrations/notifications.py:332
+#, python-format
+msgid ""
+"You have successfully registered for the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för seriekursen <strong>%(event_name)s "
+"%(event_period)s</strong> väntelista."
+
+#: registrations/notifications.py:336
+#, python-format
+msgid ""
+"You have successfully registered for the recurring volunteering "
+"<strong>%(event_name)s %(event_period)s</strong> waiting list."
+msgstr ""
+"Du har framgångsrikt registrerat dig för serievolontärarbetets "
+"<strong>%(event_name)s %(event_period)s</strong> väntelista."
+
+#: registrations/notifications.py:346
+#, python-format
+msgid ""
+"The registration for the recurring event <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Registreringen till väntelistan för serieevenemanget <strong>%(event_name)s "
+"%(event_period)s</strong> lyckades."
+
+#: registrations/notifications.py:350
+#, python-format
+msgid ""
+"The registration for the recurring course <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Registreringen till väntelistan för seriekursen <strong>%(event_name)s "
+"%(event_period)s</strong> lyckades."
+
+#: registrations/notifications.py:354
+#, python-format
+msgid ""
+"The registration for the recurring volunteering <strong>%(event_name)s "
+"%(event_period)s</strong> waiting list was successful."
+msgstr ""
+"Registreringen till väntelistan för serievolontärarbetet "
+"<strong>%(event_name)s %(event_period)s</strong> lyckades."
+
+#: registrations/notifications.py:368
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring event "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Du har flyttats från väntelistan för serieevenemanget <strong>%(event_name)s "
+"%(event_period)s</strong> till en deltagare."
+
+#: registrations/notifications.py:372
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring course "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Du har flyttats från väntelistan för seriekursen <strong>%(event_name)s "
+"%(event_period)s</strong> till en deltagare."
+
+#: registrations/notifications.py:376
+#, python-format
+msgid ""
+"You have been moved from the waiting list of the recurring volunteering "
+"<strong>%(event_name)s %(event_period)s</strong> to a participant."
+msgstr ""
+"Du har flyttats från väntelistan för serievolontärarbetet "
+"<strong>%(event_name)s %(event_period)s</strong> till en deltagare."
+
+#: registrations/notifications.py:386
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Rättigheter tilldelade deltagarlistan - %(event_name)s"
 
-#: registrations/notifications.py:200
+#: registrations/notifications.py:389
 #, python-format
 msgid "Rights granted to the registration - %(event_name)s"
 msgstr "Rättigheter beviljade till registreringen - %(event_name)s"
 
-#: registrations/notifications.py:209
+#: registrations/notifications.py:398
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1286,7 +1553,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för evenemanget <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:212
+#: registrations/notifications.py:401
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1295,7 +1562,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för kursen <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:215
+#: registrations/notifications.py:404
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1305,7 +1572,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för volontärarbetet <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:222
+#: registrations/notifications.py:411
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1315,7 +1582,7 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av evenemanget "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:225
+#: registrations/notifications.py:414
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1326,7 +1593,7 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av kursen "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:228
+#: registrations/notifications.py:417
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1367,94 +1634,94 @@ msgstr ""
 msgid "Talpa web store API error"
 msgstr ""
 
-#: registrations/serializers.py:457 registrations/serializers.py:1002
+#: registrations/serializers.py:455 registrations/serializers.py:1000
 msgid "The waiting list is already full"
 msgstr "Väntelistan är redan full"
 
-#: registrations/serializers.py:467
+#: registrations/serializers.py:465
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Du får inte ändra attendee_status för ett befintligt objekt."
 
-#: registrations/serializers.py:474 registrations/serializers.py:1246
+#: registrations/serializers.py:472 registrations/serializers.py:1244
 msgid "You may not change the registration of an existing object."
 msgstr "Du får inte ändra registration för ett befintligt objekt."
 
-#: registrations/serializers.py:523 registrations/serializers.py:534
-#: registrations/serializers.py:1337
+#: registrations/serializers.py:521 registrations/serializers.py:532
+#: registrations/serializers.py:1335
 msgid "This field must be specified."
 msgstr "Detta fält måste anges."
 
-#: registrations/serializers.py:556
+#: registrations/serializers.py:554
 msgid "The participant is too young."
 msgstr "Deltagaren är för ung."
 
-#: registrations/serializers.py:561
+#: registrations/serializers.py:559
 msgid "The participant is too old."
 msgstr "Deltagaren är för gammal."
 
-#: registrations/serializers.py:567
+#: registrations/serializers.py:565
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:578
+#: registrations/serializers.py:576
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:587
+#: registrations/serializers.py:585
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:655
+#: registrations/serializers.py:653
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:720
+#: registrations/serializers.py:718
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:727
+#: registrations/serializers.py:725
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:913
+#: registrations/serializers.py:911
 msgid "Reservation code doesn't exist."
 msgstr "Bokningskoden finns inte."
 
-#: registrations/serializers.py:935
+#: registrations/serializers.py:933
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Antalet registreringar är större än den maximala gruppstorleken: "
 "{max_group_size}."
 
-#: registrations/serializers.py:957
+#: registrations/serializers.py:955
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1108
+#: registrations/serializers.py:1106
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1340
+#: registrations/serializers.py:1338
 msgid "The value doesn't match."
 msgstr "Värdet stämmer inte överens."
 
-#: registrations/serializers.py:1358
+#: registrations/serializers.py:1356
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr "Antalet platser är större än maximal gruppstorlek: {max_group_size}."
 
-#: registrations/serializers.py:1383
+#: registrations/serializers.py:1381
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Inte tillräckligt med platser tillgängliga. Kapacitet kvar: {capacity_left}."
 
-#: registrations/serializers.py:1399
+#: registrations/serializers.py:1397
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1462,7 +1729,7 @@ msgstr ""
 "Inte tillräckligt med kapacitet på väntelistan. Kapacitet kvar: "
 "{capacity_left}."
 
-#: registrations/serializers.py:1413
+#: registrations/serializers.py:1411
 msgid "Cannot update expired seats reservation."
 msgstr "Kan inte uppdatera utgångna platsreservationer."
 

--- a/notifications/exceptions.py
+++ b/notifications/exceptions.py
@@ -1,0 +1,2 @@
+class NotificationTemplateException(Exception):
+    pass

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -1,9 +1,6 @@
 import logging
 
-from django.conf import settings
 from django.db import models
-from django.utils import timezone
-from django.utils.formats import date_format
 from django.utils.html import strip_tags
 from django.utils.translation import activate
 from django.utils.translation import gettext_lazy as _
@@ -11,7 +8,8 @@ from jinja2 import StrictUndefined
 from jinja2.exceptions import TemplateError
 from jinja2.sandbox import SandboxedEnvironment
 
-DEFAULT_LANG = settings.LANGUAGES[0][0]
+from notifications.exceptions import NotificationTemplateException
+from notifications.utils import DEFAULT_LANG, format_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +19,6 @@ class NotificationType:
     EVENT_PUBLISHED = "event_published"
     DRAFT_POSTED = "draft_posted"
     USER_CREATED = "user_created"
-
-
-class NotificationTemplateException(Exception):
-    pass
 
 
 class NotificationTemplate(models.Model):
@@ -107,25 +101,6 @@ class NotificationTemplate(models.Model):
             return rendered_notification
         except TemplateError as e:
             raise NotificationTemplateException(e) from e
-
-
-def format_datetime(dt, lang="fi"):
-    dt = timezone.template_localtime(dt)
-    if lang == "fi":
-        # 1.1.2017 klo 12:00
-        dt_format = r"j.n.Y \k\l\o G:i"
-    elif lang == "sv":
-        # 1.1.2017 kl. 12:00
-        dt_format = r"j.n.Y \k\l\. G:i"
-    elif lang == "en":
-        # 1 Jan 2017 at 12:00
-        dt_format = r"j M Y \a\t G:i"
-    else:
-        raise NotificationTemplateException(
-            f"format_datetime received unknown language '{lang}'"
-        )
-
-    return date_format(dt, dt_format)
 
 
 def render_notification_template(

--- a/notifications/tests/test_utils.py
+++ b/notifications/tests/test_utils.py
@@ -1,0 +1,52 @@
+import freezegun
+import pytest
+from django.utils.timezone import localtime
+
+from notifications.exceptions import NotificationTemplateException
+from notifications.utils import format_date, format_datetime
+
+
+@pytest.mark.parametrize(
+    "language,expected_formatted_datetime",
+    [
+        ("fi", "1.2.2024 klo 3:30"),
+        ("en", "1 Feb 2024 at 3:30"),
+        ("sv", "1.2.2024 kl. 3:30"),
+    ],
+)
+@freezegun.freeze_time("2024-02-01 03:30:00+02:00")
+def test_format_datetime_according_to_language(language, expected_formatted_datetime):
+    dt = localtime()
+    assert format_datetime(dt, lang=language) == expected_formatted_datetime
+
+
+@pytest.mark.parametrize("language", ["wrong", "", None])
+@freezegun.freeze_time("2024-02-01 03:30:00+02:00")
+def test_format_datetime_invalid_language(language):
+    dt = localtime()
+
+    with pytest.raises(NotificationTemplateException):
+        format_datetime(dt, lang=language)
+
+
+@pytest.mark.parametrize(
+    "language,expected_formatted_date",
+    [
+        ("fi", "1.2.2024"),
+        ("en", "1 Feb 2024"),
+        ("sv", "1.2.2024"),
+    ],
+)
+@freezegun.freeze_time("2024-02-01 03:30:00+02:00")
+def test_format_date_according_to_language(language, expected_formatted_date):
+    dt = localtime()
+    assert format_date(dt, lang=language) == expected_formatted_date
+
+
+@pytest.mark.parametrize("language", ["wrong", "", None])
+@freezegun.freeze_time("2024-02-01 03:30:00+02:00")
+def test_format_date_invalid_language(language):
+    dt = localtime()
+
+    with pytest.raises(NotificationTemplateException):
+        format_date(dt, lang=language)

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.utils import timezone
+from django.utils.formats import date_format
+
+from notifications.exceptions import NotificationTemplateException
+
+DEFAULT_LANG = settings.LANGUAGES[0][0]
+
+
+def format_datetime(dt, lang="fi"):
+    dt = timezone.template_localtime(dt)
+    if lang == "fi":
+        # 1.1.2017 klo 12:00
+        dt_format = r"j.n.Y \k\l\o G:i"
+    elif lang == "sv":
+        # 1.1.2017 kl. 12:00
+        dt_format = r"j.n.Y \k\l\. G:i"
+    elif lang == "en":
+        # 1 Jan 2017 at 12:00
+        dt_format = r"j M Y \a\t G:i"
+    else:
+        raise NotificationTemplateException(
+            f"format_datetime received unknown language '{lang}'"
+        )
+
+    return date_format(dt, dt_format)
+
+
+def format_date(dt, lang="fi"):
+    dt = timezone.template_localtime(dt)
+
+    if lang in ("fi", "sv"):
+        # 1.1.2017
+        dt_format = r"j.n.Y"
+    elif lang == "en":
+        # 1 Jan 2017
+        dt_format = r"j M Y"
+    else:
+        raise NotificationTemplateException(
+            f"format_date received unknown language '{lang}'"
+        )
+
+    return date_format(dt, dt_format)

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -1066,7 +1066,9 @@ class SignUpContactPerson(SignUpOrGroupDependingMixin, SerializableMixin):
             [self.email],
         )
 
-    def get_notification_message(self, notification_type, access_code=None):
+    def get_notification_message(
+        self, notification_type, access_code=None, is_sub_event_cancellation=False
+    ):
         [_, linked_registrations_ui_locale] = get_ui_locales(self.service_language)
 
         if notification_type == SignUpNotificationType.EVENT_CANCELLATION:
@@ -1087,7 +1089,9 @@ class SignUpContactPerson(SignUpOrGroupDependingMixin, SerializableMixin):
                 self, access_code=access_code
             )
             email_variables["texts"] = get_signup_notification_texts(
-                self, notification_type
+                self,
+                notification_type,
+                is_sub_event_cancellation=is_sub_event_cancellation,
             )
 
             rendered_body = render_to_string(
@@ -1096,15 +1100,23 @@ class SignUpContactPerson(SignUpOrGroupDependingMixin, SerializableMixin):
             )
 
         return (
-            get_signup_notification_subject(self, notification_type),
+            get_signup_notification_subject(
+                self,
+                notification_type,
+                is_sub_event_cancellation=is_sub_event_cancellation,
+            ),
             rendered_body,
             get_email_noreply_address(),
             [self.email],
         )
 
-    def send_notification(self, notification_type, access_code=None):
+    def send_notification(
+        self, notification_type, access_code=None, is_sub_event_cancellation=False
+    ):
         message = self.get_notification_message(
-            notification_type, access_code=access_code
+            notification_type,
+            access_code=access_code,
+            is_sub_event_cancellation=is_sub_event_cancellation,
         )
         rendered_body = message[1]
 

--- a/registrations/notifications.py
+++ b/registrations/notifications.py
@@ -5,6 +5,14 @@ from django.utils.translation import gettext_lazy as _
 from events.models import Event
 from registrations.utils import get_signup_edit_url, get_ui_locales
 
+CONFIRMATION_HEADING_WITH_USERNAME = _("Welcome %(username)s")
+CONFIRMATION_HEADING_WITHOUT_USERNAME = _("Welcome")
+CONFIRMATION_TO_WAITING_LIST_HEADING = _(
+    "Thank you for signing up for the waiting list"
+)
+EVENT_CANCELLED_TEXT = _("Thank you for your interest in the event.")
+REGISTRATION_CANCELLED_HEADING = _("Registration cancelled")
+
 
 class NotificationType:
     NO_NOTIFICATION = "none"
@@ -47,10 +55,13 @@ signup_notification_subjects = {
 signup_email_texts = {
     SignUpNotificationType.EVENT_CANCELLATION: {
         "heading": _("Event %(event_name)s has been cancelled"),
-        "text": _("Thank you for your interest in the event."),
+        "text": EVENT_CANCELLED_TEXT,
+        "sub_event_cancellation": {
+            "heading": _("Event %(event_name)s %(event_period)s has been cancelled"),
+        },
     },
     SignUpNotificationType.CANCELLATION: {
-        "heading": _("Registration cancelled"),
+        "heading": REGISTRATION_CANCELLED_HEADING,
         "secondary_heading": {
             Event.TypeId.GENERAL: _(
                 "%(username)s, registration to the event %(event_name)s has been cancelled."
@@ -86,8 +97,8 @@ signup_email_texts = {
         },
     },
     SignUpNotificationType.CONFIRMATION: {
-        "heading": _("Welcome %(username)s"),
-        "heading_without_username": _("Welcome"),
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
         "secondary_heading": {
             Event.TypeId.GENERAL: _(
                 "Registration to the event %(event_name)s has been saved."
@@ -111,7 +122,7 @@ signup_email_texts = {
             ),
         },
         "group": {
-            "heading": _("Welcome"),
+            "heading": CONFIRMATION_HEADING_WITHOUT_USERNAME,
             "secondary_heading": {
                 Event.TypeId.GENERAL: _(
                     "Group registration to the event %(event_name)s has been saved."
@@ -126,7 +137,7 @@ signup_email_texts = {
         },
     },
     SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: {
-        "heading": _("Thank you for signing up for the waiting list"),
+        "heading": CONFIRMATION_TO_WAITING_LIST_HEADING,
         "text": {
             Event.TypeId.GENERAL: _(
                 "You have successfully registered for the event <strong>%(event_name)s</strong> waiting list."
@@ -175,8 +186,8 @@ signup_email_texts = {
         },
     },
     SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT: {
-        "heading": _("Welcome %(username)s"),
-        "heading_without_username": _("Welcome"),
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
         "text": {
             Event.TypeId.GENERAL: _(
                 "You have been moved from the waiting list of the event <strong>%(event_name)s</strong> to a participant."  # noqa E501
@@ -186,6 +197,186 @@ signup_email_texts = {
             ),
             Event.TypeId.VOLUNTEERING: _(
                 "You have been moved from the waiting list of the volunteering <strong>%(event_name)s</strong> to a participant."  # noqa E501
+            ),
+        },
+    },
+}
+
+
+recurring_event_signup_notification_subjects = {
+    SignUpNotificationType.EVENT_CANCELLATION: _(
+        "Event cancelled - Recurring: %(event_name)s"
+    ),
+    SignUpNotificationType.CANCELLATION: _(
+        "Registration cancelled - Recurring: %(event_name)s"
+    ),
+    SignUpNotificationType.CONFIRMATION: _(
+        "Registration confirmation - Recurring: %(event_name)s"
+    ),
+    SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: _(
+        "Waiting list seat reserved - Recurring: %(event_name)s"
+    ),
+    SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT: _(
+        "Registration confirmation - Recurring: %(event_name)s"
+    ),
+}
+
+
+recurring_event_signup_email_texts = {
+    SignUpNotificationType.EVENT_CANCELLATION: {
+        "heading": _(
+            "Recurring event %(event_name)s %(event_period)s has been cancelled"
+        ),
+        "text": EVENT_CANCELLED_TEXT,
+    },
+    SignUpNotificationType.CANCELLATION: {
+        "heading": REGISTRATION_CANCELLED_HEADING,
+        "secondary_heading": {
+            Event.TypeId.GENERAL: _(
+                "%(username)s, registration to the recurring event %(event_name)s "
+                "%(event_period)s has been cancelled."
+            ),
+            Event.TypeId.COURSE: _(
+                "%(username)s, registration to the recurring course %(event_name)s "
+                "%(event_period)s has been cancelled."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "%(username)s, registration to the recurring volunteering %(event_name)s "
+                "%(event_period)s has been cancelled."
+            ),
+        },
+        "secondary_heading_without_username": {
+            Event.TypeId.GENERAL: _(
+                "Registration to the recurring event %(event_name)s %(event_period)s "
+                "has been cancelled."
+            ),
+            Event.TypeId.COURSE: _(
+                "Registration to the recurring course %(event_name)s %(event_period)s "
+                "has been cancelled."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Registration to the recurring volunteering %(event_name)s %(event_period)s "
+                "has been cancelled."
+            ),
+        },
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "You have successfully cancelled your registration to the recurring event "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.COURSE: _(
+                "You have successfully cancelled your registration to the recurring course "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "You have successfully cancelled your registration to the recurring volunteering "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+        },
+    },
+    SignUpNotificationType.CONFIRMATION: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "secondary_heading": {
+            Event.TypeId.GENERAL: _(
+                "Registration to the recurring event %(event_name)s %(event_period)s "
+                "has been saved."
+            ),
+            Event.TypeId.COURSE: _(
+                "Registration to the recurring course %(event_name)s %(event_period)s "
+                "has been saved."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Registration to the recurring volunteering %(event_name)s %(event_period)s "
+                "has been saved."
+            ),
+        },
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "Congratulations! Your registration has been confirmed for the recurring event "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.COURSE: _(
+                "Congratulations! Your registration has been confirmed for the recurring course "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Congratulations! Your registration has been confirmed for the recurring "
+                "volunteering <strong>%(event_name)s %(event_period)s</strong>."
+            ),
+        },
+        "group": {
+            "heading": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+            "secondary_heading": {
+                Event.TypeId.GENERAL: _(
+                    "Group registration to the recurring event %(event_name)s %(event_period)s "
+                    "has been saved."
+                ),
+                Event.TypeId.COURSE: _(
+                    "Group registration to the recurring course %(event_name)s %(event_period)s "
+                    "has been saved."
+                ),
+                Event.TypeId.VOLUNTEERING: _(
+                    "Group registration to the recurring volunteering %(event_name)s "
+                    "%(event_period)s has been saved."
+                ),
+            },
+        },
+    },
+    SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: {
+        "heading": CONFIRMATION_TO_WAITING_LIST_HEADING,
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "You have successfully registered for the recurring event "
+                "<strong>%(event_name)s %(event_period)s</strong> waiting list."
+            ),
+            Event.TypeId.COURSE: _(
+                "You have successfully registered for the recurring course "
+                "<strong>%(event_name)s %(event_period)s</strong> waiting list."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "You have successfully registered for the recurring volunteering "
+                "<strong>%(event_name)s %(event_period)s</strong> waiting list."
+            ),
+        },
+        "secondary_text": signup_email_texts[
+            SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST
+        ]["secondary_text"],
+        "group": {
+            "text": {
+                Event.TypeId.GENERAL: _(
+                    "The registration for the recurring event "
+                    "<strong>%(event_name)s %(event_period)s</strong> waiting list was successful."
+                ),
+                Event.TypeId.COURSE: _(
+                    "The registration for the recurring course "
+                    "<strong>%(event_name)s %(event_period)s</strong> waiting list was successful."
+                ),
+                Event.TypeId.VOLUNTEERING: _(
+                    "The registration for the recurring volunteering "
+                    "<strong>%(event_name)s %(event_period)s</strong> waiting list was successful."
+                ),
+            },
+            "secondary_text": signup_email_texts[
+                SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST
+            ]["group"]["secondary_text"],
+        },
+    },
+    SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "You have been moved from the waiting list of the recurring event "
+                "<strong>%(event_name)s %(event_period)s</strong> to a participant."
+            ),
+            Event.TypeId.COURSE: _(
+                "You have been moved from the waiting list of the recurring course "
+                "<strong>%(event_name)s %(event_period)s</strong> to a participant."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "You have been moved from the waiting list of the recurring volunteering "
+                "<strong>%(event_name)s %(event_period)s</strong> to a participant."
             ),
         },
     },
@@ -232,27 +423,52 @@ registration_user_access_invitation_texts = {
 }
 
 
-def _get_notification_texts(
-    notification_type, text_options, event_type_id, event_name, username
+def _get_event_text_kwargs(event_name, event_period=None):
+    kwargs = {"event_name": event_name}
+
+    if event_period is not None:
+        kwargs["event_period"] = event_period
+
+    return kwargs
+
+
+def _get_event_cancellation_texts(
+    text_options, event_name, event_period, is_sub_event_cancellation=False
 ):
-    if notification_type == SignUpNotificationType.EVENT_CANCELLATION:
-        return {
-            "heading": text_options["heading"] % {"event_name": event_name},
-            "text": text_options["text"],
+    event_text_kwargs = _get_event_text_kwargs(event_name, event_period=event_period)
+
+    if is_sub_event_cancellation:
+        texts = {
+            "heading": text_options["sub_event_cancellation"]["heading"]
+            % event_text_kwargs,
         }
+    else:
+        texts = {
+            "heading": text_options["heading"] % event_text_kwargs,
+        }
+
+    texts["text"] = text_options["text"]
+
+    return texts
+
+
+def _get_notification_texts(
+    text_options, event_type_id, event_name, event_period, username
+):
+    event_text_kwargs = _get_event_text_kwargs(event_name, event_period=event_period)
 
     if username:
         texts = {
             "heading": text_options["heading"] % {"username": username},
-            "text": text_options["text"][event_type_id] % {"event_name": event_name},
         }
     else:
         texts = {
             "heading": text_options.get(
                 "heading_without_username", text_options["heading"]
             ),
-            "text": text_options["text"][event_type_id] % {"event_name": event_name},
         }
+
+    texts["text"] = text_options["text"][event_type_id] % event_text_kwargs
 
     return texts
 
@@ -263,77 +479,120 @@ def _format_confirmation_message_texts(texts, confirmation_message):
 
 
 def _format_cancellation_texts(
-    texts, text_options, event_type_id, event_name, username
+    texts, text_options, event_type_id, event_name, event_period, username
 ):
+    event_text_kwargs = _get_event_text_kwargs(event_name, event_period=event_period)
+
     if username:
         texts["secondary_heading"] = text_options["secondary_heading"][
             event_type_id
         ] % {
-            "event_name": event_name,
+            **event_text_kwargs,
             "username": username,
         }
     else:
-        texts["secondary_heading"] = text_options["secondary_heading_without_username"][
-            event_type_id
-        ] % {"event_name": event_name}
+        texts["secondary_heading"] = (
+            text_options["secondary_heading_without_username"][event_type_id]
+            % event_text_kwargs
+        )
 
 
 def _format_confirmation_texts(
-    texts, text_options, event_type_id, event_name, contact_person
+    texts, text_options, event_type_id, event_name, event_period, contact_person
 ):
+    event_text_kwargs = _get_event_text_kwargs(event_name, event_period=event_period)
+
     if contact_person.signup_group_id:
         # Override default confirmation message heading
         texts["heading"] = text_options["group"]["heading"]
-        texts["secondary_heading"] = text_options["group"]["secondary_heading"][
-            event_type_id
-        ] % {"event_name": event_name}
+        texts["secondary_heading"] = (
+            text_options["group"]["secondary_heading"][event_type_id]
+            % event_text_kwargs
+        )
     else:
-        texts["secondary_heading"] = text_options["secondary_heading"][
-            event_type_id
-        ] % {"event_name": event_name}
+        texts["secondary_heading"] = (
+            text_options["secondary_heading"][event_type_id] % event_text_kwargs
+        )
 
 
 def _format_confirmation_to_waiting_list_texts(
-    texts, text_options, event_type_id, event_name, contact_person
+    texts, text_options, event_type_id, event_name, event_period, contact_person
 ):
     if contact_person.signup_group_id:
         # Override default confirmation message heading
-        texts["text"] = text_options["group"]["text"][event_type_id] % {
-            "event_name": event_name
-        }
+        event_text_kwargs = _get_event_text_kwargs(
+            event_name, event_period=event_period
+        )
+        texts["text"] = text_options["group"]["text"][event_type_id] % event_text_kwargs
         texts["secondary_text"] = text_options["group"]["secondary_text"][event_type_id]
     else:
         texts["secondary_text"] = text_options["secondary_text"][event_type_id]
 
 
 def get_signup_notification_texts(
-    contact_person, notification_type: SignUpNotificationType
+    contact_person,
+    notification_type: SignUpNotificationType,
+    is_sub_event_cancellation=False,
 ):
     registration = contact_person.registration
+    service_lang = contact_person.get_service_language_pk()
 
-    with translation.override(contact_person.get_service_language_pk()):
+    with translation.override(service_lang):
         confirmation_message = registration.confirmation_message
         event_name = registration.event.name
 
     event_type_id = registration.event.type_id
     username = contact_person.first_name
-    text_options = signup_email_texts[notification_type]
-    texts = _get_notification_texts(
-        notification_type, text_options, event_type_id, event_name, username
-    )
+
+    if (
+        not is_sub_event_cancellation
+        and registration.event.super_event_type == Event.SuperEventType.RECURRING
+    ):
+        # Signup or cancellation for a recurring super event.
+        text_options = recurring_event_signup_email_texts[notification_type]
+        event_period = registration.event.get_start_and_end_time_display(
+            lang=service_lang, date_only=True
+        )
+    else:
+        # Signup or cancellation for a normal event (or for a sub-event of a super event).
+        text_options = signup_email_texts[notification_type]
+        event_period = None
+
+    if notification_type == SignUpNotificationType.EVENT_CANCELLATION:
+        sub_event_period = (
+            registration.event.get_start_and_end_time_display(
+                lang=service_lang, date_only=True
+            )
+            if is_sub_event_cancellation
+            else event_period
+        )
+        texts = _get_event_cancellation_texts(
+            text_options,
+            event_name,
+            sub_event_period,
+            is_sub_event_cancellation=is_sub_event_cancellation,
+        )
+    else:
+        texts = _get_notification_texts(
+            text_options,
+            event_type_id,
+            event_name,
+            event_period,
+            username,
+        )
 
     if notification_type == SignUpNotificationType.CANCELLATION:
         _format_cancellation_texts(
-            texts, text_options, event_type_id, event_name, username
+            texts, text_options, event_type_id, event_name, event_period, username
         )
     elif notification_type == SignUpNotificationType.CONFIRMATION:
         _format_confirmation_texts(
-            texts, text_options, event_type_id, event_name, contact_person
+            texts, text_options, event_type_id, event_name, event_period, contact_person
         )
         _format_confirmation_message_texts(texts, confirmation_message)
     elif notification_type == SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST:
         _format_confirmation_to_waiting_list_texts(
-            texts, text_options, event_type_id, event_name, contact_person
+            texts, text_options, event_type_id, event_name, event_period, contact_person
         )
     elif notification_type == SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT:
         _format_confirmation_message_texts(texts, confirmation_message)
@@ -341,17 +600,35 @@ def get_signup_notification_texts(
     return texts
 
 
-def get_signup_notification_subject(contact_person, notification_type):
+def get_signup_notification_subject(
+    contact_person, notification_type, is_sub_event_cancellation=False
+):
     registration = contact_person.registration
     linked_registrations_ui_locale = get_ui_locales(contact_person.service_language)[1]
 
     with translation.override(contact_person.get_service_language_pk()):
-        event_name = registration.event.name
+        subject_format_kwargs = {"event_name": registration.event.name}
 
     with translation.override(linked_registrations_ui_locale):
-        notification_subject = signup_notification_subjects[notification_type] % {
-            "event_name": event_name
-        }
+        if (
+            not is_sub_event_cancellation
+            and registration.event.super_event_type == Event.SuperEventType.RECURRING
+        ):
+            # Signup or cancellation for a recurring super event.
+            subject_format_kwargs[
+                "event_period"
+            ] = registration.event.get_start_and_end_time_display(
+                lang=linked_registrations_ui_locale, date_only=True
+            )
+            notification_subject = (
+                recurring_event_signup_notification_subjects[notification_type]
+                % subject_format_kwargs
+            )
+        else:
+            # Signup or cancellation for a normal event (or for a sub-event of a super event).
+            notification_subject = (
+                signup_notification_subjects[notification_type] % subject_format_kwargs
+            )
 
     return notification_subject
 


### PR DESCRIPTION
### Description
Adds email notifications for signups that have been made for recurring super events. Also adds an event cancellation notification for the case where a sub event of a recurring super event is cancelled (the registration will have been done to the super event, but not to the sub event in this case). 
### Closes
[LINK-1811](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1811)

[LINK-1811]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ