### PR TITLE
LINK-1905 | Automatically Generate and Set Signup Link for An Event

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -34,6 +34,7 @@ from registrations.models import (
 from registrations.permissions import CanAccessRegistrationSignups
 from registrations.utils import (
     code_validity_duration,
+    get_signup_create_url,
     has_allowed_substitute_user_email_domain,
 )
 from web_store.order.clients import WebStoreOrderAPIClient
@@ -839,10 +840,7 @@ class RegistrationBaseSerializer(CreatedModifiedBaseSerializer):
         return obj.publisher.id
 
     def get_signup_url(self, obj):
-        return {
-            lang: f"{settings.LINKED_REGISTRATIONS_UI_URL}/{lang}/registration/{obj.id}/signup-group/create"
-            for lang in ["en", "fi", "sv"]
-        }
+        return {lang: get_signup_create_url(obj, lang) for lang in ["en", "fi", "sv"]}
 
     class Meta(CreatedModifiedBaseSerializer.Meta):
         fields = (

--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from django.db.models import Q
-from django.db.models.signals import post_delete, pre_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 from events.models import Event
@@ -13,6 +13,7 @@ from registrations.models import (
     SignUpGroup,
     SignUpNotificationType,
 )
+from registrations.utils import get_signup_create_url
 
 
 def _signup_or_group_post_delete(instance: Union[SignUp, SignUpGroup]) -> None:
@@ -90,3 +91,26 @@ def calculate_registration_price_group_vat_prices(
     **kwargs: dict,
 ) -> None:
     instance.calculate_vat_and_price_without_vat()
+
+
+@receiver(
+    post_save,
+    sender=Registration,
+    dispatch_uid="create_signup_link_for_event",
+)
+def create_signup_link_for_event(
+    sender: type[Registration], instance: Registration, **kwargs: dict
+) -> None:
+    if not kwargs.get("created"):
+        # Only create the signup link if a new registration has been created.
+        return
+
+    instance.event.offers.filter(
+        (Q(info_url_fi=None) | Q(info_url_fi=""))
+        & (Q(info_url_sv=None) | Q(info_url_sv=""))
+        & (Q(info_url_en=None) | Q(info_url_en=""))
+    ).update(
+        info_url_fi=get_signup_create_url(instance, "fi"),
+        info_url_sv=get_signup_create_url(instance, "sv"),
+        info_url_en=get_signup_create_url(instance, "en"),
+    )

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -25,12 +25,19 @@ def get_ui_locales(language):
     return [linked_events_ui_locale, linked_registrations_ui_locale]
 
 
+def get_signup_create_url(registration, language):
+    return (
+        f"{settings.LINKED_REGISTRATIONS_UI_URL}/{language}/"
+        f"registration/{registration.id}/signup-group/create"
+    )
+
+
 def get_signup_edit_url(
     contact_person, linked_registrations_ui_locale, access_code=None
 ):
     signup_edit_url = (
-        f"{settings.LINKED_REGISTRATIONS_UI_URL}/{linked_registrations_ui_locale}"
-        f"/registration/{contact_person.registration.id}/"
+        f"{settings.LINKED_REGISTRATIONS_UI_URL}/{linked_registrations_ui_locale}/"
+        f"registration/{contact_person.registration.id}/"
     )
 
     if contact_person.signup_group_id:


### PR DESCRIPTION
### Description
Currently users need to manually copy the signup link to the event's offer once they've created a registration for the event. This PR solves the issue by automatically creating and setting the link.

### Closes
[LINK-1905](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1905)

[LINK-1905]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ