### PR TITLE
fix: don't use create_payment in create_signups

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1038,6 +1038,7 @@ class CreateSignUpsSerializer(serializers.Serializer):
             date_of_birth = cleaned_signup_data.pop("date_of_birth", None)
             contact_person = cleaned_signup_data.pop("contact_person", None)
             price_group = cleaned_signup_data.pop("price_group", None)
+            cleaned_signup_data.pop("create_payment", False)
 
             signup = SignUp(**cleaned_signup_data)
 

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -287,6 +287,34 @@ def test_authenticated_user_can_create_signup_group_with_payment(
 
 
 @pytest.mark.django_db
+def test_can_create_signup_group_with_create_payment_as_false_in_payload(
+    registration, api_client
+):
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    LanguageFactory(pk="fi", service_language=True)
+    LanguageFactory(pk="en", service_language=True)
+
+    reservation = SeatReservationCodeFactory(seats=2, registration=registration)
+
+    signup_group_data = deepcopy(default_signup_group_data)
+    signup_group_data.update(
+        {
+            "registration": registration.pk,
+            "reservation_code": reservation.code,
+            "create_payment": False,
+        }
+    )
+
+    assert SignUpPayment.objects.count() == 0
+
+    assert_create_signup_group(api_client, signup_group_data)
+
+    assert SignUpPayment.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_create_signup_group_payment_without_pricetotal_in_response(
     registration, api_client
 ):

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -248,6 +248,36 @@ def test_authenticated_user_can_create_signups_with_payments(
 
 
 @pytest.mark.django_db
+def test_can_create_signup_with_create_payment_as_false_in_payload(
+    registration, api_client
+):
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    LanguageFactory(pk="fi", service_language=True)
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+
+    signups_data = deepcopy(default_signups_data)
+    signups_data.update(
+        {
+            "registration": registration.pk,
+            "reservation_code": reservation.code,
+        }
+    )
+    signups_data["signups"][0].update(
+        {
+            "create_payment": False,
+        }
+    )
+
+    assert SignUpPayment.objects.count() == 0
+
+    assert_create_signups(api_client, signups_data)
+
+    assert SignUpPayment.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_create_signup_payment_without_pricetotal_in_response(registration, api_client):
     LanguageFactory(pk="fi", service_language=True)
     reservation = SeatReservationCodeFactory(seats=1, registration=registration)


### PR DESCRIPTION
### Description
The `create_payment` kwarg will no longer be used in `SignUp` init in the `CreateSignUpSerializer.create_signups` method. Giving the kwarg resulted in a 500 internal error, and it is not needed at all in the said method as payment creation is handled by `SignUpSerializer.create` instead.
### Closes
[LINK-1896](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1896)

[LINK-1896]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ