### PR TITLE
feat: event ordering and filtering by enrolment start and end time

### DIFF
--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from datetime import datetime, timedelta
-from typing import Optional
 
 import pytest
 import pytz
@@ -10,6 +9,7 @@ from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import Point
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.test.utils import CaptureQueriesContext
+from django.utils.timezone import localtime
 from freezegun import freeze_time
 from rest_framework import status
 
@@ -19,6 +19,7 @@ from events.tests.conftest import APIClient
 from events.tests.factories import EventFactory
 from events.tests.utils import assert_fields_exist, datetime_zone_aware, get
 from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.factories import RegistrationFactory
 
 api_client = APIClient()
 
@@ -1370,6 +1371,224 @@ def test_sort_events_by_minimum_attendee_capacity(api_client, event, event2, eve
     assert results[0]["id"] == event3.id
     assert results[1]["id"] == event2.id
     assert results[2]["id"] == event.id
+
+
+@pytest.mark.parametrize(
+    "db_field_name,ordering",
+    [
+        ("enrolment_start_time", "enrolment_start"),
+        ("enrolment_start_time", "-enrolment_start"),
+        ("enrolment_end_time", "enrolment_end"),
+        ("enrolment_end_time", "-enrolment_end"),
+    ],
+)
+@pytest.mark.django_db
+def test_sort_events_by_enrolment_start_or_enrolment_end(
+    api_client, db_field_name, ordering
+):
+    event = EventFactory(
+        **{db_field_name: localtime().replace(year=2024, month=1, day=1, hour=10)}
+    )
+
+    event2 = EventFactory(
+        **{db_field_name: localtime().replace(year=2024, month=1, day=1, hour=12)}
+    )
+
+    event3 = EventFactory(
+        **{db_field_name: localtime().replace(year=2024, month=2, day=1, hour=12)}
+    )
+
+    event4 = EventFactory(
+        **{db_field_name: localtime().replace(year=2024, month=2, day=2, hour=12)}
+    )
+    RegistrationFactory(
+        event=event4,
+        **{db_field_name: localtime().replace(year=2024, month=1, day=1, hour=11)},
+    )
+
+    event5 = EventFactory()
+
+    event6 = EventFactory()
+    RegistrationFactory(event=event6)
+
+    event7 = EventFactory()
+    RegistrationFactory(
+        event=event7,
+        **{db_field_name: localtime().replace(year=2024, month=2, day=1, hour=11)},
+    )
+
+    response = get_list(api_client=api_client, query_string=f"sort={ordering}")
+
+    results = response.data["data"]
+    assert len(results) == 7
+
+    if ordering.startswith("-"):
+        # Desc.
+        assert results[0]["id"] == event3.id  # 1 Feb 2024 at 12.00
+        assert (
+            results[1]["id"] == event7.id
+        )  # 1 Feb 2024 at 11.00 (registration's time)
+        assert results[2]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert (
+            results[3]["id"] == event4.id
+        )  # 1 Jan 2024 at 11.00 (registration's time)
+        assert results[4]["id"] == event.id  # 1 Jan 2024 at 10.00
+    else:
+        # Asc.
+        assert results[0]["id"] == event.id  # 1 Jan 2024 at 10.00
+        assert (
+            results[1]["id"] == event4.id
+        )  # 1 Jan 2024 at 11.00 (registration's time)
+        assert results[2]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert (
+            results[3]["id"] == event7.id
+        )  # 1 Feb 2024 at 11.00 (registration's time)
+        assert results[4]["id"] == event3.id  # 1 Feb 2024 at 12.00
+
+    # Events with null enrolment times will be last. Order might vary.
+    assert Counter([results[5]["id"], results[6]["id"]]) == Counter(
+        [event5.id, event6.id]
+    )
+
+
+@pytest.mark.parametrize(
+    "ordering",
+    [
+        "enrolment_start_time",
+        "-enrolment_start_time",
+        "enrolment_end_time",
+        "-enrolment_end_time",
+    ],
+)
+@pytest.mark.django_db
+def test_sort_events_by_enrolment_start_time_or_enrolment_end_time(
+    api_client, ordering
+):
+    db_field_name = ordering.removeprefix("-")
+    now = localtime()
+
+    event = EventFactory(
+        **{db_field_name: now.replace(year=2024, month=1, day=1, hour=10)}
+    )
+
+    event2 = EventFactory(
+        **{db_field_name: now.replace(year=2024, month=1, day=1, hour=12)}
+    )
+
+    event3 = EventFactory(
+        **{db_field_name: now.replace(year=2024, month=2, day=1, hour=12)}
+    )
+
+    event4 = EventFactory(
+        **{db_field_name: now.replace(year=2024, month=2, day=2, hour=12)}
+    )
+    RegistrationFactory(
+        event=event4, **{db_field_name: now.replace(year=2024, month=1, day=1, hour=11)}
+    )
+
+    event5 = EventFactory()
+
+    event6 = EventFactory()
+    RegistrationFactory(event=event6)
+
+    event7 = EventFactory()
+    RegistrationFactory(
+        event=event7, **{db_field_name: now.replace(year=2024, month=2, day=1, hour=11)}
+    )
+
+    response = get_list(api_client=api_client, query_string=f"sort={ordering}")
+
+    results = response.data["data"]
+    assert len(results) == 7
+
+    if ordering.startswith("-"):
+        # Desc.
+        assert Counter(
+            [results[0]["id"], results[1]["id"], results[2]["id"]]
+        ) == Counter([event5.id, event6.id, event7.id])
+        assert results[3]["id"] == event4.id  # 2 Feb 2024 at 12.00
+        assert results[4]["id"] == event3.id  # 1 Feb 2024 at 12.00
+        assert results[5]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert results[6]["id"] == event.id  # 1 Jan 2024 at 10.00
+    else:
+        # Asc.
+        assert results[0]["id"] == event.id  # 1 Jan 2024 at 10.00
+        assert results[1]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert results[2]["id"] == event3.id  # 1 Feb 2024 at 12.00
+        assert results[3]["id"] == event4.id  # 2 Feb 2024 at 12.00
+        assert Counter(
+            [results[4]["id"], results[5]["id"], results[6]["id"]]
+        ) == Counter([event5.id, event6.id, event7.id])
+
+
+@pytest.mark.parametrize(
+    "ordering",
+    [
+        "registration__enrolment_start_time",
+        "-registration__enrolment_start_time",
+        "registration__enrolment_end_time",
+        "-registration__enrolment_end_time",
+    ],
+)
+@pytest.mark.django_db
+def test_sort_events_by_registration_enrolment_start_time_or_enrolment_end_time(
+    api_client, ordering
+):
+    db_field_name = ordering.split("__")[1]
+    now = localtime()
+
+    event = EventFactory()
+    RegistrationFactory(
+        event=event, **{db_field_name: now.replace(year=2024, month=1, day=1, hour=10)}
+    )
+
+    event2 = EventFactory()
+    RegistrationFactory(
+        event=event2, **{db_field_name: now.replace(year=2024, month=1, day=1, hour=12)}
+    )
+
+    event3 = EventFactory()
+    RegistrationFactory(
+        event=event3, **{db_field_name: now.replace(year=2024, month=2, day=1, hour=12)}
+    )
+
+    event4 = EventFactory(
+        **{db_field_name: now.replace(year=2024, month=2, day=2, hour=12)}
+    )
+    RegistrationFactory(
+        event=event4, **{db_field_name: now.replace(year=2024, month=2, day=2, hour=12)}
+    )
+
+    event5 = EventFactory()
+
+    event6 = EventFactory()
+    RegistrationFactory(event=event6)
+
+    event7 = EventFactory()
+
+    response = get_list(api_client=api_client, query_string=f"sort={ordering}")
+
+    results = response.data["data"]
+    assert len(results) == 7
+
+    if ordering.startswith("-"):
+        # Desc.
+        assert Counter(
+            [results[0]["id"], results[1]["id"], results[2]["id"]]
+        ) == Counter([event5.id, event6.id, event7.id])
+        assert results[3]["id"] == event4.id  # 2 Feb 2024 at 12.00
+        assert results[4]["id"] == event3.id  # 1 Feb 2024 at 12.00
+        assert results[5]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert results[6]["id"] == event.id  # 1 Jan 2024 at 10.00
+    else:
+        # Asc.
+        assert results[0]["id"] == event.id  # 1 Jan 2024 at 10.00
+        assert results[1]["id"] == event2.id  # 1 Jan 2024 at 12.00
+        assert results[2]["id"] == event3.id  # 1 Feb 2024 at 12.00
+        assert results[3]["id"] == event4.id  # 2 Feb 2024 at 12.00
+        assert Counter(
+            [results[4]["id"], results[5]["id"], results[6]["id"]]
+        ) == Counter([event5.id, event6.id, event7.id])
 
 
 @pytest.mark.django_db

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -361,6 +361,16 @@
         <pre><code>event/?enrolment_open_waitlist=true</code></pre>
         <p><a href="?enrolment_open_waitlist=true" title="json">See the result</a></p>
 
+        <h3 id="enrolment-open-on">Enrolment open on a given date</h3>
+        <p>It is possible to check if a given datetime is within events' enrolment start and end times. In other words,
+            if any events are open on a given date and time. The given datetime is expected to be in the events' timezone.</p>
+        <p><code>enrolment_open_on</code> parameter displays events where the given datetime is within the
+            <code>enrolment_start_time</code> and <code>enrolment_end_time</code> of the events. If an event
+            has a registration, the registration's enrolment start and end times will be preferred over the event's times.</p>
+        <p>For example:</p>
+        <pre><code>event/?enrolment_open_on=2024-02-19T12:00:00</code></pre>
+        <p><a href="?enrolment_open_on=2024-02-19T12:00:00" title="json">See the result</a></p>
+
         <h3 id="attendee-capacity">Attendee capacity</h3>
         <p>Filters for filtering by event maximum_attendee_capacity and minimum_attendee_capacity:</p>
 
@@ -452,11 +462,24 @@
 
         <h2 id="ordering">Ordering</h2>
         <p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order
-            results by <code>start_time</code>, <code>end_time</code>, <code>name</code> and
-            <code>duration</code>. Descending order is denoted by adding <code>-</code> in front of the
-            parameter, default order is ascending.</p>
+            results by <code>start_time</code>, <code>end_time</code>, <code>name</code>,
+            <code>duration</code>, <code>enrolment_start_time</code>, <code>enrolment_end_time</code>,
+            <code>registration__enrolment_start_time</code>, <code>registration__enrolment_end_time</code>,
+            <code>enrolment_start</code> and <code>enrolment_end</code>. Descending order is denoted by
+            adding <code>-</code> in front of the parameter, default order is ascending.</p>
         <p>For example:</p>
         <pre><code>event/?sort=-end_time</code></pre>
         <p><a href="?sort=-end_time" title="json">See the result</a></p>
+
+        <h3 id="enrolment-start-enrolment-end">Enrolment start and enrolment end</h3>
+        <p>The ordering filters <code>enrolment_start</code> and <code>enrolment_end</code> have two
+            notable differences compared to the rest of the ordering filters related to enrolment start
+            and enrolment end times:</p>
+        <p>First, if an event has a registration with an enrolment time defined, the registration's time
+            will be preferred over the event's time.</p>
+        <p>Second, if neither the event's registration nor the event has enrolment times defined
+            (<code>enrolment_start_time</code> and <code>enrolment_end_time</code> are both NULL), the
+            event will be placed at the end of the results list regardless of whether ascending or
+            descending order was used.</p>
     </div>
 </div>


### PR DESCRIPTION
### Description
Adds six new ordering filters / sorting options for the `event` endpoint:

- `enrolment_start_time`: sorts by `event.enrolment_start_time` only.
- `enrolment_end_time`: sort by `event.enrolment_end_time` only.
- `registration__enrolment_start_time`: sorts by `event.registration.enrolment_start_time` only.
- `registration__enrolment_end_time`: sort by `event.registration.enrolment_end_time` only.
- `enrolment_start`: sorts primarily by `event.registration.enrolment_start_time`, but will fall back to using `event.enrolment_start_time` if `registration`or `registration.enrolment_start_time` is NULL. If both the event's and registration's `enrolment_start_time` are NULL, the event will be placed at the end of the sorted list (doesn't matter if ascending or descending direction is used).
- `enrolment_end`: sorts primarily by `event.registration.enrolment_end_time`, but will fall back to using `event.enrolment_end_time` if `registration`or `registration.enrolment_end_time` is NULL. If both the event's and registration's `enrolment_end_time` are NULL, the event will be placed at the end of the sorted list (doesn't matter if ascending or descending direction is used).

Also add the possibility to filter events by checking if a given datetime is within the events' `enrolment_start_time` and `enrolment_end_time`. The same priority is used here as with the ordering filters: the related registrations' fields are checked first before using the events' own fields.

### Closes
[LINK-1868](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1868)
[LINK-1870](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1870)

[LINK-1868]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ