### PR TITLE
LINK-1881 | Send Payment Link to Contact Person, Allow Waitlisted Signups for Paid Events

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-29 08:50+0000\n"
+"POT-Creation-Date: 2024-03-07 11:50+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -224,7 +224,7 @@ msgid "Licenses"
 msgstr "Lisenssit"
 
 #: events/models.py:241 events/models.py:481 events/models.py:669
-#: events/models.py:987 registrations/models.py:210
+#: events/models.py:987 registrations/models.py:223
 msgid "Publisher"
 msgstr "Julkaisija"
 
@@ -311,8 +311,8 @@ msgstr "Paikan kotisivu"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: events/models.py:682 events/models.py:1485 registrations/models.py:737
-#: registrations/models.py:1023
+#: events/models.py:682 events/models.py:1485 registrations/models.py:812
+#: registrations/models.py:1118
 msgid "E-mail"
 msgstr "Sähköposti"
 
@@ -324,7 +324,7 @@ msgstr "Puhelinnumero"
 msgid "Contact type"
 msgstr "Yhteydtiedon tyyppi"
 
-#: events/models.py:690 registrations/models.py:58 registrations/models.py:847
+#: events/models.py:690 registrations/models.py:59 registrations/models.py:932
 msgid "Street address"
 msgstr "Katuosoite"
 
@@ -419,7 +419,7 @@ msgstr "Käyttäjän organisaatio"
 msgid "Event organizer information."
 msgstr "Tapahtuman järjestäjän tiedot."
 
-#: events/models.py:947 registrations/models.py:869
+#: events/models.py:947 registrations/models.py:954
 msgid "User consent"
 msgstr "Käyttäjän suostumus"
 
@@ -487,11 +487,11 @@ msgstr "Alkuaika"
 msgid "End time"
 msgstr "Loppuaika"
 
-#: events/models.py:1038 registrations/models.py:275
+#: events/models.py:1038 registrations/models.py:288
 msgid "Minimum recommended age"
 msgstr "Suositeltu vähimmäisikä"
 
-#: events/models.py:1041 registrations/models.py:278
+#: events/models.py:1041 registrations/models.py:291
 msgid "Maximum recommended age"
 msgstr "Suurin suositeltu ikä"
 
@@ -725,19 +725,19 @@ msgstr "Maksun tilaa ei voitu tarkistaa Talpa-rajapinnasta."
 msgid "Could not check order status from Talpa API."
 msgstr "Tilauksen tilaa ei voitu tarkistaa Talpa-rajapinnasta."
 
-#: registrations/api.py:607
+#: registrations/api.py:616
 msgid "Order marked as cancelled in webhook payload, but not in Talpa API."
 msgstr ""
 "Tilaus on merkitty perutuksi webhook-notifikaatiossa, mutta ei Talpa-"
 "rajapinnassa."
 
-#: registrations/api.py:638
+#: registrations/api.py:647
 msgid "Payment marked as paid in webhook payload, but not in Talpa API."
 msgstr ""
 "Maksu on merkitty maksetuksi webhook-notifikaatiossa, mutta ei Talpa-"
 "rajapinnassa."
 
-#: registrations/api.py:658
+#: registrations/api.py:667
 msgid "Payment marked as cancelled in webhook payload, but not in Talpa API."
 msgstr ""
 "Maksu on merkitty perutuksi webhook-notifikaatiossa, mutta ei Talpa-"
@@ -751,12 +751,12 @@ msgstr "Pyyntö on ristiriidassa kohderesurssin nykyisen tilan kanssa"
 msgid "Registered persons"
 msgstr "Ilmoittautuneet"
 
-#: registrations/exports.py:49 registrations/models.py:974
+#: registrations/exports.py:49 registrations/models.py:1069
 msgid "Date of birth"
 msgstr "Syntymäaika"
 
-#: registrations/exports.py:53 registrations/models.py:57
-#: registrations/models.py:826 registrations/models.py:1027
+#: registrations/exports.py:53 registrations/models.py:58
+#: registrations/models.py:911 registrations/models.py:1122
 msgid "Phone number"
 msgstr "Puhelinnumero"
 
@@ -792,21 +792,21 @@ msgstr ""
 msgid "Invalid registration ID(s) given."
 msgstr ""
 
-#: registrations/models.py:54 registrations/models.py:833
+#: registrations/models.py:55 registrations/models.py:918
 msgid "City"
 msgstr "Kaupunki"
 
-#: registrations/models.py:55 registrations/models.py:812
-#: registrations/models.py:1008
+#: registrations/models.py:56 registrations/models.py:897
+#: registrations/models.py:1103
 msgid "First name"
 msgstr "Etunimi"
 
-#: registrations/models.py:56 registrations/models.py:819
-#: registrations/models.py:1015
+#: registrations/models.py:57 registrations/models.py:904
+#: registrations/models.py:1110
 msgid "Last name"
 msgstr "Sukunimi"
 
-#: registrations/models.py:59 registrations/models.py:854
+#: registrations/models.py:60 registrations/models.py:939
 msgid "ZIP code"
 msgstr "Postinumero"
 
@@ -818,174 +818,182 @@ msgstr ""
 msgid "You can only provide signup_group or signup, not both."
 msgstr ""
 
-#: registrations/models.py:131
+#: registrations/models.py:144
 msgid "Created at"
 msgstr "Luotu klo"
 
-#: registrations/models.py:137
+#: registrations/models.py:150
 msgid "Modified at"
 msgstr "Muokattu klo"
 
-#: registrations/models.py:240
+#: registrations/models.py:253
 msgid "You may not delete a default price group."
 msgstr ""
 
-#: registrations/models.py:248
+#: registrations/models.py:261
 msgid "You may not edit a default price group."
 msgstr ""
 
-#: registrations/models.py:254
+#: registrations/models.py:267
 msgid ""
 "You may not change the publisher of a price group that has been used in "
 "registrations."
 msgstr ""
 "Ilmoittautumisissa käytetyn asiakasryhmän julkaisija-kenttää ei voi vaihtaa."
 
-#: registrations/models.py:282
+#: registrations/models.py:295
 msgid "Enrollment start time"
 msgstr "Ilmoittautumisen alkamisaika"
 
-#: registrations/models.py:285
+#: registrations/models.py:298
 msgid "Enrollment end time"
 msgstr "Ilmoittautumisen päättymisaika"
 
-#: registrations/models.py:289
+#: registrations/models.py:302
 msgid "Confirmation message"
 msgstr "Vahvistusviesti"
 
-#: registrations/models.py:292
+#: registrations/models.py:305
 msgid "Instructions"
 msgstr "Ohjeet"
 
-#: registrations/models.py:296
+#: registrations/models.py:309
 msgid "Maximum attendee capacity"
 msgstr "Paikkojen enimmäismäärä"
 
-#: registrations/models.py:299
+#: registrations/models.py:312
 msgid "Minimum attendee capacity"
 msgstr "Paikkojen vähimmäismäärä"
 
-#: registrations/models.py:302
+#: registrations/models.py:315
 msgid "Waiting list capacity"
 msgstr "Jonopaikkojen lukumäärä"
 
-#: registrations/models.py:305
+#: registrations/models.py:318
 msgid "Maximum group size"
 msgstr "Ryhmän enimmäiskoko"
 
-#: registrations/models.py:319
+#: registrations/models.py:332
 msgid "Mandatory fields"
 msgstr "Pakolliset kentät"
 
-#: registrations/models.py:592 registrations/models.py:874
+#: registrations/models.py:664 registrations/models.py:959
 msgid "Anonymization time"
 msgstr ""
 
-#: registrations/models.py:676
+#: registrations/models.py:758
 msgid "Group registration to event"
 msgstr "Ryhmäilmoittautuminen tapahtumaan"
 
-#: registrations/models.py:677
+#: registrations/models.py:759
 msgid "Group registration to course"
 msgstr "Ryhmäilmoittautuminen kurssille"
 
-#: registrations/models.py:678
+#: registrations/models.py:760
 msgid "Group registration to volunteering"
 msgstr "Ryhmäilmoittautuminen vapaaehtoistehtävään"
 
-#: registrations/models.py:702
+#: registrations/models.py:773
+msgid "No price groups exist for signup group."
+msgstr ""
+
+#: registrations/models.py:787
 msgid "Extra info"
 msgstr "Lisätiedot"
 
-#: registrations/models.py:786
+#: registrations/models.py:871
 msgid "Waitlisted"
 msgstr "Jonossa"
 
-#: registrations/models.py:787
+#: registrations/models.py:872
 msgid "Attending"
 msgstr "Osallistuu"
 
-#: registrations/models.py:795
+#: registrations/models.py:880
 msgid "Not present"
 msgstr "Ei paikalla"
 
-#: registrations/models.py:796
+#: registrations/models.py:881
 msgid "Present"
 msgstr "Paikalla"
 
-#: registrations/models.py:840
+#: registrations/models.py:925
 msgid "Attendee status"
 msgstr "Osallistujan tila"
 
-#: registrations/models.py:862
+#: registrations/models.py:947
 msgid "Presence status"
 msgstr "Läsnäolotila"
 
-#: registrations/models.py:959
+#: registrations/models.py:1052
 msgid "Registration to event"
 msgstr "Ilmoittautuminen tapahtumaan"
 
-#: registrations/models.py:960
+#: registrations/models.py:1053
 msgid "Registration to course"
 msgstr "Ilmoittautuminen kurssille"
 
-#: registrations/models.py:961
+#: registrations/models.py:1054
 msgid "Registration to volunteering"
 msgstr "Ilmoittautuminen vapaaehtoistehtävään"
 
-#: registrations/models.py:1050
+#: registrations/models.py:1062
+msgid "Price group does not exist for signup."
+msgstr ""
+
+#: registrations/models.py:1145
 msgid "Membership number"
 msgstr "Jäsennumero"
 
-#: registrations/models.py:1058
+#: registrations/models.py:1153
 msgid "Notification type"
 msgstr "Ilmoitusten tyyppi"
 
-#: registrations/models.py:1065
+#: registrations/models.py:1160
 msgid "Access code"
 msgstr ""
 
-#: registrations/models.py:1246
+#: registrations/models.py:1353
 msgid "Number of seats"
 msgstr "Paikkojen lukumäärä"
 
-#: registrations/models.py:1252
+#: registrations/models.py:1359
 msgid "Seat reservation code"
 msgstr "Paikkavarauskoodi"
 
-#: registrations/models.py:1255
+#: registrations/models.py:1362
 msgid "Timestamp"
 msgstr "Aikaleima"
 
-#: registrations/models.py:1295
+#: registrations/models.py:1402
 msgid "pcs"
 msgstr "kpl"
 
-#: registrations/models.py:1319
+#: registrations/models.py:1426
 msgid "Created"
 msgstr "Luotu"
 
-#: registrations/models.py:1320
+#: registrations/models.py:1427
 msgid "Paid"
 msgstr "Maksettu"
 
-#: registrations/models.py:1321
+#: registrations/models.py:1428
 msgid "Cancelled"
 msgstr "Peruttu"
 
-#: registrations/models.py:1322
+#: registrations/models.py:1429
 msgid "Refunded"
 msgstr "Hyvitety"
 
-#: registrations/models.py:1323
+#: registrations/models.py:1430
 msgid "Expired"
 msgstr "Vanhentunut"
 
-#: registrations/models.py:1347
+#: registrations/models.py:1454
 msgid "Payment status"
 msgstr "Maksun tila"
 
-#: registrations/models.py:1361
+#: registrations/models.py:1468
 msgid "Expires at"
 msgstr "Vanhenee"
 
@@ -1038,54 +1046,54 @@ msgstr "Sähköposti"
 msgid "Both SMS and email."
 msgstr "Tekstiviesti ja sähköposti"
 
-#: registrations/notifications.py:42
+#: registrations/notifications.py:50
 #, python-format
 msgid "Event cancelled - %(event_name)s"
 msgstr "Tapahtuma peruttu - %(event_name)s"
 
-#: registrations/notifications.py:43
+#: registrations/notifications.py:51
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Ilmoittautuminen peruttu - %(event_name)s"
 
-#: registrations/notifications.py:45 registrations/notifications.py:51
+#: registrations/notifications.py:53 registrations/notifications.py:60
 #, python-format
 msgid "Registration confirmation - %(event_name)s"
 msgstr "Vahvistus ilmoittautumisesta - %(event_name)s"
 
-#: registrations/notifications.py:48
+#: registrations/notifications.py:57
 #, python-format
 msgid "Waiting list seat reserved - %(event_name)s"
 msgstr "Paikka jonotuslistalla varattu - %(event_name)s"
 
-#: registrations/notifications.py:54
+#: registrations/notifications.py:64
 #, python-format
 msgid "Registration payment expired - %(event_name)s"
 msgstr "Ilmoittautumismaksu vanhentunut - %(event_name)s"
 
-#: registrations/notifications.py:61
+#: registrations/notifications.py:71
 #, python-format
 msgid "Event %(event_name)s has been cancelled"
 msgstr "Tapahtuma %(event_name)s on peruttu."
 
-#: registrations/notifications.py:64
+#: registrations/notifications.py:74
 #, python-format
 msgid "Event %(event_name)s %(event_period)s has been cancelled"
 msgstr "Tapahtuma %(event_name)s %(event_period)s on peruttu."
 
-#: registrations/notifications.py:71
+#: registrations/notifications.py:81
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen tapahtumaan %(event_name)s on peruttu."
 
-#: registrations/notifications.py:74
+#: registrations/notifications.py:84
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, ilmoittautuminen kurssille %(event_name)s on peruttu."
 
-#: registrations/notifications.py:77
+#: registrations/notifications.py:87
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -1094,22 +1102,22 @@ msgstr ""
 "%(username)s, ilmoittautuminen vapaaehtoistehtävään %(event_name)s on "
 "peruttu."
 
-#: registrations/notifications.py:82
+#: registrations/notifications.py:92
 #, python-format
 msgid "Registration to the event %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen tapahtumaan %(event_name)s on peruttu."
 
-#: registrations/notifications.py:85
+#: registrations/notifications.py:95
 #, python-format
 msgid "Registration to the course %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen kurssille %(event_name)s on peruttu."
 
-#: registrations/notifications.py:88
+#: registrations/notifications.py:98
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been cancelled."
 msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on peruttu."
 
-#: registrations/notifications.py:93
+#: registrations/notifications.py:103
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -1118,7 +1126,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:106
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -1127,7 +1135,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:109
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -1136,7 +1144,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:105
+#: registrations/notifications.py:115
 #, python-format
 msgid ""
 "Your registration and payment for the event <strong>%(event_name)s</strong> "
@@ -1145,7 +1153,7 @@ msgstr ""
 "Ilmoittautumisesi ja maksusi tapahtumaan <strong>%(event_name)s</strong> on "
 "peruttu."
 
-#: registrations/notifications.py:108
+#: registrations/notifications.py:118
 #, python-format
 msgid ""
 "Your registration and payment for the course <strong>%(event_name)s</strong> "
@@ -1154,7 +1162,7 @@ msgstr ""
 "Ilmoittautumisesi ja maksusi kurssille <strong>%(event_name)s</strong> on "
 "peruttu."
 
-#: registrations/notifications.py:111
+#: registrations/notifications.py:121
 #, python-format
 msgid ""
 "Your registration to the volunteering <strong>%(event_name)s</strong> has "
@@ -1163,22 +1171,22 @@ msgstr ""
 "Ilmoittautumisesi vapaaehtoistehtävään <strong>%(event_name)s</strong> on "
 "peruttu."
 
-#: registrations/notifications.py:121
+#: registrations/notifications.py:131
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Ilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:124
+#: registrations/notifications.py:134
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Ilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:127
+#: registrations/notifications.py:137
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:132
+#: registrations/notifications.py:142
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -1187,7 +1195,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu tapahtumaan "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:135
+#: registrations/notifications.py:145
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -1196,7 +1204,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu kurssille "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:138
+#: registrations/notifications.py:148
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -1205,30 +1213,30 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu vapaaehtoistehtävään "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:145
+#: registrations/notifications.py:155
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen tapahtumaan %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:148
+#: registrations/notifications.py:158
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Ryhmäilmoittautuminen kurssille %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:151
+#: registrations/notifications.py:161
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr ""
 "Ryhmäilmoittautuminen vapaaehtoistehtävään %(event_name)s on tallennettu."
 
-#: registrations/notifications.py:160
+#: registrations/notifications.py:171
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the event %(event_name)s."
 msgstr ""
 "Maksu vaaditaan ilmoittautumisesi vahvistamiseksi tapahtumaan %(event_name)s."
 
-#: registrations/notifications.py:170
+#: registrations/notifications.py:174
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the course "
@@ -1236,7 +1244,7 @@ msgid ""
 msgstr ""
 "Maksu vaaditaan ilmoittautumisesi vahvistamiseksi kurssille %(event_name)s."
 
-#: registrations/notifications.py:173
+#: registrations/notifications.py:177
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the volunteering "
@@ -1245,7 +1253,7 @@ msgstr ""
 "Maksu vaaditaan ilmoittautumisesi vahvistamiseksi vapaaehtoistehtävään "
 "%(event_name)s."
 
-#: registrations/notifications.py:179
+#: registrations/notifications.py:183
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the event "
@@ -1253,10 +1261,10 @@ msgid ""
 "%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>%(event_name)s</strong> "
-"oheisen maksulinkin avulla. Maksulinkki vanhenee "
-"%(expiration_hours)s tunnin kuluttua."
+"oheisen maksulinkin avulla. Maksulinkki vanhenee %(expiration_hours)s tunnin "
+"kuluttua."
 
-#: registrations/notifications.py:184
+#: registrations/notifications.py:188
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the course "
@@ -1264,10 +1272,10 @@ msgid ""
 "%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi kurssille <strong>%(event_name)s</strong> "
-"oheisen maksulinkin avulla. Maksulinkki vanhenee "
-"%(expiration_hours)s tunnin kuluttua."
+"oheisen maksulinkin avulla. Maksulinkki vanhenee %(expiration_hours)s tunnin "
+"kuluttua."
 
-#: registrations/notifications.py:189
+#: registrations/notifications.py:193
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the "
@@ -1275,10 +1283,10 @@ msgid ""
 "%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi vapaaehtoistehtävään "
-"<strong>%(event_name)s</strong> oheisen maksulinkin avulla. Maksulinkki vanhenee "
-"%(expiration_hours)s tunnin kuluttua."
+"<strong>%(event_name)s</strong> oheisen maksulinkin avulla. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:198
+#: registrations/notifications.py:202
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the event "
@@ -1287,7 +1295,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi tapahtumaan "
 "%(event_name)s."
 
-#: registrations/notifications.py:202
+#: registrations/notifications.py:206
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the course "
@@ -1296,7 +1304,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi kurssille "
 "%(event_name)s."
 
-#: registrations/notifications.py:206
+#: registrations/notifications.py:210
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the volunteering "
@@ -1305,7 +1313,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi vapaaehtoistehtävään "
 "%(event_name)s."
 
-#: registrations/notifications.py:216
+#: registrations/notifications.py:220
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1314,7 +1322,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:163
+#: registrations/notifications.py:223
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -1323,7 +1331,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut kurssin <strong>%(event_name)s</strong> "
 "jonotuslistalle."
 
-#: registrations/notifications.py:166
+#: registrations/notifications.py:226
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -1332,7 +1340,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut vapaaehtoistehtävän "
 "<strong>%(event_name)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:171
+#: registrations/notifications.py:231
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -1340,7 +1348,7 @@ msgstr ""
 "Sinut siirretään automaattisesti tapahtuman osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:174
+#: registrations/notifications.py:234
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1348,7 +1356,7 @@ msgstr ""
 "Sinut siirretään automaattisesti kurssin osallistujaksi mikäli paikka "
 "vapautuu."
 
-#: registrations/notifications.py:177
+#: registrations/notifications.py:237
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1356,7 +1364,7 @@ msgstr ""
 "Sinut siirretään automaattisesti vapaaehtoistehtävän osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:183
+#: registrations/notifications.py:243
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1365,7 +1373,7 @@ msgstr ""
 "Ilmoittautuminen tapahtuman <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:186
+#: registrations/notifications.py:246
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1374,7 +1382,7 @@ msgstr ""
 "Ilmoittautuminen kurssin <strong>%(event_name)s</strong> jonotuslistalle "
 "onnistui."
 
-#: registrations/notifications.py:189
+#: registrations/notifications.py:249
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1383,7 +1391,7 @@ msgstr ""
 "Ilmoittautuminen vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalle onnistui."
 
-#: registrations/notifications.py:194
+#: registrations/notifications.py:254
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1391,7 +1399,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti tapahtuman osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:197
+#: registrations/notifications.py:257
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1399,7 +1407,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti kurssin osallistujaksi mikäli "
 "paikka vapautuu."
 
-#: registrations/notifications.py:200
+#: registrations/notifications.py:260
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1407,7 +1415,7 @@ msgstr ""
 "Jonotuslistalta siirretään automaattisesti vapaaehtoistehtävän "
 "osallistujaksi mikäli paikka vapautuu."
 
-#: registrations/notifications.py:210
+#: registrations/notifications.py:270
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1416,7 +1424,7 @@ msgstr ""
 "Sinut on siirretty tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:213
+#: registrations/notifications.py:274
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1425,7 +1433,7 @@ msgstr ""
 "Sinut on siirretty kurssin <strong>%(event_name)s</strong> jonotuslistalta "
 "osallistujaksi."
 
-#: registrations/notifications.py:216
+#: registrations/notifications.py:278
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1434,66 +1442,7 @@ msgstr ""
 "Sinut on siirretty vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:221
-msgid "Registration payment expired"
-msgstr "Ilmoittautumismaksu vanhentunut"
-
-#: registrations/notifications.py:224
-#, python-format
-msgid ""
-"Registration to the event %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Ilmoittautuminen tapahtumaan %(event_name)s on peruttu ilmoittautumismaksun "
-"vanhenemisen vuoksi."
-
-#: registrations/notifications.py:228
-#, python-format
-msgid ""
-"Registration to the course %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Ilmoittautuminen kurssille %(event_name)s on peruttu ilmoittautumismaksun "
-"vanhenemisen vuoksi."
-
-#: registrations/notifications.py:232
-#, python-format
-msgid ""
-"Registration to the volunteering %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on peruttu "
-"ilmoittautumismaksun vanhenemisen vuoksi."
-
-#: registrations/notifications.py:238
-#, python-format
-msgid ""
-"Your registration to the event <strong>%(event_name)s</strong> has been "
-"cancelled due no payment received within the payment period."
-msgstr ""
-"Ilmoittautumisesi tapahtumaan <strong>%(event_name)s</strong> on peruttu, "
-"koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun mennessä."
-
-#: registrations/notifications.py:242
-#, python-format
-msgid ""
-"Your registration to the course <strong>%(event_name)s</strong> has been "
-"cancelled due no payment received within the payment period."
-msgstr ""
-"Ilmoittautumisesi kurssille <strong>%(event_name)s</strong> on peruttu, "
-"koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun mennessä."
-
-#: registrations/notifications.py:246
-#, python-format
-msgid ""
-"Your registration to the volunteering <strong>%(event_name)s</strong> has "
-"been cancelled due no payment received within the payment period."
-msgstr ""
-"Ilmoittautumisesi vapaaehtoistehtävään <strong>%(event_name)s</strong> on "
-"peruttu, koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun "
-"mennessä."
-
-#: registrations/notifications.py:256
+#: registrations/notifications.py:288
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the event "
@@ -1503,10 +1452,10 @@ msgid ""
 msgstr ""
 "Sinut on valittu siirrettäväksi tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
-"%(expiration_hours)s tunnin kuluttua."
+"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee %(expiration_hours)s "
+"tunnin kuluttua."
 
-#: registrations/notifications.py:290
+#: registrations/notifications.py:294
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the course "
@@ -1516,10 +1465,10 @@ msgid ""
 msgstr ""
 "Sinut on valittu siirrettäväksi kurssin <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
-"%(expiration_hours)s tunnin kuluttua."
+"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee %(expiration_hours)s "
+"tunnin kuluttua."
 
-#: registrations/notifications.py:296
+#: registrations/notifications.py:300
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the volunteering "
@@ -1533,31 +1482,90 @@ msgstr ""
 "%(expiration_hours)s tunnin kuluttua."
 
 #: registrations/notifications.py:308
+msgid "Registration payment expired"
+msgstr "Ilmoittautumismaksu vanhentunut"
+
+#: registrations/notifications.py:311
+#, python-format
+msgid ""
+"Registration to the event %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Ilmoittautuminen tapahtumaan %(event_name)s on peruttu ilmoittautumismaksun "
+"vanhenemisen vuoksi."
+
+#: registrations/notifications.py:315
+#, python-format
+msgid ""
+"Registration to the course %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Ilmoittautuminen kurssille %(event_name)s on peruttu ilmoittautumismaksun "
+"vanhenemisen vuoksi."
+
+#: registrations/notifications.py:319
+#, python-format
+msgid ""
+"Registration to the volunteering %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Ilmoittautuminen vapaaehtoistehtävään %(event_name)s on peruttu "
+"ilmoittautumismaksun vanhenemisen vuoksi."
+
+#: registrations/notifications.py:325
+#, python-format
+msgid ""
+"Your registration to the event <strong>%(event_name)s</strong> has been "
+"cancelled due no payment received within the payment period."
+msgstr ""
+"Ilmoittautumisesi tapahtumaan <strong>%(event_name)s</strong> on peruttu, "
+"koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun mennessä."
+
+#: registrations/notifications.py:329
+#, python-format
+msgid ""
+"Your registration to the course <strong>%(event_name)s</strong> has been "
+"cancelled due no payment received within the payment period."
+msgstr ""
+"Ilmoittautumisesi kurssille <strong>%(event_name)s</strong> on peruttu, "
+"koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun mennessä."
+
+#: registrations/notifications.py:333
+#, python-format
+msgid ""
+"Your registration to the volunteering <strong>%(event_name)s</strong> has "
+"been cancelled due no payment received within the payment period."
+msgstr ""
+"Ilmoittautumisesi vapaaehtoistehtävään <strong>%(event_name)s</strong> on "
+"peruttu, koska ilmoittautumismaksua ei ole maksettu maksuajan loppuun "
+"mennessä."
+
+#: registrations/notifications.py:343
 #, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Tapahtuma peruttu - Sarja: %(event_name)s"
 
-#: registrations/notifications.py:259
+#: registrations/notifications.py:346
 #, python-format
 msgid "Registration cancelled - Recurring: %(event_name)s"
 msgstr "Ilmoittautuminen peruttu - Sarja: %(event_name)s"
 
-#: registrations/notifications.py:262 registrations/notifications.py:268
+#: registrations/notifications.py:349 registrations/notifications.py:356
 #, python-format
 msgid "Registration confirmation - Recurring: %(event_name)s"
 msgstr "Vahvistus ilmoittautumisesta - Sarja: %(event_name)s"
 
-#: registrations/notifications.py:265
+#: registrations/notifications.py:353
 #, python-format
 msgid "Waiting list seat reserved - Recurring: %(event_name)s"
 msgstr "Paikka jonotuslistalla varattu - Sarja: %(event_name)s"
 
-#: registrations/notifications.py:276
+#: registrations/notifications.py:365
 #, python-format
 msgid "Recurring event %(event_name)s %(event_period)s has been cancelled"
 msgstr "Sarjatapahtuma %(event_name)s %(event_period)s on peruttu."
 
-#: registrations/notifications.py:284
+#: registrations/notifications.py:373
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring event %(event_name)s "
@@ -1566,7 +1574,7 @@ msgstr ""
 "%(username)s, ilmoittautuminen sarjatapahtumaan %(event_name)s "
 "%(event_period)s on peruttu."
 
-#: registrations/notifications.py:288
+#: registrations/notifications.py:377
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring course %(event_name)s "
@@ -1575,7 +1583,7 @@ msgstr ""
 "%(username)s, ilmoittautuminen sarjakurssille %(event_name)s "
 "%(event_period)s on peruttu."
 
-#: registrations/notifications.py:292
+#: registrations/notifications.py:381
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring volunteering %(event_name)s "
@@ -1584,7 +1592,7 @@ msgstr ""
 "%(username)s, ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s "
 "%(event_period)s on peruttu."
 
-#: registrations/notifications.py:298
+#: registrations/notifications.py:387
 #, python-format
 msgid ""
 "Registration to the recurring event %(event_name)s %(event_period)s has been "
@@ -1592,7 +1600,7 @@ msgid ""
 msgstr ""
 "Ilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on peruttu."
 
-#: registrations/notifications.py:302
+#: registrations/notifications.py:391
 #, python-format
 msgid ""
 "Registration to the recurring course %(event_name)s %(event_period)s has "
@@ -1600,7 +1608,7 @@ msgid ""
 msgstr ""
 "Ilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on peruttu."
 
-#: registrations/notifications.py:306
+#: registrations/notifications.py:395
 #, python-format
 msgid ""
 "Registration to the recurring volunteering %(event_name)s %(event_period)s "
@@ -1609,7 +1617,7 @@ msgstr ""
 "Ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s %(event_period)s "
 "on peruttu."
 
-#: registrations/notifications.py:312
+#: registrations/notifications.py:401
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring event "
@@ -1618,7 +1626,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi sarjatapahtumaan "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:316
+#: registrations/notifications.py:405
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring course "
@@ -1627,7 +1635,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi sarjakurssille "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:320
+#: registrations/notifications.py:409
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring "
@@ -1636,7 +1644,7 @@ msgstr ""
 "Olet onnistuneesti peruuttanut ilmoittautumisesi sarjavapaaehtoistehtävään "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:330
+#: registrations/notifications.py:419
 #, python-format
 msgid ""
 "Registration to the recurring event %(event_name)s %(event_period)s has been "
@@ -1645,7 +1653,7 @@ msgstr ""
 "Ilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on "
 "tallennettu."
 
-#: registrations/notifications.py:334
+#: registrations/notifications.py:423
 #, python-format
 msgid ""
 "Registration to the recurring course %(event_name)s %(event_period)s has "
@@ -1654,7 +1662,7 @@ msgstr ""
 "Ilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on "
 "tallennettu."
 
-#: registrations/notifications.py:338
+#: registrations/notifications.py:427
 #, python-format
 msgid ""
 "Registration to the recurring volunteering %(event_name)s %(event_period)s "
@@ -1663,7 +1671,7 @@ msgstr ""
 "Ilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s %(event_period)s "
 "on tallennettu."
 
-#: registrations/notifications.py:344
+#: registrations/notifications.py:433
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1672,7 +1680,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu sarjatapahtumaan "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:348
+#: registrations/notifications.py:437
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1681,7 +1689,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu sarjakurssille "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:352
+#: registrations/notifications.py:441
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1690,7 +1698,7 @@ msgstr ""
 "Onnittelut! Ilmoittautumisesi on vahvistettu sarjavapaaehtoistehtävään "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:360
+#: registrations/notifications.py:449
 #, python-format
 msgid ""
 "Group registration to the recurring event %(event_name)s %(event_period)s "
@@ -1699,7 +1707,7 @@ msgstr ""
 "Ryhmäilmoittautuminen sarjatapahtumaan %(event_name)s %(event_period)s on "
 "tallennettu."
 
-#: registrations/notifications.py:364
+#: registrations/notifications.py:453
 #, python-format
 msgid ""
 "Group registration to the recurring course %(event_name)s %(event_period)s "
@@ -1708,7 +1716,7 @@ msgstr ""
 "Ryhmäilmoittautuminen sarjakurssille %(event_name)s %(event_period)s on "
 "tallennettu."
 
-#: registrations/notifications.py:368
+#: registrations/notifications.py:457
 #, python-format
 msgid ""
 "Group registration to the recurring volunteering %(event_name)s "
@@ -1717,7 +1725,7 @@ msgstr ""
 "Ryhmäilmoittautuminen sarjavapaaehtoistehtävään %(event_name)s "
 "%(event_period)s on tallennettu."
 
-#: registrations/notifications.py:378
+#: registrations/notifications.py:468
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring event "
@@ -1726,7 +1734,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:439
+#: registrations/notifications.py:472
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring course "
@@ -1735,7 +1743,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:443
+#: registrations/notifications.py:476
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring "
@@ -1744,7 +1752,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
 "sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:449
+#: registrations/notifications.py:482
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1752,10 +1760,10 @@ msgid ""
 "expires in %(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi sarjatapahtumaan <strong>%(event_name)s "
-"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
-"vanhenee %(expiration_hours)s tunnin kuluttua."
+"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:454
+#: registrations/notifications.py:487
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1763,10 +1771,10 @@ msgid ""
 "expires in %(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi sarjakurssille <strong>%(event_name)s "
-"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
-"vanhenee %(expiration_hours)s tunnin kuluttua."
+"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:459
+#: registrations/notifications.py:492
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1774,10 +1782,10 @@ msgid ""
 "link expires in %(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi sarjavapaaehtoistehtävään "
-"<strong>%(event_name)s %(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
-"vanhenee %(expiration_hours)s tunnin kuluttua."
+"<strong>%(event_name)s %(event_period)s</strong> oheisen maksulinkin avulla. "
+"Maksulinkki vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:468
+#: registrations/notifications.py:501
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1786,7 +1794,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:472
+#: registrations/notifications.py:505
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1795,7 +1803,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:476
+#: registrations/notifications.py:509
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1804,7 +1812,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
 "sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:486
+#: registrations/notifications.py:519
 #, python-format
 msgid ""
 "You have successfully registered for the recurring event "
@@ -1813,7 +1821,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut sarjatapahtuman <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:382
+#: registrations/notifications.py:523
 #, python-format
 msgid ""
 "You have successfully registered for the recurring course "
@@ -1822,7 +1830,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut sarjakurssin <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:386
+#: registrations/notifications.py:527
 #, python-format
 msgid ""
 "You have successfully registered for the recurring volunteering "
@@ -1831,7 +1839,7 @@ msgstr ""
 "Olet onnistuneesti ilmoittautunut sarjavapaaehtoistehtävän "
 "<strong>%(event_name)s %(event_period)s</strong> jonotuslistalle."
 
-#: registrations/notifications.py:396
+#: registrations/notifications.py:537
 #, python-format
 msgid ""
 "The registration for the recurring event <strong>%(event_name)s "
@@ -1840,7 +1848,7 @@ msgstr ""
 "Ilmoittautuminen sarjatapahtuman <strong>%(event_name)s %(event_period)s</"
 "strong> jonotuslistalle onnistui."
 
-#: registrations/notifications.py:400
+#: registrations/notifications.py:541
 #, python-format
 msgid ""
 "The registration for the recurring course <strong>%(event_name)s "
@@ -1849,7 +1857,7 @@ msgstr ""
 "Ilmoittautuminen sarjakurssin <strong>%(event_name)s %(event_period)s</"
 "strong> jonotuslistalle onnistui."
 
-#: registrations/notifications.py:404
+#: registrations/notifications.py:545
 #, python-format
 msgid ""
 "The registration for the recurring volunteering <strong>%(event_name)s "
@@ -1858,7 +1866,7 @@ msgstr ""
 "Ilmoittautuminen sarjavapaaehtoistehtävän <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalle onnistui."
 
-#: registrations/notifications.py:418
+#: registrations/notifications.py:559
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring event "
@@ -1867,7 +1875,7 @@ msgstr ""
 "Sinut on siirretty sarjatapahtuman <strong>%(event_name)s %(event_period)s</"
 "strong> jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:422
+#: registrations/notifications.py:563
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring course "
@@ -1876,7 +1884,7 @@ msgstr ""
 "Sinut on siirretty sarjakurssin <strong>%(event_name)s %(event_period)s</"
 "strong> jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:426
+#: registrations/notifications.py:567
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring volunteering "
@@ -1885,7 +1893,7 @@ msgstr ""
 "Sinut on siirretty sarjavapaaehtoistehtävän <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalta osallistujaksi."
 
-#: registrations/notifications.py:436
+#: registrations/notifications.py:577
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
@@ -1895,10 +1903,10 @@ msgid ""
 msgstr ""
 "Sinut on valittu siirrettäväksi sarjatapahtuman <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
-"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki "
-"vanhenee %(expiration_hours)s tunnin kuluttua."
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:550
+#: registrations/notifications.py:583
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
@@ -1908,10 +1916,10 @@ msgid ""
 msgstr ""
 "Sinut on valittu siirrettäväksi sarjakurssin <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
-"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki "
-"vanhenee %(expiration_hours)s tunnin kuluttua."
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:556
+#: registrations/notifications.py:589
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
@@ -1924,17 +1932,17 @@ msgstr ""
 "osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä vahvistaaksesi "
 "osallistumisesi. Maksulinkki vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:568
+#: registrations/notifications.py:601
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
 
-#: registrations/notifications.py:439
+#: registrations/notifications.py:604
 #, python-format
 msgid "Rights granted to the registration - %(event_name)s"
 msgstr "Oikeudet myönnetty ilmoittautumiseen - %(event_name)s"
 
-#: registrations/notifications.py:448
+#: registrations/notifications.py:613
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1943,7 +1951,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "tapahtuman <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:451
+#: registrations/notifications.py:616
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1952,7 +1960,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "kurssin <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:454
+#: registrations/notifications.py:619
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1962,7 +1970,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
 "vapaaehtoistehtävän <strong>%(event_name)s</strong> osallistujalista."
 
-#: registrations/notifications.py:461
+#: registrations/notifications.py:626
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1971,7 +1979,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty sijaisen "
 "käyttöoikeudet tapahtuman <strong>%(event_name)s</strong> ilmoittautumiselle."
 
-#: registrations/notifications.py:464
+#: registrations/notifications.py:629
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1981,7 +1989,7 @@ msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty sijaisen "
 "käyttöoikeudet kurssin <strong>%(event_name)s</strong> ilmoittautumiselle."
 
-#: registrations/notifications.py:467
+#: registrations/notifications.py:632
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -2158,10 +2166,10 @@ msgstr "Viesti vapaaehtoistehtävästä %(event_name)s."
 msgid "View the participants"
 msgstr "Katso osallistujat"
 
-#: registrations/utils.py:156
+#: registrations/utils.py:188
 msgid "Unknown Talpa web store API error"
 msgstr ""
 
-#: registrations/utils.py:159
+#: registrations/utils.py:191
 msgid "Talpa web store API error"
 msgstr ""

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-23 14:42+0000\n"
+"POT-Creation-Date: 2024-02-29 08:50+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -311,7 +311,7 @@ msgstr "Paikan kotisivu"
 msgid "Description"
 msgstr "Kuvaus"
 
-#: events/models.py:682 events/models.py:1485 registrations/models.py:727
+#: events/models.py:682 events/models.py:1485 registrations/models.py:737
 #: registrations/models.py:1023
 msgid "E-mail"
 msgstr "Sähköposti"
@@ -592,7 +592,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1433
+#: linkedevents/fields.py:69 registrations/serializers.py:1426
 msgid "This field is required."
 msgstr "Kenttä on pakollinen."
 
@@ -1249,30 +1249,36 @@ msgstr ""
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the event "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>%(event_name)s</strong> "
-"oheisen maksulinkin avulla."
+"oheisen maksulinkin avulla. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:183
+#: registrations/notifications.py:184
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the course "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi kurssille <strong>%(event_name)s</strong> "
-"oheisen maksulinkin avulla."
+"oheisen maksulinkin avulla. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:187
+#: registrations/notifications.py:189
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the "
-"volunteering <strong>%(event_name)s</strong>."
+"volunteering <strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi vapaaehtoistehtävään "
-"<strong>%(event_name)s</strong> oheisen maksulinkin avulla."
+"<strong>%(event_name)s</strong> oheisen maksulinkin avulla. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:195
+#: registrations/notifications.py:198
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the event "
@@ -1281,7 +1287,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi tapahtumaan "
 "%(event_name)s."
 
-#: registrations/notifications.py:199
+#: registrations/notifications.py:202
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the course "
@@ -1290,7 +1296,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi kurssille "
 "%(event_name)s."
 
-#: registrations/notifications.py:203
+#: registrations/notifications.py:206
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the volunteering "
@@ -1299,7 +1305,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi vapaaehtoistehtävään "
 "%(event_name)s."
 
-#: registrations/notifications.py:213
+#: registrations/notifications.py:216
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1492,35 +1498,41 @@ msgstr ""
 msgid ""
 "You have been selected to be moved from the waiting list of the event "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi tapahtuman <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-"vahvistaaksesi osallistumisesi."
+"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:286
+#: registrations/notifications.py:290
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the course "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi kurssin <strong>%(event_name)s</strong> "
 "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-"vahvistaaksesi osallistumisesi."
+"vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:291
+#: registrations/notifications.py:296
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the volunteering "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi vapaaehtoistehtävän <strong>%(event_name)s</"
 "strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista "
-"maksulinkkiä vahvistaaksesi osallistumisesi."
+"maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+"%(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:302
+#: registrations/notifications.py:308
 #, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Tapahtuma peruttu - Sarja: %(event_name)s"
@@ -1714,7 +1726,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:431
+#: registrations/notifications.py:439
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring course "
@@ -1723,7 +1735,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:435
+#: registrations/notifications.py:443
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring "
@@ -1732,34 +1744,40 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
 "sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:441
-#, python-format
-msgid ""
-"Please use the payment link to confirm your registration for the recurring "
-"event <strong>%(event_name)s %(event_period)s</strong>."
-msgstr ""
-"Voit vahvistaa ilmoittautumisesi sarjatapahtumaan <strong>%(event_name)s "
-"%(event_period)s</strong> oheisen maksulinkin avulla."
-
-#: registrations/notifications.py:445
-#, python-format
-msgid ""
-"Please use the payment link to confirm your registration for the recurring "
-"course <strong>%(event_name)s %(event_period)s</strong>."
-msgstr ""
-"Voit vahvistaa ilmoittautumisesi sarjakurssille <strong>%(event_name)s "
-"%(event_period)s</strong> oheisen maksulinkin avulla."
-
 #: registrations/notifications.py:449
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
-"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+"event <strong>%(event_name)s %(event_period)s</strong>. The payment link "
+"expires in %(expiration_hours)s hours."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi sarjatapahtumaan <strong>%(event_name)s "
+"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
+
+#: registrations/notifications.py:454
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>. The payment link "
+"expires in %(expiration_hours)s hours."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi sarjakurssille <strong>%(event_name)s "
+"%(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
+
+#: registrations/notifications.py:459
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>. The payment "
+"link expires in %(expiration_hours)s hours."
 msgstr ""
 "Voit vahvistaa ilmoittautumisesi sarjavapaaehtoistehtävään "
-"<strong>%(event_name)s %(event_period)s</strong> oheisen maksulinkin avulla."
+"<strong>%(event_name)s %(event_period)s</strong> oheisen maksulinkin avulla. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:457
+#: registrations/notifications.py:468
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1768,7 +1786,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:461
+#: registrations/notifications.py:472
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1777,7 +1795,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:465
+#: registrations/notifications.py:476
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1786,7 +1804,7 @@ msgstr ""
 "Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
 "sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:475
+#: registrations/notifications.py:486
 #, python-format
 msgid ""
 "You have successfully registered for the recurring event "
@@ -1872,36 +1890,41 @@ msgstr ""
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-"Please use the payment link to confirm your participation."
+"Please use the payment link to confirm your participation. The payment link "
+"expires in %(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi sarjatapahtuman <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
-"oheista maksulinkkiä vahvistaaksesi osallistumisesi."
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:538
+#: registrations/notifications.py:550
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-"Please use the payment link to confirm your participation."
+"Please use the payment link to confirm your participation. The payment link "
+"expires in %(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi sarjakurssin <strong>%(event_name)s "
 "%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
-"oheista maksulinkkiä vahvistaaksesi osallistumisesi."
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki "
+"vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:543
+#: registrations/notifications.py:556
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "volunteering <strong>%(event_name)s %(event_period)s</strong> to a "
-"participant. Please use the payment link to confirm your participation."
+"participant. Please use the payment link to confirm your participation. The "
+"payment link expires in %(expiration_hours)s hours."
 msgstr ""
 "Sinut on valittu siirrettäväksi sarjavapaaehtoistehtävän "
 "<strong>%(event_name)s %(event_period)s</strong> jonotuslistalta "
 "osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä vahvistaaksesi "
-"osallistumisesi."
+"osallistumisesi. Maksulinkki vanhenee %(expiration_hours)s tunnin kuluttua."
 
-#: registrations/notifications.py:554
+#: registrations/notifications.py:568
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
@@ -1969,117 +1992,113 @@ msgstr ""
 "käyttöoikeudet vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "ilmoittautumiselle."
 
-#: registrations/serializers.py:75
+#: registrations/serializers.py:101
 msgid "Enrolment is not yet open."
 msgstr "Ilmoittautuminen ei ole vielä auki."
 
-#: registrations/serializers.py:77
+#: registrations/serializers.py:103
 msgid "Enrolment is already closed."
 msgstr "Ilmoittautuminen on jo päättynyt."
 
-#: registrations/serializers.py:85
+#: registrations/serializers.py:111
 msgid "Contact person's first and last name are required to make a payment."
 msgstr ""
 
-#: registrations/serializers.py:101
+#: registrations/serializers.py:127
 msgid ""
 "Participants must have a price group with price greater than 0 selected to "
 "make a payment."
 msgstr ""
 
-#: registrations/serializers.py:115
-msgid "A payment can only be added for attending participants."
-msgstr ""
-
-#: registrations/serializers.py:392 registrations/serializers.py:938
+#: registrations/serializers.py:407 registrations/serializers.py:934
 msgid "The waiting list is already full"
 msgstr "Jonotuslista on jo täynnä"
 
-#: registrations/serializers.py:402
+#: registrations/serializers.py:417
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Olemassa olevan objektin attendee_status-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:409 registrations/serializers.py:1184
+#: registrations/serializers.py:424 registrations/serializers.py:1177
 msgid "You may not change the registration of an existing object."
 msgstr "Olemassa olevan objektin registration-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:458 registrations/serializers.py:469
-#: registrations/serializers.py:1275
+#: registrations/serializers.py:473 registrations/serializers.py:484
+#: registrations/serializers.py:1268
 msgid "This field must be specified."
 msgstr "Kenttä on pakollinen."
 
-#: registrations/serializers.py:491
+#: registrations/serializers.py:506
 msgid "The participant is too young."
 msgstr "Osallistuja on liian nuori."
 
-#: registrations/serializers.py:496
+#: registrations/serializers.py:511
 msgid "The participant is too old."
 msgstr "Osallistuja on liian vanha."
 
-#: registrations/serializers.py:502
+#: registrations/serializers.py:517
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:513
+#: registrations/serializers.py:528
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:522
+#: registrations/serializers.py:537
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:590
+#: registrations/serializers.py:603
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:655
+#: registrations/serializers.py:668
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:662
+#: registrations/serializers.py:675
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:849
+#: registrations/serializers.py:862
 msgid "Reservation code doesn't exist."
 msgstr "Varauskoodia ei ole olemassa."
 
-#: registrations/serializers.py:871
+#: registrations/serializers.py:884
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Ilmoittautumisten määrä on suurempi kuin ryhmän enimmäiskoko: "
 "{max_group_size}."
 
-#: registrations/serializers.py:893
+#: registrations/serializers.py:906
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1045
+#: registrations/serializers.py:1041
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1278
+#: registrations/serializers.py:1271
 msgid "The value doesn't match."
 msgstr "Arvo ei täsmää."
 
-#: registrations/serializers.py:1296
+#: registrations/serializers.py:1289
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
 
-#: registrations/serializers.py:1321
+#: registrations/serializers.py:1314
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Paikkoja ei ole riittävästi jäljellä. Paikkoja jäljellä: {capacity_left}."
 
-#: registrations/serializers.py:1337
+#: registrations/serializers.py:1330
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -2087,7 +2106,7 @@ msgstr ""
 "Jonotuslistalle ei ole tarpeeksi paikkoja jäljellä. Paikkoja jäljellä "
 "jonotuslistalla: {capacity_left}."
 
-#: registrations/serializers.py:1351
+#: registrations/serializers.py:1344
 msgid "Cannot update expired seats reservation."
 msgstr "Vanhentunutta paikkavarausta ei voi päivittää."
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-21 10:59+0000\n"
+"POT-Creation-Date: 2024-02-23 14:42+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -592,7 +592,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1499
+#: linkedevents/fields.py:69 registrations/serializers.py:1433
 msgid "This field is required."
 msgstr "Kenttä on pakollinen."
 
@@ -810,11 +810,11 @@ msgstr "Sukunimi"
 msgid "ZIP code"
 msgstr "Postinumero"
 
-#: registrations/models.py:96
+#: registrations/models.py:97
 msgid "You must provide either signup_group or signup."
 msgstr ""
 
-#: registrations/models.py:100
+#: registrations/models.py:101
 msgid "You can only provide signup_group or signup, not both."
 msgstr ""
 
@@ -1002,27 +1002,39 @@ msgstr "Tervetuloa"
 msgid "Thank you for signing up for the waiting list"
 msgstr "Kiitos ilmoittautumisesta jonoon"
 
-#: registrations/notifications.py:13
+#: registrations/notifications.py:14
+#, python-format
+msgid "Payment required for registration confirmation - %(event_name)s"
+msgstr "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - %(event_name)s"
+
+#: registrations/notifications.py:17
+#, python-format
+msgid ""
+"Payment required for registration confirmation - Recurring: %(event_name)s"
+msgstr ""
+"Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Sarja: %(event_name)s"
+
+#: registrations/notifications.py:19
 msgid "Thank you for your interest in the event."
 msgstr "Kiitos mielenkiinnosta tapahtumaa kohtaan."
 
-#: registrations/notifications.py:14
+#: registrations/notifications.py:20
 msgid "Registration cancelled"
 msgstr "Ilmoittautuminen peruttu"
 
-#: registrations/notifications.py:25
+#: registrations/notifications.py:31
 msgid "No Notification"
 msgstr "Ei ilmoituksia"
 
-#: registrations/notifications.py:26
+#: registrations/notifications.py:32
 msgid "SMS"
 msgstr "Teksiviesti"
 
-#: registrations/notifications.py:27
+#: registrations/notifications.py:33
 msgid "E-Mail"
 msgstr "Sähköposti"
 
-#: registrations/notifications.py:28
+#: registrations/notifications.py:34
 msgid "Both SMS and email."
 msgstr "Tekstiviesti ja sähköposti"
 
@@ -1212,6 +1224,84 @@ msgstr ""
 #: registrations/notifications.py:160
 #, python-format
 msgid ""
+"Payment is required to confirm your registration to the event %(event_name)s."
+msgstr ""
+"Maksu vaaditaan ilmoittautumisesi vahvistamiseksi tapahtumaan %(event_name)s."
+
+#: registrations/notifications.py:170
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the course "
+"%(event_name)s."
+msgstr ""
+"Maksu vaaditaan ilmoittautumisesi vahvistamiseksi kurssille %(event_name)s."
+
+#: registrations/notifications.py:173
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the volunteering "
+"%(event_name)s."
+msgstr ""
+"Maksu vaaditaan ilmoittautumisesi vahvistamiseksi vapaaehtoistehtävään "
+"%(event_name)s."
+
+#: registrations/notifications.py:179
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the event "
+"<strong>%(event_name)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>%(event_name)s</strong> "
+"oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:183
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the course "
+"<strong>%(event_name)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi kurssille <strong>%(event_name)s</strong> "
+"oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:187
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the "
+"volunteering <strong>%(event_name)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi vapaaehtoistehtävään "
+"<strong>%(event_name)s</strong> oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:195
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the event "
+"%(event_name)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi tapahtumaan "
+"%(event_name)s."
+
+#: registrations/notifications.py:199
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the course "
+"%(event_name)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi kurssille "
+"%(event_name)s."
+
+#: registrations/notifications.py:203
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the volunteering "
+"%(event_name)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi vapaaehtoistehtävään "
+"%(event_name)s."
+
+#: registrations/notifications.py:213
+#, python-format
+msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
 "strong> waiting list."
 msgstr ""
@@ -1399,6 +1489,39 @@ msgstr ""
 
 #: registrations/notifications.py:256
 #, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the event "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi tapahtuman <strong>%(event_name)s</strong> "
+"jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
+"vahvistaaksesi osallistumisesi."
+
+#: registrations/notifications.py:286
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the course "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi kurssin <strong>%(event_name)s</strong> "
+"jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
+"vahvistaaksesi osallistumisesi."
+
+#: registrations/notifications.py:291
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the volunteering "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi vapaaehtoistehtävän <strong>%(event_name)s</"
+"strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista "
+"maksulinkkiä vahvistaaksesi osallistumisesi."
+
+#: registrations/notifications.py:302
+#, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Tapahtuma peruttu - Sarja: %(event_name)s"
 
@@ -1585,6 +1708,87 @@ msgstr ""
 #: registrations/notifications.py:378
 #, python-format
 msgid ""
+"Payment is required to confirm your registration to the recurring event "
+"%(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:431
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the recurring course "
+"%(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:435
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the recurring "
+"volunteering %(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
+"sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:441
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi sarjatapahtumaan <strong>%(event_name)s "
+"%(event_period)s</strong> oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:445
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi sarjakurssille <strong>%(event_name)s "
+"%(event_period)s</strong> oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:449
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Voit vahvistaa ilmoittautumisesi sarjavapaaehtoistehtävään "
+"<strong>%(event_name)s %(event_period)s</strong> oheisen maksulinkin avulla."
+
+#: registrations/notifications.py:457
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"event %(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjatapahtumaan "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:461
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"course %(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi sarjakurssille "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:465
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"volunteering %(event_name)s %(event_period)s."
+msgstr ""
+"Maksu vaaditaan ryhmäilmoittautumisesi vahvistamiseksi "
+"sarjavapaaehtoistehtävään %(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:475
+#, python-format
+msgid ""
 "You have successfully registered for the recurring event "
 "<strong>%(event_name)s %(event_period)s</strong> waiting list."
 msgstr ""
@@ -1665,6 +1869,40 @@ msgstr ""
 
 #: registrations/notifications.py:436
 #, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+"Please use the payment link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi sarjatapahtuman <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi."
+
+#: registrations/notifications.py:538
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+"Please use the payment link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi sarjakurssin <strong>%(event_name)s "
+"%(event_period)s</strong> jonotuslistalta osallistujaksi. Ole hyvä ja käytä "
+"oheista maksulinkkiä vahvistaaksesi osallistumisesi."
+
+#: registrations/notifications.py:543
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong> to a "
+"participant. Please use the payment link to confirm your participation."
+msgstr ""
+"Sinut on valittu siirrettäväksi sarjavapaaehtoistehtävän "
+"<strong>%(event_name)s %(event_period)s</strong> jonotuslistalta "
+"osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä vahvistaaksesi "
+"osallistumisesi."
+
+#: registrations/notifications.py:554
+#, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Oikeudet myönnetty osallistujalistaan  - %(event_name)s"
 
@@ -1731,125 +1969,117 @@ msgstr ""
 "käyttöoikeudet vapaaehtoistehtävän <strong>%(event_name)s</strong> "
 "ilmoittautumiselle."
 
-#: registrations/serializers.py:78
+#: registrations/serializers.py:75
 msgid "Enrolment is not yet open."
 msgstr "Ilmoittautuminen ei ole vielä auki."
 
-#: registrations/serializers.py:80
+#: registrations/serializers.py:77
 msgid "Enrolment is already closed."
 msgstr "Ilmoittautuminen on jo päättynyt."
 
-#: registrations/serializers.py:88
+#: registrations/serializers.py:85
 msgid "Contact person's first and last name are required to make a payment."
 msgstr ""
 
-#: registrations/serializers.py:104
+#: registrations/serializers.py:101
 msgid ""
 "Participants must have a price group with price greater than 0 selected to "
 "make a payment."
 msgstr ""
 
-#: registrations/serializers.py:118
+#: registrations/serializers.py:115
 msgid "A payment can only be added for attending participants."
 msgstr ""
 
-#: registrations/serializers.py:293
-msgid "Unknown Talpa web store API error"
-msgstr ""
-
-#: registrations/serializers.py:296
-msgid "Talpa web store API error"
-msgstr ""
-
-#: registrations/serializers.py:458 registrations/serializers.py:1004
+#: registrations/serializers.py:392 registrations/serializers.py:938
 msgid "The waiting list is already full"
 msgstr "Jonotuslista on jo täynnä"
 
-#: registrations/serializers.py:468
+#: registrations/serializers.py:402
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Olemassa olevan objektin attendee_status-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:475 registrations/serializers.py:1250
+#: registrations/serializers.py:409 registrations/serializers.py:1184
 msgid "You may not change the registration of an existing object."
 msgstr "Olemassa olevan objektin registration-kenttää ei voi vaihtaa."
 
-#: registrations/serializers.py:524 registrations/serializers.py:535
-#: registrations/serializers.py:1341
+#: registrations/serializers.py:458 registrations/serializers.py:469
+#: registrations/serializers.py:1275
 msgid "This field must be specified."
 msgstr "Kenttä on pakollinen."
 
-#: registrations/serializers.py:557
+#: registrations/serializers.py:491
 msgid "The participant is too young."
 msgstr "Osallistuja on liian nuori."
 
-#: registrations/serializers.py:562
+#: registrations/serializers.py:496
 msgid "The participant is too old."
 msgstr "Osallistuja on liian vanha."
 
-#: registrations/serializers.py:568
+#: registrations/serializers.py:502
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:579
+#: registrations/serializers.py:513
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:588
+#: registrations/serializers.py:522
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:656
+#: registrations/serializers.py:590
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:721
+#: registrations/serializers.py:655
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:728
+#: registrations/serializers.py:662
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:915
+#: registrations/serializers.py:849
 msgid "Reservation code doesn't exist."
 msgstr "Varauskoodia ei ole olemassa."
 
-#: registrations/serializers.py:937
+#: registrations/serializers.py:871
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Ilmoittautumisten määrä on suurempi kuin ryhmän enimmäiskoko: "
 "{max_group_size}."
 
-#: registrations/serializers.py:959
+#: registrations/serializers.py:893
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1111
+#: registrations/serializers.py:1045
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1344
+#: registrations/serializers.py:1278
 msgid "The value doesn't match."
 msgstr "Arvo ei täsmää."
 
-#: registrations/serializers.py:1362
+#: registrations/serializers.py:1296
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Paikkojen lukumäärä on suurempi kuin ryhmän enimmäiskoko: {max_group_size}."
 
-#: registrations/serializers.py:1387
+#: registrations/serializers.py:1321
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Paikkoja ei ole riittävästi jäljellä. Paikkoja jäljellä: {capacity_left}."
 
-#: registrations/serializers.py:1403
+#: registrations/serializers.py:1337
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1857,9 +2087,13 @@ msgstr ""
 "Jonotuslistalle ei ole tarpeeksi paikkoja jäljellä. Paikkoja jäljellä "
 "jonotuslistalla: {capacity_left}."
 
-#: registrations/serializers.py:1417
+#: registrations/serializers.py:1351
 msgid "Cannot update expired seats reservation."
 msgstr "Vanhentunutta paikkavarausta ei voi päivittää."
+
+#: registrations/templates/_open_payment_link_button.html:6
+msgid "Open payment link"
+msgstr "Avaa maksulinkki"
 
 #: registrations/templates/_open_registration_button.html:6
 msgid "Check your registration here"
@@ -1904,3 +2138,11 @@ msgstr "Viesti vapaaehtoistehtävästä %(event_name)s."
 #: registrations/templates/registration_user_access_invitation.html:16
 msgid "View the participants"
 msgstr "Katso osallistujat"
+
+#: registrations/utils.py:156
+msgid "Unknown Talpa web store API error"
+msgstr ""
+
+#: registrations/utils.py:159
+msgid "Talpa web store API error"
+msgstr ""

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-21 10:59+0000\n"
+"POT-Creation-Date: 2024-02-23 14:42+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -588,7 +588,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1499
+#: linkedevents/fields.py:69 registrations/serializers.py:1433
 msgid "This field is required."
 msgstr "Detta fält måste anges."
 
@@ -805,11 +805,11 @@ msgstr "Efternamn"
 msgid "ZIP code"
 msgstr "Postnummer"
 
-#: registrations/models.py:96
+#: registrations/models.py:97
 msgid "You must provide either signup_group or signup."
 msgstr ""
 
-#: registrations/models.py:100
+#: registrations/models.py:101
 msgid "You can only provide signup_group or signup, not both."
 msgstr ""
 
@@ -998,27 +998,39 @@ msgstr "Välkommen"
 msgid "Thank you for signing up for the waiting list"
 msgstr "Tack för att du skrev upp dig på väntelistan"
 
-#: registrations/notifications.py:13
+#: registrations/notifications.py:14
+#, python-format
+msgid "Payment required for registration confirmation - %(event_name)s"
+msgstr "Betalning krävs för bekräftelse av registreringen - %(event_name)s"
+
+#: registrations/notifications.py:17
+#, python-format
+msgid ""
+"Payment required for registration confirmation - Recurring: %(event_name)s"
+msgstr ""
+"Betalning krävs för bekräftelse av registreringen - Serie: %(event_name)s"
+
+#: registrations/notifications.py:19
 msgid "Thank you for your interest in the event."
 msgstr "Tack för ditt intresse för evenemanget."
 
-#: registrations/notifications.py:14
+#: registrations/notifications.py:20
 msgid "Registration cancelled"
 msgstr "Registreringen avbruten"
 
-#: registrations/notifications.py:25
+#: registrations/notifications.py:31
 msgid "No Notification"
 msgstr "Ingen anmälan"
 
-#: registrations/notifications.py:26
+#: registrations/notifications.py:32
 msgid "SMS"
 msgstr "SMS"
 
-#: registrations/notifications.py:27
+#: registrations/notifications.py:33
 msgid "E-Mail"
 msgstr "E-post"
 
-#: registrations/notifications.py:28
+#: registrations/notifications.py:34
 msgid "Both SMS and email."
 msgstr "Både SMS och e-post."
 
@@ -1203,6 +1215,84 @@ msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr "Gruppregistrering till volontärarbetet %(event_name)s har sparats."
 
 #: registrations/notifications.py:160
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the event %(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till evenemanget %(event_name)s."
+
+#: registrations/notifications.py:170
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the course "
+"%(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till kursen %(event_name)s."
+
+#: registrations/notifications.py:173
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the volunteering "
+"%(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till volontärarbetet "
+"%(event_name)s."
+
+#: registrations/notifications.py:179
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the event "
+"<strong>%(event_name)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till evenemanget "
+"<strong>%(event_name)s</strong>."
+
+#: registrations/notifications.py:183
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the course "
+"<strong>%(event_name)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till kursen "
+"<strong>%(event_name)s</strong>."
+
+#: registrations/notifications.py:187
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the "
+"volunteering <strong>%(event_name)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till volontärarbetet "
+"<strong>%(event_name)s</strong>."
+
+#: registrations/notifications.py:195
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the event "
+"%(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till evenemanget "
+"%(event_name)s."
+
+#: registrations/notifications.py:199
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the course "
+"%(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till kursen "
+"%(event_name)s."
+
+#: registrations/notifications.py:203
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the volunteering "
+"%(event_name)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till volontärarbetet "
+"%(event_name)s."
+
+#: registrations/notifications.py:213
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1391,6 +1481,39 @@ msgstr ""
 
 #: registrations/notifications.py:256
 #, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the event "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för evenemanget "
+"<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
+"för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:286
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the course "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för kursen "
+"<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
+"för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:291
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the volunteering "
+"<strong>%(event_name)s</strong> to a participant. Please use the payment "
+"link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för volontärarbetet "
+"<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
+"för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:302
+#, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Evenemanget inställt - Serie: %(event_name)s"
 
@@ -1574,6 +1697,87 @@ msgstr ""
 #: registrations/notifications.py:378
 #, python-format
 msgid ""
+"Payment is required to confirm your registration to the recurring event "
+"%(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till serieevenemanget "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:431
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the recurring course "
+"%(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till seriekursen %(event_name)s "
+"%(event_period)s."
+
+#: registrations/notifications.py:435
+#, python-format
+msgid ""
+"Payment is required to confirm your registration to the recurring "
+"volunteering %(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din anmälan till serievolontärarbetet "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:441
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till serieevenemanget "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:445
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till seriekursen "
+"<strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:449
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till "
+"serievolontärarbetet <strong>%(event_name)s %(event_period)s</strong>."
+
+#: registrations/notifications.py:457
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"event %(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till serieevenemanget "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:461
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"course %(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till seriekursen "
+"%(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:465
+#, python-format
+msgid ""
+"Payment is required to confirm your group registration to the recurring "
+"volunteering %(event_name)s %(event_period)s."
+msgstr ""
+"Betalning krävs för att bekräfta din gruppregistrering till "
+"serievolontärarbetet %(event_name)s %(event_period)s."
+
+#: registrations/notifications.py:475
+#, python-format
+msgid ""
 "You have successfully registered for the recurring event "
 "<strong>%(event_name)s %(event_period)s</strong> waiting list."
 msgstr ""
@@ -1654,6 +1858,39 @@ msgstr ""
 
 #: registrations/notifications.py:436
 #, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+"Please use the payment link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
+"<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
+"betalningslänken för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:538
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+"Please use the payment link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för seriekursen "
+"<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
+"betalningslänken för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:543
+#, python-format
+msgid ""
+"You have been selected to be moved from the waiting list of the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong> to a "
+"participant. Please use the payment link to confirm your participation."
+msgstr ""
+"Du har blivit utvald att flyttats från väntelistan för serievolontärarbetet "
+"<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
+"betalningslänken för att bekräfta ditt deltagande."
+
+#: registrations/notifications.py:554
+#, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Rättigheter tilldelade deltagarlistan - %(event_name)s"
 
@@ -1722,124 +1959,116 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/serializers.py:78
+#: registrations/serializers.py:75
 msgid "Enrolment is not yet open."
 msgstr "Anmälan är ännu inte öppen."
 
-#: registrations/serializers.py:80
+#: registrations/serializers.py:77
 msgid "Enrolment is already closed."
 msgstr "Anmälan är redan stängd"
 
-#: registrations/serializers.py:88
+#: registrations/serializers.py:85
 msgid "Contact person's first and last name are required to make a payment."
 msgstr ""
 
-#: registrations/serializers.py:104
+#: registrations/serializers.py:101
 msgid ""
 "Participants must have a price group with price greater than 0 selected to "
 "make a payment."
 msgstr ""
 
-#: registrations/serializers.py:118
+#: registrations/serializers.py:115
 msgid "A payment can only be added for attending participants."
 msgstr ""
 
-#: registrations/serializers.py:293
-msgid "Unknown Talpa web store API error"
-msgstr ""
-
-#: registrations/serializers.py:296
-msgid "Talpa web store API error"
-msgstr ""
-
-#: registrations/serializers.py:458 registrations/serializers.py:1004
+#: registrations/serializers.py:392 registrations/serializers.py:938
 msgid "The waiting list is already full"
 msgstr "Väntelistan är redan full"
 
-#: registrations/serializers.py:468
+#: registrations/serializers.py:402
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Du får inte ändra attendee_status för ett befintligt objekt."
 
-#: registrations/serializers.py:475 registrations/serializers.py:1250
+#: registrations/serializers.py:409 registrations/serializers.py:1184
 msgid "You may not change the registration of an existing object."
 msgstr "Du får inte ändra registration för ett befintligt objekt."
 
-#: registrations/serializers.py:524 registrations/serializers.py:535
-#: registrations/serializers.py:1341
+#: registrations/serializers.py:458 registrations/serializers.py:469
+#: registrations/serializers.py:1275
 msgid "This field must be specified."
 msgstr "Detta fält måste anges."
 
-#: registrations/serializers.py:557
+#: registrations/serializers.py:491
 msgid "The participant is too young."
 msgstr "Deltagaren är för ung."
 
-#: registrations/serializers.py:562
+#: registrations/serializers.py:496
 msgid "The participant is too old."
 msgstr "Deltagaren är för gammal."
 
-#: registrations/serializers.py:568
+#: registrations/serializers.py:502
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:579
+#: registrations/serializers.py:513
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:588
+#: registrations/serializers.py:522
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:656
+#: registrations/serializers.py:590
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:721
+#: registrations/serializers.py:655
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:728
+#: registrations/serializers.py:662
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:915
+#: registrations/serializers.py:849
 msgid "Reservation code doesn't exist."
 msgstr "Bokningskoden finns inte."
 
-#: registrations/serializers.py:937
+#: registrations/serializers.py:871
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Antalet registreringar är större än den maximala gruppstorleken: "
 "{max_group_size}."
 
-#: registrations/serializers.py:959
+#: registrations/serializers.py:893
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1111
+#: registrations/serializers.py:1045
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1344
+#: registrations/serializers.py:1278
 msgid "The value doesn't match."
 msgstr "Värdet stämmer inte överens."
 
-#: registrations/serializers.py:1362
+#: registrations/serializers.py:1296
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr "Antalet platser är större än maximal gruppstorlek: {max_group_size}."
 
-#: registrations/serializers.py:1387
+#: registrations/serializers.py:1321
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Inte tillräckligt med platser tillgängliga. Kapacitet kvar: {capacity_left}."
 
-#: registrations/serializers.py:1403
+#: registrations/serializers.py:1337
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -1847,9 +2076,13 @@ msgstr ""
 "Inte tillräckligt med kapacitet på väntelistan. Kapacitet kvar: "
 "{capacity_left}."
 
-#: registrations/serializers.py:1417
+#: registrations/serializers.py:1351
 msgid "Cannot update expired seats reservation."
 msgstr "Kan inte uppdatera utgångna platsreservationer."
+
+#: registrations/templates/_open_payment_link_button.html:6
+msgid "Open payment link"
+msgstr "Öppna betalningslänken"
 
 #: registrations/templates/_open_registration_button.html:6
 msgid "Check your registration here"
@@ -1894,3 +2127,11 @@ msgstr "Ett meddelande om volontärarbetet %(event_name)s."
 #: registrations/templates/registration_user_access_invitation.html:16
 msgid "View the participants"
 msgstr "Se deltagarna"
+
+#: registrations/utils.py:156
+msgid "Unknown Talpa web store API error"
+msgstr ""
+
+#: registrations/utils.py:159
+msgid "Talpa web store API error"
+msgstr ""

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-23 14:42+0000\n"
+"POT-Creation-Date: 2024-02-29 08:50+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -588,7 +588,7 @@ msgstr ""
 msgid "@id field missing"
 msgstr ""
 
-#: linkedevents/fields.py:69 registrations/serializers.py:1433
+#: linkedevents/fields.py:69 registrations/serializers.py:1426
 msgid "This field is required."
 msgstr "Detta fält måste anges."
 
@@ -1242,30 +1242,36 @@ msgstr ""
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the event "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till evenemanget "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:183
+#: registrations/notifications.py:184
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the course "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till kursen "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:187
+#: registrations/notifications.py:189
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the "
-"volunteering <strong>%(event_name)s</strong>."
+"volunteering <strong>%(event_name)s</strong>. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till volontärarbetet "
-"<strong>%(event_name)s</strong>."
+"<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:195
+#: registrations/notifications.py:198
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the event "
@@ -1274,7 +1280,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till evenemanget "
 "%(event_name)s."
 
-#: registrations/notifications.py:199
+#: registrations/notifications.py:202
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the course "
@@ -1283,7 +1289,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till kursen "
 "%(event_name)s."
 
-#: registrations/notifications.py:203
+#: registrations/notifications.py:206
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the volunteering "
@@ -1292,7 +1298,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till volontärarbetet "
 "%(event_name)s."
 
-#: registrations/notifications.py:213
+#: registrations/notifications.py:216
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1484,35 +1490,41 @@ msgstr ""
 msgid ""
 "You have been selected to be moved from the waiting list of the event "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för evenemanget "
 "<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
-"för att bekräfta ditt deltagande."
+"för att bekräfta ditt deltagande. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:286
+#: registrations/notifications.py:290
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the course "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för kursen "
 "<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
-"för att bekräfta ditt deltagande."
+"för att bekräfta ditt deltagande. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:291
+#: registrations/notifications.py:296
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the volunteering "
 "<strong>%(event_name)s</strong> to a participant. Please use the payment "
-"link to confirm your participation."
+"link to confirm your participation. The payment link expires in "
+"%(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för volontärarbetet "
 "<strong>%(event_name)s</strong> till en deltagare. Använd betalningslänken "
-"för att bekräfta ditt deltagande."
+"för att bekräfta ditt deltagande. Betalningslänken går ut efter "
+"%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:302
+#: registrations/notifications.py:308
 #, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Evenemanget inställt - Serie: %(event_name)s"
@@ -1703,7 +1715,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till serieevenemanget "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:431
+#: registrations/notifications.py:439
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring course "
@@ -1712,7 +1724,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till seriekursen %(event_name)s "
 "%(event_period)s."
 
-#: registrations/notifications.py:435
+#: registrations/notifications.py:443
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring "
@@ -1721,34 +1733,40 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till serievolontärarbetet "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:441
-#, python-format
-msgid ""
-"Please use the payment link to confirm your registration for the recurring "
-"event <strong>%(event_name)s %(event_period)s</strong>."
-msgstr ""
-"Använd betalningslänken för att bekräfta din anmälan till serieevenemanget "
-"<strong>%(event_name)s %(event_period)s</strong>."
-
-#: registrations/notifications.py:445
-#, python-format
-msgid ""
-"Please use the payment link to confirm your registration for the recurring "
-"course <strong>%(event_name)s %(event_period)s</strong>."
-msgstr ""
-"Använd betalningslänken för att bekräfta din anmälan till seriekursen "
-"<strong>%(event_name)s %(event_period)s</strong>."
-
 #: registrations/notifications.py:449
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
-"volunteering <strong>%(event_name)s %(event_period)s</strong>."
+"event <strong>%(event_name)s %(event_period)s</strong>. The payment link "
+"expires in %(expiration_hours)s hours."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till serieevenemanget "
+"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
+"går ut efter %(expiration_hours)s timmar."
+
+#: registrations/notifications.py:454
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"course <strong>%(event_name)s %(event_period)s</strong>. The payment link "
+"expires in %(expiration_hours)s hours."
+msgstr ""
+"Använd betalningslänken för att bekräfta din anmälan till seriekursen "
+"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
+"går ut efter %(expiration_hours)s timmar."
+
+#: registrations/notifications.py:459
+#, python-format
+msgid ""
+"Please use the payment link to confirm your registration for the recurring "
+"volunteering <strong>%(event_name)s %(event_period)s</strong>. The payment "
+"link expires in %(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till "
-"serievolontärarbetet <strong>%(event_name)s %(event_period)s</strong>."
+"serievolontärarbetet <strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
+"går ut efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:457
+#: registrations/notifications.py:468
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1757,7 +1775,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till serieevenemanget "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:461
+#: registrations/notifications.py:472
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1766,7 +1784,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till seriekursen "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:465
+#: registrations/notifications.py:476
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1775,7 +1793,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till "
 "serievolontärarbetet %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:475
+#: registrations/notifications.py:486
 #, python-format
 msgid ""
 "You have successfully registered for the recurring event "
@@ -1861,35 +1879,41 @@ msgstr ""
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-"Please use the payment link to confirm your participation."
+"Please use the payment link to confirm your participation. The payment link "
+"expires in %(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande."
+"betalningslänken för att bekräfta ditt deltagande. Betalningslänken "
+"går ut efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:538
-#, python-format
+#: registrations/notifications.py:550
+#,  python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-"Please use the payment link to confirm your participation."
+"Please use the payment link to confirm your participation. The payment link "
+"expires in %(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för seriekursen "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande."
+"betalningslänken för att bekräfta ditt deltagande. Betalningslänken "
+"går ut efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:543
+#: registrations/notifications.py:556
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "volunteering <strong>%(event_name)s %(event_period)s</strong> to a "
-"participant. Please use the payment link to confirm your participation."
+"participant. Please use the payment link to confirm your participation. The "
+"payment link expires in %(expiration_hours)s hours."
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande."
+"betalningslänken för att bekräfta ditt deltagande. "
+"Betalningslänken går ut efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:554
+#: registrations/notifications.py:568
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Rättigheter tilldelade deltagarlistan - %(event_name)s"
@@ -1959,116 +1983,112 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/serializers.py:75
+#: registrations/serializers.py:101
 msgid "Enrolment is not yet open."
 msgstr "Anmälan är ännu inte öppen."
 
-#: registrations/serializers.py:77
+#: registrations/serializers.py:103
 msgid "Enrolment is already closed."
 msgstr "Anmälan är redan stängd"
 
-#: registrations/serializers.py:85
+#: registrations/serializers.py:111
 msgid "Contact person's first and last name are required to make a payment."
 msgstr ""
 
-#: registrations/serializers.py:101
+#: registrations/serializers.py:127
 msgid ""
 "Participants must have a price group with price greater than 0 selected to "
 "make a payment."
 msgstr ""
 
-#: registrations/serializers.py:115
-msgid "A payment can only be added for attending participants."
-msgstr ""
-
-#: registrations/serializers.py:392 registrations/serializers.py:938
+#: registrations/serializers.py:407 registrations/serializers.py:934
 msgid "The waiting list is already full"
 msgstr "Väntelistan är redan full"
 
-#: registrations/serializers.py:402
+#: registrations/serializers.py:417
 msgid "You may not change the attendee_status of an existing object."
 msgstr "Du får inte ändra attendee_status för ett befintligt objekt."
 
-#: registrations/serializers.py:409 registrations/serializers.py:1184
+#: registrations/serializers.py:424 registrations/serializers.py:1177
 msgid "You may not change the registration of an existing object."
 msgstr "Du får inte ändra registration för ett befintligt objekt."
 
-#: registrations/serializers.py:458 registrations/serializers.py:469
-#: registrations/serializers.py:1275
+#: registrations/serializers.py:473 registrations/serializers.py:484
+#: registrations/serializers.py:1268
 msgid "This field must be specified."
 msgstr "Detta fält måste anges."
 
-#: registrations/serializers.py:491
+#: registrations/serializers.py:506
 msgid "The participant is too young."
 msgstr "Deltagaren är för ung."
 
-#: registrations/serializers.py:496
+#: registrations/serializers.py:511
 msgid "The participant is too old."
 msgstr "Deltagaren är för gammal."
 
-#: registrations/serializers.py:502
+#: registrations/serializers.py:517
 msgid "Price group selection is mandatory for this registration."
 msgstr ""
 
-#: registrations/serializers.py:513
+#: registrations/serializers.py:528
 msgid "Price group is already assigned to another participant."
 msgstr ""
 
-#: registrations/serializers.py:522
+#: registrations/serializers.py:537
 msgid ""
 "Price group is not one of the allowed price groups for this registration."
 msgstr ""
 
-#: registrations/serializers.py:590
+#: registrations/serializers.py:603
 msgid ""
 "The user's email domain is not one of the allowed domains for substitute "
 "users."
 msgstr ""
 
-#: registrations/serializers.py:655
+#: registrations/serializers.py:668
 #, python-format
 msgid "%(value)s is not a valid choice."
 msgstr ""
 
-#: registrations/serializers.py:662
+#: registrations/serializers.py:675
 msgid "Price must be greater than or equal to 0."
 msgstr ""
 
-#: registrations/serializers.py:849
+#: registrations/serializers.py:862
 msgid "Reservation code doesn't exist."
 msgstr "Bokningskoden finns inte."
 
-#: registrations/serializers.py:871
+#: registrations/serializers.py:884
 #, python-brace-format
 msgid "Amount of signups is greater than maximum group size: {max_group_size}."
 msgstr ""
 "Antalet registreringar är större än den maximala gruppstorleken: "
 "{max_group_size}."
 
-#: registrations/serializers.py:893
+#: registrations/serializers.py:906
 msgid "Only one signup is supported when creating a Talpa web store payment."
 msgstr ""
 
-#: registrations/serializers.py:1045
+#: registrations/serializers.py:1041
 msgid "Contact person information must be provided for a group."
 msgstr ""
 
-#: registrations/serializers.py:1278
+#: registrations/serializers.py:1271
 msgid "The value doesn't match."
 msgstr "Värdet stämmer inte överens."
 
-#: registrations/serializers.py:1296
+#: registrations/serializers.py:1289
 #, python-brace-format
 msgid "Amount of seats is greater than maximum group size: {max_group_size}."
 msgstr "Antalet platser är större än maximal gruppstorlek: {max_group_size}."
 
-#: registrations/serializers.py:1321
+#: registrations/serializers.py:1314
 #, python-brace-format
 msgid "Not enough seats available. Capacity left: {capacity_left}."
 msgstr ""
 "Inte tillräckligt med platser tillgängliga. Kapacitet kvar: {capacity_left}."
 
-#: registrations/serializers.py:1337
+#: registrations/serializers.py:1330
 #, python-brace-format
 msgid ""
 "Not enough capacity in the waiting list. Capacity left: {capacity_left}."
@@ -2076,7 +2096,7 @@ msgstr ""
 "Inte tillräckligt med kapacitet på väntelistan. Kapacitet kvar: "
 "{capacity_left}."
 
-#: registrations/serializers.py:1351
+#: registrations/serializers.py:1344
 msgid "Cannot update expired seats reservation."
 msgstr "Kan inte uppdatera utgångna platsreservationer."
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-29 08:50+0000\n"
+"POT-Creation-Date: 2024-03-07 11:50+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -221,7 +221,7 @@ msgid "Licenses"
 msgstr "Licenser"
 
 #: events/models.py:241 events/models.py:481 events/models.py:669
-#: events/models.py:987 registrations/models.py:210
+#: events/models.py:987 registrations/models.py:223
 msgid "Publisher"
 msgstr "Utgivare"
 
@@ -308,8 +308,8 @@ msgstr "Placera hemsida"
 msgid "Description"
 msgstr "Beskrivning"
 
-#: events/models.py:682 events/models.py:1485 registrations/models.py:727
-#: registrations/models.py:1023
+#: events/models.py:682 events/models.py:1485 registrations/models.py:812
+#: registrations/models.py:1118
 msgid "E-mail"
 msgstr "E-post"
 
@@ -321,7 +321,7 @@ msgstr "Telefon"
 msgid "Contact type"
 msgstr "Kontakt typ"
 
-#: events/models.py:690 registrations/models.py:58 registrations/models.py:847
+#: events/models.py:690 registrations/models.py:59 registrations/models.py:932
 msgid "Street address"
 msgstr "Gatuadress"
 
@@ -416,7 +416,7 @@ msgstr "Användarens organisation"
 msgid "Event organizer information."
 msgstr "Event arrangör information."
 
-#: events/models.py:947 registrations/models.py:869
+#: events/models.py:947 registrations/models.py:954
 msgid "User consent"
 msgstr "Användarens samtycke"
 
@@ -484,11 +484,11 @@ msgstr "Starttid"
 msgid "End time"
 msgstr "Sluttid"
 
-#: events/models.py:1038 registrations/models.py:275
+#: events/models.py:1038 registrations/models.py:288
 msgid "Minimum recommended age"
 msgstr "Rekommenderad lägsta ålder"
 
-#: events/models.py:1041 registrations/models.py:278
+#: events/models.py:1041 registrations/models.py:291
 msgid "Maximum recommended age"
 msgstr "Högsta rekommenderade ålder"
 
@@ -723,17 +723,17 @@ msgstr "Kunde inte kolla betalningsstatus från Talpa API."
 msgid "Could not check order status from Talpa API."
 msgstr "Kunde inte kolla beställningsstatus från Talpa API."
 
-#: registrations/api.py:607
+#: registrations/api.py:616
 msgid "Order marked as cancelled in webhook payload, but not in Talpa API."
 msgstr ""
 "Beställning markerad som avbruten i webhook-avisering, men inte i Talpa API."
 
-#: registrations/api.py:638
+#: registrations/api.py:647
 msgid "Payment marked as paid in webhook payload, but not in Talpa API."
 msgstr ""
 "Betalning markerad som betald i webhook-avisering, men inte i Talpa API."
 
-#: registrations/api.py:658
+#: registrations/api.py:667
 msgid "Payment marked as cancelled in webhook payload, but not in Talpa API."
 msgstr ""
 "Betalning markerad som avbruten i webhook-avisering, men inte i Talpa API."
@@ -746,12 +746,12 @@ msgstr "Begärkonflikt med målresursens aktuella tillstånd"
 msgid "Registered persons"
 msgstr "Registrerade personer"
 
-#: registrations/exports.py:49 registrations/models.py:974
+#: registrations/exports.py:49 registrations/models.py:1069
 msgid "Date of birth"
 msgstr "Födelsedatum"
 
-#: registrations/exports.py:53 registrations/models.py:57
-#: registrations/models.py:826 registrations/models.py:1027
+#: registrations/exports.py:53 registrations/models.py:58
+#: registrations/models.py:911 registrations/models.py:1122
 msgid "Phone number"
 msgstr "Telefonnummer"
 
@@ -787,21 +787,21 @@ msgstr ""
 msgid "Invalid registration ID(s) given."
 msgstr ""
 
-#: registrations/models.py:54 registrations/models.py:833
+#: registrations/models.py:55 registrations/models.py:918
 msgid "City"
 msgstr "Stad"
 
-#: registrations/models.py:55 registrations/models.py:812
-#: registrations/models.py:1008
+#: registrations/models.py:56 registrations/models.py:897
+#: registrations/models.py:1103
 msgid "First name"
 msgstr "Förnamn"
 
-#: registrations/models.py:56 registrations/models.py:819
-#: registrations/models.py:1015
+#: registrations/models.py:57 registrations/models.py:904
+#: registrations/models.py:1110
 msgid "Last name"
 msgstr "Efternamn"
 
-#: registrations/models.py:59 registrations/models.py:854
+#: registrations/models.py:60 registrations/models.py:939
 msgid "ZIP code"
 msgstr "Postnummer"
 
@@ -813,23 +813,23 @@ msgstr ""
 msgid "You can only provide signup_group or signup, not both."
 msgstr ""
 
-#: registrations/models.py:131
+#: registrations/models.py:144
 msgid "Created at"
 msgstr "Skapad kl"
 
-#: registrations/models.py:137
+#: registrations/models.py:150
 msgid "Modified at"
 msgstr "Ändrad kl"
 
-#: registrations/models.py:240
+#: registrations/models.py:253
 msgid "You may not delete a default price group."
 msgstr ""
 
-#: registrations/models.py:248
+#: registrations/models.py:261
 msgid "You may not edit a default price group."
 msgstr ""
 
-#: registrations/models.py:254
+#: registrations/models.py:267
 msgid ""
 "You may not change the publisher of a price group that has been used in "
 "registrations."
@@ -837,151 +837,159 @@ msgstr ""
 "Du får inte byta utgivare för en prisgrupp som har använts vid "
 "registreringar."
 
-#: registrations/models.py:282
+#: registrations/models.py:295
 msgid "Enrollment start time"
 msgstr "Starttid för anmälan"
 
-#: registrations/models.py:285
+#: registrations/models.py:298
 msgid "Enrollment end time"
 msgstr "Sluttid för anmälan"
 
-#: registrations/models.py:289
+#: registrations/models.py:302
 msgid "Confirmation message"
 msgstr "Bekräftelsemeddelande"
 
-#: registrations/models.py:292
+#: registrations/models.py:305
 msgid "Instructions"
 msgstr "Instruktioner"
 
-#: registrations/models.py:296
+#: registrations/models.py:309
 msgid "Maximum attendee capacity"
 msgstr "Maximal deltagarekapacitet"
 
-#: registrations/models.py:299
+#: registrations/models.py:312
 msgid "Minimum attendee capacity"
 msgstr "Minsta deltagarekapacitet"
 
-#: registrations/models.py:302
+#: registrations/models.py:315
 msgid "Waiting list capacity"
 msgstr "Väntelistans kapacitet"
 
-#: registrations/models.py:305
+#: registrations/models.py:318
 msgid "Maximum group size"
 msgstr "Maximal gruppstorlek"
 
-#: registrations/models.py:319
+#: registrations/models.py:332
 msgid "Mandatory fields"
 msgstr "Obligatoriska fält"
 
-#: registrations/models.py:592 registrations/models.py:874
+#: registrations/models.py:664 registrations/models.py:959
 msgid "Anonymization time"
 msgstr ""
 
-#: registrations/models.py:676
+#: registrations/models.py:758
 msgid "Group registration to event"
 msgstr "Gruppregistrering till evenemanget"
 
-#: registrations/models.py:677
+#: registrations/models.py:759
 msgid "Group registration to course"
 msgstr "Gruppregistrering till kursen"
 
-#: registrations/models.py:678
+#: registrations/models.py:760
 msgid "Group registration to volunteering"
 msgstr "Gruppregistrering till volontärarbetet"
 
-#: registrations/models.py:702
+#: registrations/models.py:773
+msgid "No price groups exist for signup group."
+msgstr ""
+
+#: registrations/models.py:787
 msgid "Extra info"
 msgstr "Ytterligare info"
 
-#: registrations/models.py:786
+#: registrations/models.py:871
 msgid "Waitlisted"
 msgstr "I kö"
 
-#: registrations/models.py:787
+#: registrations/models.py:872
 msgid "Attending"
 msgstr "Deltar"
 
-#: registrations/models.py:795
+#: registrations/models.py:880
 msgid "Not present"
 msgstr "Inte närvarande"
 
-#: registrations/models.py:796
+#: registrations/models.py:881
 msgid "Present"
 msgstr "Närvarande"
 
-#: registrations/models.py:840
+#: registrations/models.py:925
 msgid "Attendee status"
 msgstr "Deltagarstatus"
 
-#: registrations/models.py:862
+#: registrations/models.py:947
 msgid "Presence status"
 msgstr "Närvarostatus"
 
-#: registrations/models.py:959
+#: registrations/models.py:1052
 msgid "Registration to event"
 msgstr "Registreringen till evenemanget"
 
-#: registrations/models.py:960
+#: registrations/models.py:1053
 msgid "Registration to course"
 msgstr "Registreringen till kursen"
 
-#: registrations/models.py:961
+#: registrations/models.py:1054
 msgid "Registration to volunteering"
 msgstr "Registreringen till volontärarbetet"
 
-#: registrations/models.py:1050
+#: registrations/models.py:1062
+msgid "Price group does not exist for signup."
+msgstr ""
+
+#: registrations/models.py:1145
 msgid "Membership number"
 msgstr "Medlemsnummer"
 
-#: registrations/models.py:1058
+#: registrations/models.py:1153
 msgid "Notification type"
 msgstr "Aviseringstyp"
 
-#: registrations/models.py:1065
+#: registrations/models.py:1160
 msgid "Access code"
 msgstr ""
 
-#: registrations/models.py:1246
+#: registrations/models.py:1353
 msgid "Number of seats"
 msgstr "Antal platser"
 
-#: registrations/models.py:1252
+#: registrations/models.py:1359
 msgid "Seat reservation code"
 msgstr "Platsreservationskod"
 
-#: registrations/models.py:1255
+#: registrations/models.py:1362
 msgid "Timestamp"
 msgstr "Tidsstämpel"
 
-#: registrations/models.py:1295
+#: registrations/models.py:1402
 msgid "pcs"
 msgstr "st"
 
-#: registrations/models.py:1319
+#: registrations/models.py:1426
 msgid "Created"
 msgstr "Skapad"
 
-#: registrations/models.py:1320
+#: registrations/models.py:1427
 msgid "Paid"
 msgstr "Betalt"
 
-#: registrations/models.py:1321
+#: registrations/models.py:1428
 msgid "Cancelled"
 msgstr "Inställt"
 
-#: registrations/models.py:1322
+#: registrations/models.py:1429
 msgid "Refunded"
 msgstr "Återbetalat"
 
-#: registrations/models.py:1323
+#: registrations/models.py:1430
 msgid "Expired"
 msgstr "Utgått"
 
-#: registrations/models.py:1347
+#: registrations/models.py:1454
 msgid "Payment status"
 msgstr "Betalningens status"
 
-#: registrations/models.py:1361
+#: registrations/models.py:1468
 msgid "Expires at"
 msgstr "Utgår på"
 
@@ -1034,54 +1042,54 @@ msgstr "E-post"
 msgid "Both SMS and email."
 msgstr "Både SMS och e-post."
 
-#: registrations/notifications.py:42
+#: registrations/notifications.py:50
 #, python-format
 msgid "Event cancelled - %(event_name)s"
 msgstr "Evenemanget inställt - %(event_name)s"
 
-#: registrations/notifications.py:43
+#: registrations/notifications.py:51
 #, python-format
 msgid "Registration cancelled - %(event_name)s"
 msgstr "Registreringen avbruten - %(event_name)s"
 
-#: registrations/notifications.py:45 registrations/notifications.py:51
+#: registrations/notifications.py:53 registrations/notifications.py:60
 #, python-format
 msgid "Registration confirmation - %(event_name)s"
 msgstr "Bekräftelse av registrering - %(event_name)s"
 
-#: registrations/notifications.py:48
+#: registrations/notifications.py:57
 #, python-format
 msgid "Waiting list seat reserved - %(event_name)s"
 msgstr "Väntelista plats reserverad - %(event_name)s"
 
-#: registrations/notifications.py:54
+#: registrations/notifications.py:64
 #, python-format
 msgid "Registration payment expired - %(event_name)s"
 msgstr "Registreringsbetalning har gått ut - %(event_name)s"
 
-#: registrations/notifications.py:61
+#: registrations/notifications.py:71
 #, python-format
 msgid "Event %(event_name)s has been cancelled"
 msgstr "Evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:64
+#: registrations/notifications.py:74
 #, python-format
 msgid "Event %(event_name)s %(event_period)s has been cancelled"
 msgstr "Evenemanget %(event_name)s %(event_period)s har ställts in."
 
-#: registrations/notifications.py:71
+#: registrations/notifications.py:81
 #, python-format
 msgid ""
 "%(username)s, registration to the event %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:74
+#: registrations/notifications.py:84
 #, python-format
 msgid ""
 "%(username)s, registration to the course %(event_name)s has been cancelled."
 msgstr "%(username)s, anmälan till kursen %(event_name)s har ställts in."
 
-#: registrations/notifications.py:77
+#: registrations/notifications.py:87
 #, python-format
 msgid ""
 "%(username)s, registration to the volunteering %(event_name)s has been "
@@ -1089,22 +1097,22 @@ msgid ""
 msgstr ""
 "%(username)s, anmälan till volontärarbetet %(event_name)s har ställts in."
 
-#: registrations/notifications.py:82
+#: registrations/notifications.py:92
 #, python-format
 msgid "Registration to the event %(event_name)s has been cancelled."
 msgstr "Anmälan till evenemanget %(event_name)s har ställts in."
 
-#: registrations/notifications.py:85
+#: registrations/notifications.py:95
 #, python-format
 msgid "Registration to the course %(event_name)s has been cancelled."
 msgstr "Anmälan till kursen %(event_name)s har ställts in."
 
-#: registrations/notifications.py:88
+#: registrations/notifications.py:98
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been cancelled."
 msgstr "Anmälan till volontärarbetet %(event_name)s har ställts in."
 
-#: registrations/notifications.py:93
+#: registrations/notifications.py:103
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the event "
@@ -1113,7 +1121,7 @@ msgstr ""
 "Du har avbrutit din registrering till evenemanget <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:96
+#: registrations/notifications.py:106
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the course "
@@ -1121,7 +1129,7 @@ msgid ""
 msgstr ""
 "Du har avbrutit din registrering till kursen <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:99
+#: registrations/notifications.py:109
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the volunteering "
@@ -1130,7 +1138,7 @@ msgstr ""
 "Du har avbrutit din registrering till volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:105
+#: registrations/notifications.py:115
 #, python-format
 msgid ""
 "Your registration and payment for the event <strong>%(event_name)s</strong> "
@@ -1139,7 +1147,7 @@ msgstr ""
 "Din registrering och betalning för evenemanget <strong>%(event_name)s</"
 "strong> har ställts in."
 
-#: registrations/notifications.py:108
+#: registrations/notifications.py:118
 #, python-format
 msgid ""
 "Your registration and payment for the course <strong>%(event_name)s</strong> "
@@ -1148,7 +1156,7 @@ msgstr ""
 "Din registrering och betalning för kursen <strong>%(event_name)s</strong> "
 "har ställts in."
 
-#: registrations/notifications.py:111
+#: registrations/notifications.py:121
 #, python-format
 msgid ""
 "Your registration to the volunteering <strong>%(event_name)s</strong> has "
@@ -1157,22 +1165,22 @@ msgstr ""
 "Din registrering till volontärarbetet <strong>%(event_name)s</strong> har "
 "ställts in."
 
-#: registrations/notifications.py:121
+#: registrations/notifications.py:131
 #, python-format
 msgid "Registration to the event %(event_name)s has been saved."
 msgstr "Anmälan till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:124
+#: registrations/notifications.py:134
 #, python-format
 msgid "Registration to the course %(event_name)s has been saved."
 msgstr "Anmälan till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:127
+#: registrations/notifications.py:137
 #, python-format
 msgid "Registration to the volunteering %(event_name)s has been saved."
 msgstr "Anmälan till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:132
+#: registrations/notifications.py:142
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the event "
@@ -1181,7 +1189,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för evenemanget "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:135
+#: registrations/notifications.py:145
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the course "
@@ -1190,7 +1198,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för kursen <strong>%(event_name)s</"
 "strong>."
 
-#: registrations/notifications.py:138
+#: registrations/notifications.py:148
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the volunteering "
@@ -1199,29 +1207,29 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för volontärarbetet "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:145
+#: registrations/notifications.py:155
 #, python-format
 msgid "Group registration to the event %(event_name)s has been saved."
 msgstr "Gruppregistrering till evenemanget %(event_name)s har sparats."
 
-#: registrations/notifications.py:148
+#: registrations/notifications.py:158
 #, python-format
 msgid "Group registration to the course %(event_name)s has been saved."
 msgstr "Gruppregistrering till kursen %(event_name)s har sparats."
 
-#: registrations/notifications.py:151
+#: registrations/notifications.py:161
 #, python-format
 msgid "Group registration to the volunteering %(event_name)s has been saved."
 msgstr "Gruppregistrering till volontärarbetet %(event_name)s har sparats."
 
-#: registrations/notifications.py:160
+#: registrations/notifications.py:171
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the event %(event_name)s."
 msgstr ""
 "Betalning krävs för att bekräfta din anmälan till evenemanget %(event_name)s."
 
-#: registrations/notifications.py:170
+#: registrations/notifications.py:174
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the course "
@@ -1229,7 +1237,7 @@ msgid ""
 msgstr ""
 "Betalning krävs för att bekräfta din anmälan till kursen %(event_name)s."
 
-#: registrations/notifications.py:173
+#: registrations/notifications.py:177
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the volunteering "
@@ -1238,7 +1246,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till volontärarbetet "
 "%(event_name)s."
 
-#: registrations/notifications.py:179
+#: registrations/notifications.py:183
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the event "
@@ -1249,7 +1257,7 @@ msgstr ""
 "<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
 "%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:184
+#: registrations/notifications.py:188
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the course "
@@ -1260,7 +1268,7 @@ msgstr ""
 "<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
 "%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:189
+#: registrations/notifications.py:193
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the "
@@ -1271,7 +1279,7 @@ msgstr ""
 "<strong>%(event_name)s</strong>. Betalningslänken går ut efter "
 "%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:198
+#: registrations/notifications.py:202
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the event "
@@ -1280,7 +1288,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till evenemanget "
 "%(event_name)s."
 
-#: registrations/notifications.py:202
+#: registrations/notifications.py:206
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the course "
@@ -1289,7 +1297,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till kursen "
 "%(event_name)s."
 
-#: registrations/notifications.py:206
+#: registrations/notifications.py:210
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the volunteering "
@@ -1298,7 +1306,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till volontärarbetet "
 "%(event_name)s."
 
-#: registrations/notifications.py:216
+#: registrations/notifications.py:220
 #, python-format
 msgid ""
 "You have successfully registered for the event <strong>%(event_name)s</"
@@ -1307,7 +1315,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för evenemangets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:163
+#: registrations/notifications.py:223
 #, python-format
 msgid ""
 "You have successfully registered for the course <strong>%(event_name)s</"
@@ -1316,7 +1324,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för kursen <strong>%(event_name)s</"
 "strong> väntelista."
 
-#: registrations/notifications.py:166
+#: registrations/notifications.py:226
 #, python-format
 msgid ""
 "You have successfully registered for the volunteering "
@@ -1325,7 +1333,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för volontärarbetets "
 "<strong>%(event_name)s</strong> väntelista."
 
-#: registrations/notifications.py:171
+#: registrations/notifications.py:231
 msgid ""
 "You will be automatically transferred as an event participant if a seat "
 "becomes available."
@@ -1333,7 +1341,7 @@ msgstr ""
 "Du kommer automatiskt att överföras som evenemangsdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:174
+#: registrations/notifications.py:234
 msgid ""
 "You will be automatically transferred as a course participant if a seat "
 "becomes available."
@@ -1341,7 +1349,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som kursdeltagare om en plats blir "
 "ledig."
 
-#: registrations/notifications.py:177
+#: registrations/notifications.py:237
 msgid ""
 "You will be automatically transferred as a volunteering participant if a "
 "seat becomes available."
@@ -1349,7 +1357,7 @@ msgstr ""
 "Du kommer automatiskt att flyttas över som evenemangsdeltagare om en plats "
 "blir ledig."
 
-#: registrations/notifications.py:183
+#: registrations/notifications.py:243
 #, python-format
 msgid ""
 "The registration for the event <strong>%(event_name)s</strong> waiting list "
@@ -1358,7 +1366,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "evenemanget lyckades."
 
-#: registrations/notifications.py:186
+#: registrations/notifications.py:246
 #, python-format
 msgid ""
 "The registration for the course <strong>%(event_name)s</strong> waiting list "
@@ -1367,7 +1375,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-kursen "
 "lyckades."
 
-#: registrations/notifications.py:189
+#: registrations/notifications.py:249
 #, python-format
 msgid ""
 "The registration for the volunteering <strong>%(event_name)s</strong> "
@@ -1376,7 +1384,7 @@ msgstr ""
 "Registreringen till väntelistan för <strong>%(event_name)s</strong>-"
 "volontärarbetet lyckades."
 
-#: registrations/notifications.py:194
+#: registrations/notifications.py:254
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the event if a place becomes available."
@@ -1384,7 +1392,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "evenemanget om en plats blir ledig."
 
-#: registrations/notifications.py:197
+#: registrations/notifications.py:257
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the course if a place becomes available."
@@ -1392,7 +1400,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i kursen "
 "om en plats blir ledig."
 
-#: registrations/notifications.py:200
+#: registrations/notifications.py:260
 msgid ""
 "You will be automatically transferred from the waiting list to become a "
 "participant in the volunteering if a place becomes available."
@@ -1400,7 +1408,7 @@ msgstr ""
 "Du flyttas automatiskt över från väntelistan för att bli deltagare i "
 "volontärarbetet om en plats blir ledig."
 
-#: registrations/notifications.py:210
+#: registrations/notifications.py:270
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the event "
@@ -1409,7 +1417,7 @@ msgstr ""
 "Du har flyttats från väntelistan för evenemanget <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:213
+#: registrations/notifications.py:274
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the course "
@@ -1418,7 +1426,7 @@ msgstr ""
 "Du har flyttats från väntelistan för kursen <strong>%(event_name)s</strong> "
 "till en deltagare."
 
-#: registrations/notifications.py:216
+#: registrations/notifications.py:278
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the volunteering "
@@ -1427,65 +1435,7 @@ msgstr ""
 "Du har flyttats från väntelistan för volontärarbetet <strong>%(event_name)s</"
 "strong> till en deltagare."
 
-#: registrations/notifications.py:221
-msgid "Registration payment expired"
-msgstr "Registreringsbetalning har gått ut"
-
-#: registrations/notifications.py:224
-#, python-format
-msgid ""
-"Registration to the event %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Anmälan till evenemanget %(event_name)s har ställts in på grund av en "
-"utgången betalning."
-
-#: registrations/notifications.py:228
-#, python-format
-msgid ""
-"Registration to the course %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Anmälan till kursen %(event_name)s har ställts in på grund av en utgången "
-"betalning."
-
-#: registrations/notifications.py:232
-#, python-format
-msgid ""
-"Registration to the volunteering %(event_name)s has been cancelled due to an "
-"expired payment."
-msgstr ""
-"Anmälan till volontärarbetet %(event_name)s har ställts in på grund av en "
-"utgången betalning."
-
-#: registrations/notifications.py:238
-#, python-format
-msgid ""
-"Your registration to the event <strong>%(event_name)s</strong> has been "
-"cancelled due no payment received within the payment period."
-msgstr ""
-"Din registrering till evenemanget <strong>%(event_name)s</strong> har "
-"ställts in på grund av att ingen betalning mottagits inom betalningsperioden."
-
-#: registrations/notifications.py:242
-#, python-format
-msgid ""
-"Your registration to the course <strong>%(event_name)s</strong> has been "
-"cancelled due no payment received within the payment period."
-msgstr ""
-"Din registrering till kursen <strong>%(event_name)s</strong> har ställts in "
-"på grund av att ingen betalning mottagits inom betalningsperioden."
-
-#: registrations/notifications.py:246
-#, python-format
-msgid ""
-"Your registration to the volunteering <strong>%(event_name)s</strong> has "
-"been cancelled due no payment received within the payment period."
-msgstr ""
-"Din registrering till volontärarbetet <strong>%(event_name)s</strong> har "
-"ställts in på grund av att ingen betalning mottagits inom betalningsperioden."
-
-#: registrations/notifications.py:256
+#: registrations/notifications.py:288
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the event "
@@ -1498,7 +1448,7 @@ msgstr ""
 "för att bekräfta ditt deltagande. Betalningslänken går ut efter "
 "%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:290
+#: registrations/notifications.py:294
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the course "
@@ -1511,7 +1461,7 @@ msgstr ""
 "för att bekräfta ditt deltagande. Betalningslänken går ut efter "
 "%(expiration_hours)s timmar."
 
-#: registrations/notifications.py:296
+#: registrations/notifications.py:300
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the volunteering "
@@ -1525,31 +1475,89 @@ msgstr ""
 "%(expiration_hours)s timmar."
 
 #: registrations/notifications.py:308
+msgid "Registration payment expired"
+msgstr "Registreringsbetalning har gått ut"
+
+#: registrations/notifications.py:311
+#, python-format
+msgid ""
+"Registration to the event %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Anmälan till evenemanget %(event_name)s har ställts in på grund av en "
+"utgången betalning."
+
+#: registrations/notifications.py:315
+#, python-format
+msgid ""
+"Registration to the course %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Anmälan till kursen %(event_name)s har ställts in på grund av en utgången "
+"betalning."
+
+#: registrations/notifications.py:319
+#, python-format
+msgid ""
+"Registration to the volunteering %(event_name)s has been cancelled due to an "
+"expired payment."
+msgstr ""
+"Anmälan till volontärarbetet %(event_name)s har ställts in på grund av en "
+"utgången betalning."
+
+#: registrations/notifications.py:325
+#, python-format
+msgid ""
+"Your registration to the event <strong>%(event_name)s</strong> has been "
+"cancelled due no payment received within the payment period."
+msgstr ""
+"Din registrering till evenemanget <strong>%(event_name)s</strong> har "
+"ställts in på grund av att ingen betalning mottagits inom betalningsperioden."
+
+#: registrations/notifications.py:329
+#, python-format
+msgid ""
+"Your registration to the course <strong>%(event_name)s</strong> has been "
+"cancelled due no payment received within the payment period."
+msgstr ""
+"Din registrering till kursen <strong>%(event_name)s</strong> har ställts in "
+"på grund av att ingen betalning mottagits inom betalningsperioden."
+
+#: registrations/notifications.py:333
+#, python-format
+msgid ""
+"Your registration to the volunteering <strong>%(event_name)s</strong> has "
+"been cancelled due no payment received within the payment period."
+msgstr ""
+"Din registrering till volontärarbetet <strong>%(event_name)s</strong> har "
+"ställts in på grund av att ingen betalning mottagits inom betalningsperioden."
+
+#: registrations/notifications.py:343
 #, python-format
 msgid "Event cancelled - Recurring: %(event_name)s"
 msgstr "Evenemanget inställt - Serie: %(event_name)s"
 
-#: registrations/notifications.py:259
+#: registrations/notifications.py:346
 #, python-format
 msgid "Registration cancelled - Recurring: %(event_name)s"
 msgstr "Registreringen avbruten - Serie: %(event_name)s"
 
-#: registrations/notifications.py:262 registrations/notifications.py:268
+#: registrations/notifications.py:349 registrations/notifications.py:356
 #, python-format
 msgid "Registration confirmation - Recurring: %(event_name)s"
 msgstr "Bekräftelse av registrering - Serie: %(event_name)s"
 
-#: registrations/notifications.py:265
+#: registrations/notifications.py:353
 #, python-format
 msgid "Waiting list seat reserved - Recurring: %(event_name)s"
 msgstr "Väntelista plats reserverad - Serie: %(event_name)s"
 
-#: registrations/notifications.py:276
+#: registrations/notifications.py:365
 #, python-format
 msgid "Recurring event %(event_name)s %(event_period)s has been cancelled"
 msgstr "Serieevenemanget %(event_name)s %(event_period)s har ställts in."
 
-#: registrations/notifications.py:284
+#: registrations/notifications.py:373
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring event %(event_name)s "
@@ -1558,7 +1566,7 @@ msgstr ""
 "%(username)s, anmälan till serieevenemanget %(event_name)s %(event_period)s "
 "har ställts in."
 
-#: registrations/notifications.py:288
+#: registrations/notifications.py:377
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring course %(event_name)s "
@@ -1567,7 +1575,7 @@ msgstr ""
 "%(username)s, anmälan till seriekursen %(event_name)s %(event_period)s har "
 "ställts in."
 
-#: registrations/notifications.py:292
+#: registrations/notifications.py:381
 #, python-format
 msgid ""
 "%(username)s, registration to the recurring volunteering %(event_name)s "
@@ -1576,7 +1584,7 @@ msgstr ""
 "%(username)s, anmälan till serievolontärarbetet %(event_name)s "
 "%(event_period)s har ställts in."
 
-#: registrations/notifications.py:298
+#: registrations/notifications.py:387
 #, python-format
 msgid ""
 "Registration to the recurring event %(event_name)s %(event_period)s has been "
@@ -1584,7 +1592,7 @@ msgid ""
 msgstr ""
 "Anmälan till serieevenemanget %(event_name)s %(event_period)s har ställts in."
 
-#: registrations/notifications.py:302
+#: registrations/notifications.py:391
 #, python-format
 msgid ""
 "Registration to the recurring course %(event_name)s %(event_period)s has "
@@ -1592,7 +1600,7 @@ msgid ""
 msgstr ""
 "Anmälan till seriekursen %(event_name)s %(event_period)s har ställts in."
 
-#: registrations/notifications.py:306
+#: registrations/notifications.py:395
 #, python-format
 msgid ""
 "Registration to the recurring volunteering %(event_name)s %(event_period)s "
@@ -1601,7 +1609,7 @@ msgstr ""
 "Anmälan till serievolontärarbetet %(event_name)s %(event_period)s har "
 "ställts in."
 
-#: registrations/notifications.py:312
+#: registrations/notifications.py:401
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring event "
@@ -1610,7 +1618,7 @@ msgstr ""
 "Du har avbrutit din registrering till serieevenemanget "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:316
+#: registrations/notifications.py:405
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring course "
@@ -1619,7 +1627,7 @@ msgstr ""
 "Du har avbrutit din registrering till seriekursen <strong>%(event_name)s "
 "%(event_period)s</strong>."
 
-#: registrations/notifications.py:320
+#: registrations/notifications.py:409
 #, python-format
 msgid ""
 "You have successfully cancelled your registration to the recurring "
@@ -1628,7 +1636,7 @@ msgstr ""
 "Du har avbrutit din registrering till serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:330
+#: registrations/notifications.py:419
 #, python-format
 msgid ""
 "Registration to the recurring event %(event_name)s %(event_period)s has been "
@@ -1636,14 +1644,14 @@ msgid ""
 msgstr ""
 "Anmälan till serieevenemanget %(event_name)s %(event_period)s har sparats."
 
-#: registrations/notifications.py:334
+#: registrations/notifications.py:423
 #, python-format
 msgid ""
 "Registration to the recurring course %(event_name)s %(event_period)s has "
 "been saved."
 msgstr "Anmälan till seriekursen %(event_name)s %(event_period)s har sparats."
 
-#: registrations/notifications.py:338
+#: registrations/notifications.py:427
 #, python-format
 msgid ""
 "Registration to the recurring volunteering %(event_name)s %(event_period)s "
@@ -1652,7 +1660,7 @@ msgstr ""
 "Anmälan till serievolontärarbetet %(event_name)s %(event_period)s har "
 "sparats."
 
-#: registrations/notifications.py:344
+#: registrations/notifications.py:433
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1661,7 +1669,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för serieevenemanget "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:348
+#: registrations/notifications.py:437
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1670,7 +1678,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för seriekursen "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:352
+#: registrations/notifications.py:441
 #, python-format
 msgid ""
 "Congratulations! Your registration has been confirmed for the recurring "
@@ -1679,7 +1687,7 @@ msgstr ""
 "Grattis! Din registrering har bekräftats för serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong>."
 
-#: registrations/notifications.py:360
+#: registrations/notifications.py:449
 #, python-format
 msgid ""
 "Group registration to the recurring event %(event_name)s %(event_period)s "
@@ -1688,7 +1696,7 @@ msgstr ""
 "Gruppregistrering till serieevenemanget %(event_name)s %(event_period)s har "
 "sparats."
 
-#: registrations/notifications.py:364
+#: registrations/notifications.py:453
 #, python-format
 msgid ""
 "Group registration to the recurring course %(event_name)s %(event_period)s "
@@ -1697,7 +1705,7 @@ msgstr ""
 "Gruppregistrering till seriekursen %(event_name)s %(event_period)s har "
 "sparats."
 
-#: registrations/notifications.py:368
+#: registrations/notifications.py:457
 #, python-format
 msgid ""
 "Group registration to the recurring volunteering %(event_name)s "
@@ -1706,7 +1714,7 @@ msgstr ""
 "Gruppregistrering till serievolontärarbetet %(event_name)s %(event_period)s "
 "har sparats."
 
-#: registrations/notifications.py:378
+#: registrations/notifications.py:468
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring event "
@@ -1715,7 +1723,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till serieevenemanget "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:439
+#: registrations/notifications.py:472
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring course "
@@ -1724,7 +1732,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till seriekursen %(event_name)s "
 "%(event_period)s."
 
-#: registrations/notifications.py:443
+#: registrations/notifications.py:476
 #, python-format
 msgid ""
 "Payment is required to confirm your registration to the recurring "
@@ -1733,7 +1741,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din anmälan till serievolontärarbetet "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:449
+#: registrations/notifications.py:482
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1741,10 +1749,10 @@ msgid ""
 "expires in %(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till serieevenemanget "
-"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
-"går ut efter %(expiration_hours)s timmar."
+"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken går ut "
+"efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:454
+#: registrations/notifications.py:487
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1752,10 +1760,10 @@ msgid ""
 "expires in %(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till seriekursen "
-"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
-"går ut efter %(expiration_hours)s timmar."
+"<strong>%(event_name)s %(event_period)s</strong>. Betalningslänken går ut "
+"efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:459
+#: registrations/notifications.py:492
 #, python-format
 msgid ""
 "Please use the payment link to confirm your registration for the recurring "
@@ -1763,10 +1771,10 @@ msgid ""
 "link expires in %(expiration_hours)s hours."
 msgstr ""
 "Använd betalningslänken för att bekräfta din anmälan till "
-"serievolontärarbetet <strong>%(event_name)s %(event_period)s</strong>. Betalningslänken "
-"går ut efter %(expiration_hours)s timmar."
+"serievolontärarbetet <strong>%(event_name)s %(event_period)s</strong>. "
+"Betalningslänken går ut efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:468
+#: registrations/notifications.py:501
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1775,7 +1783,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till serieevenemanget "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:472
+#: registrations/notifications.py:505
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1784,7 +1792,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till seriekursen "
 "%(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:476
+#: registrations/notifications.py:509
 #, python-format
 msgid ""
 "Payment is required to confirm your group registration to the recurring "
@@ -1793,7 +1801,7 @@ msgstr ""
 "Betalning krävs för att bekräfta din gruppregistrering till "
 "serievolontärarbetet %(event_name)s %(event_period)s."
 
-#: registrations/notifications.py:486
+#: registrations/notifications.py:519
 #, python-format
 msgid ""
 "You have successfully registered for the recurring event "
@@ -1802,7 +1810,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för serieevenemangets "
 "<strong>%(event_name)s %(event_period)s</strong> väntelista."
 
-#: registrations/notifications.py:382
+#: registrations/notifications.py:523
 #, python-format
 msgid ""
 "You have successfully registered for the recurring course "
@@ -1811,7 +1819,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för seriekursen <strong>%(event_name)s "
 "%(event_period)s</strong> väntelista."
 
-#: registrations/notifications.py:386
+#: registrations/notifications.py:527
 #, python-format
 msgid ""
 "You have successfully registered for the recurring volunteering "
@@ -1820,7 +1828,7 @@ msgstr ""
 "Du har framgångsrikt registrerat dig för serievolontärarbetets "
 "<strong>%(event_name)s %(event_period)s</strong> väntelista."
 
-#: registrations/notifications.py:396
+#: registrations/notifications.py:537
 #, python-format
 msgid ""
 "The registration for the recurring event <strong>%(event_name)s "
@@ -1829,7 +1837,7 @@ msgstr ""
 "Registreringen till väntelistan för serieevenemanget <strong>%(event_name)s "
 "%(event_period)s</strong> lyckades."
 
-#: registrations/notifications.py:400
+#: registrations/notifications.py:541
 #, python-format
 msgid ""
 "The registration for the recurring course <strong>%(event_name)s "
@@ -1838,7 +1846,7 @@ msgstr ""
 "Registreringen till väntelistan för seriekursen <strong>%(event_name)s "
 "%(event_period)s</strong> lyckades."
 
-#: registrations/notifications.py:404
+#: registrations/notifications.py:545
 #, python-format
 msgid ""
 "The registration for the recurring volunteering <strong>%(event_name)s "
@@ -1847,7 +1855,7 @@ msgstr ""
 "Registreringen till väntelistan för serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong> lyckades."
 
-#: registrations/notifications.py:418
+#: registrations/notifications.py:559
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring event "
@@ -1856,7 +1864,7 @@ msgstr ""
 "Du har flyttats från väntelistan för serieevenemanget <strong>%(event_name)s "
 "%(event_period)s</strong> till en deltagare."
 
-#: registrations/notifications.py:422
+#: registrations/notifications.py:563
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring course "
@@ -1865,7 +1873,7 @@ msgstr ""
 "Du har flyttats från väntelistan för seriekursen <strong>%(event_name)s "
 "%(event_period)s</strong> till en deltagare."
 
-#: registrations/notifications.py:426
+#: registrations/notifications.py:567
 #, python-format
 msgid ""
 "You have been moved from the waiting list of the recurring volunteering "
@@ -1874,7 +1882,7 @@ msgstr ""
 "Du har flyttats från väntelistan för serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare."
 
-#: registrations/notifications.py:436
+#: registrations/notifications.py:577
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
@@ -1884,11 +1892,11 @@ msgid ""
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande. Betalningslänken "
-"går ut efter %(expiration_hours)s timmar."
+"betalningslänken för att bekräfta ditt deltagande. Betalningslänken går ut "
+"efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:550
-#,  python-format
+#: registrations/notifications.py:583
+#, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
 "course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
@@ -1897,10 +1905,10 @@ msgid ""
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för seriekursen "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande. Betalningslänken "
-"går ut efter %(expiration_hours)s timmar."
+"betalningslänken för att bekräfta ditt deltagande. Betalningslänken går ut "
+"efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:556
+#: registrations/notifications.py:589
 #, python-format
 msgid ""
 "You have been selected to be moved from the waiting list of the recurring "
@@ -1910,20 +1918,20 @@ msgid ""
 msgstr ""
 "Du har blivit utvald att flyttats från väntelistan för serievolontärarbetet "
 "<strong>%(event_name)s %(event_period)s</strong> till en deltagare. Använd "
-"betalningslänken för att bekräfta ditt deltagande. "
-"Betalningslänken går ut efter %(expiration_hours)s timmar."
+"betalningslänken för att bekräfta ditt deltagande. Betalningslänken går ut "
+"efter %(expiration_hours)s timmar."
 
-#: registrations/notifications.py:568
+#: registrations/notifications.py:601
 #, python-format
 msgid "Rights granted to the participant list - %(event_name)s"
 msgstr "Rättigheter tilldelade deltagarlistan - %(event_name)s"
 
-#: registrations/notifications.py:439
+#: registrations/notifications.py:604
 #, python-format
 msgid "Rights granted to the registration - %(event_name)s"
 msgstr "Rättigheter beviljade till registreringen - %(event_name)s"
 
-#: registrations/notifications.py:448
+#: registrations/notifications.py:613
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1932,7 +1940,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för evenemanget <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:451
+#: registrations/notifications.py:616
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1941,7 +1949,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för kursen <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:454
+#: registrations/notifications.py:619
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted the rights to "
@@ -1951,7 +1959,7 @@ msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
 "deltagarlistan för volontärarbetet <strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:461
+#: registrations/notifications.py:626
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1961,7 +1969,7 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av evenemanget "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:464
+#: registrations/notifications.py:629
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -1972,7 +1980,7 @@ msgstr ""
 "ersättningsanvändarrättigheter till registreringen av kursen "
 "<strong>%(event_name)s</strong>."
 
-#: registrations/notifications.py:467
+#: registrations/notifications.py:632
 #, python-format
 msgid ""
 "The e-mail address <strong>%(email)s</strong> has been granted substitute "
@@ -2148,10 +2156,10 @@ msgstr "Ett meddelande om volontärarbetet %(event_name)s."
 msgid "View the participants"
 msgstr "Se deltagarna"
 
-#: registrations/utils.py:156
+#: registrations/utils.py:188
 msgid "Unknown Talpa web store API error"
 msgstr ""
 
-#: registrations/utils.py:159
+#: registrations/utils.py:191
 msgid "Talpa web store API error"
 msgstr ""

--- a/registrations/api.py
+++ b/registrations/api.py
@@ -573,6 +573,15 @@ class WebStoreWebhookViewSet(AuditLogApiViewMixin, viewsets.ViewSet):
         if not contact_person:
             return
 
+        if (
+            getattr(signup_or_signup_group, "attendee_status", "")
+            == SignUp.AttendeeStatus.WAITING_LIST
+        ):
+            # In this case, the signup has probably been in waiting list until they've
+            # received a payment link and made the payment.
+            signup_or_signup_group.attendee_status = SignUp.AttendeeStatus.ATTENDING
+            signup_or_signup_group.save(update_fields=["attendee_status"])
+
         access_code = get_access_code_for_contact_person(
             contact_person, signup_or_signup_group.created_by
         )

--- a/registrations/exceptions.py
+++ b/registrations/exceptions.py
@@ -12,3 +12,7 @@ class ConflictException(APIException):
 
 class PriceGroupValidationError(ValidationError):
     pass
+
+
+class WebStoreAPIError(ValidationError):
+    pass

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -37,6 +37,7 @@ from registrations.notifications import (
 from registrations.utils import (
     code_validity_duration,
     create_event_ics_file_content,
+    create_web_store_api_order,
     get_email_noreply_address,
     get_ui_locales,
     strip_trailing_zeroes_from_decimal,
@@ -426,19 +427,47 @@ class Registration(CreatedModifiedBaseModel):
             waiting_list_capacity - waiting_list_count - reserved_seats_amount, 0
         )
 
-    def move_first_waitlisted_to_attending(self):
+    def get_first_waitlisted(self):
         waitlisted = (
-            self.signups.filter(
-                attendee_status=SignUp.AttendeeStatus.WAITING_LIST,
-            )
+            self.signups.filter(attendee_status=SignUp.AttendeeStatus.WAITING_LIST)
             .select_for_update()
             .order_by("id")
         )
 
-        if not waitlisted.exists():
+        return waitlisted[0] if waitlisted else None
+
+    def move_first_waitlisted_to_attending_with_payment_link(self):
+        first_on_list = self.get_first_waitlisted()
+        if not first_on_list:
             return
 
-        first_on_list = waitlisted[0]
+        try:
+            payment = (
+                first_on_list.create_web_store_payment()
+                if first_on_list.price_group.price > 0
+                else None
+            )
+        except (ValidationError, AttributeError) as exc:
+            logger.error(
+                f"Failed to create payment when moving waitlisted signup #{first_on_list.pk} "
+                f"to attending: {exc}"
+            )
+            return
+
+        if not payment:
+            self.move_first_waitlisted_to_attending(first_on_list)
+        else:
+            contact_person = first_on_list.actual_contact_person
+            contact_person.send_notification(
+                SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
+                payment_link=payment.logged_in_checkout_url or payment.checkout_url,
+            )
+
+    def move_first_waitlisted_to_attending(self, first_on_list=None):
+        first_on_list = first_on_list or self.get_first_waitlisted()
+        if not first_on_list:
+            return
+
         first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
         first_on_list.save(update_fields=["attendee_status"])
 
@@ -535,6 +564,37 @@ class SignUpMixin:
 
     def is_user_editable_resources(self):
         return bool(self.data_source and self.data_source.user_editable_resources)
+
+    def create_web_store_payment(self):
+        if isinstance(self, SignUp):
+            kwargs = {"signup": self}
+        else:
+            kwargs = {"signup_group": self}
+
+        kwargs["expires_at"] = localtime() + timedelta(
+            hours=settings.WEB_STORE_ORDER_EXPIRATION_HOURS
+        )
+
+        api_response = create_web_store_api_order(self, kwargs["expires_at"])
+
+        if api_response.get("orderId"):
+            kwargs["external_order_id"] = api_response["orderId"]
+
+        if api_response.get("priceTotal"):
+            kwargs["amount"] = Decimal(api_response["priceTotal"])
+        else:
+            kwargs["amount"] = self.total_payment_amount
+
+        if api_response.get("checkoutUrl"):
+            kwargs["checkout_url"] = api_response["checkoutUrl"]
+
+        if api_response.get("loggedInCheckoutUrl"):
+            kwargs["logged_in_checkout_url"] = api_response["loggedInCheckoutUrl"]
+
+        kwargs["created_by"] = self.created_by
+        kwargs["last_modified_by"] = self.created_by
+
+        return SignUpPayment.objects.create(**kwargs)
 
     @property
     def web_store_meta_label(self):
@@ -703,16 +763,19 @@ class SignUpGroup(
         return labels[self.registration.event.type_id]
 
     def add_price_groups_to_web_store_order_data(self, order_data):
-        for signup in (
+        signups_with_price_groups = (
             self.signups.select_related("price_group")
             .filter(price_group__isnull=False)
             .order_by("pk")
-        ):
+        )
+        if not signups_with_price_groups.exists():
+            raise PriceGroupValidationError(
+                _("No price groups exist for signup group.")
+            )
+
+        for signup in signups_with_price_groups:
             signup_price_group = getattr(signup, "price_group", None)
-            if signup_price_group:
-                self.add_price_group_to_web_store_order_data(
-                    signup_price_group, order_data
-                )
+            self.add_price_group_to_web_store_order_data(signup_price_group, order_data)
 
 
 class SignUpProtectedDataBaseModel(models.Model):
@@ -995,8 +1058,10 @@ class SignUp(
 
     def add_price_groups_to_web_store_order_data(self, order_data):
         signup_price_group = getattr(self, "price_group", None)
-        if signup_price_group:
-            self.add_price_group_to_web_store_order_data(signup_price_group, order_data)
+        if not signup_price_group:
+            raise PriceGroupValidationError(_("Price group does not exist for signup."))
+
+        self.add_price_group_to_web_store_order_data(signup_price_group, order_data)
 
 
 class SignUpProtectedData(SignUpProtectedDataBaseModel, SoftDeletableBaseModel):
@@ -1181,7 +1246,11 @@ class SignUpContactPerson(
         )
 
     def get_notification_message(
-        self, notification_type, access_code=None, is_sub_event_cancellation=False
+        self,
+        notification_type,
+        access_code=None,
+        is_sub_event_cancellation=False,
+        payment_link=None,
     ):
         [_, linked_registrations_ui_locale] = get_ui_locales(self.service_language)
 
@@ -1194,8 +1263,10 @@ class SignUpContactPerson(
             email_template = "cancellation_confirmation.html"
         elif notification_type in (
             SignUpNotificationType.CONFIRMATION,
+            SignUpNotificationType.CONFIRMATION_WITH_PAYMENT,
             SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST,
             SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT,
+            SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
         ):
             email_template = "common_signup_confirmation.html"
         else:
@@ -1210,6 +1281,7 @@ class SignUpContactPerson(
                 notification_type,
                 is_sub_event_cancellation=is_sub_event_cancellation,
             )
+            email_variables["payment_url"] = payment_link
 
             rendered_body = render_to_string(
                 email_template,
@@ -1228,12 +1300,17 @@ class SignUpContactPerson(
         )
 
     def send_notification(
-        self, notification_type, access_code=None, is_sub_event_cancellation=False
+        self,
+        notification_type,
+        access_code=None,
+        is_sub_event_cancellation=False,
+        payment_link=None,
     ):
         message = self.get_notification_message(
             notification_type,
             access_code=access_code,
             is_sub_event_cancellation=is_sub_event_cancellation,
+            payment_link=payment_link,
         )
         rendered_body = message[1]
 

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -460,7 +460,7 @@ class Registration(CreatedModifiedBaseModel):
             contact_person = first_on_list.actual_contact_person
             contact_person.send_notification(
                 SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
-                payment_link=payment.logged_in_checkout_url or payment.checkout_url,
+                payment_link=payment.checkout_url,
             )
 
     def move_first_waitlisted_to_attending(self, first_on_list=None):

--- a/registrations/notifications.py
+++ b/registrations/notifications.py
@@ -181,15 +181,18 @@ signup_email_texts = {
         "text": {
             Event.TypeId.GENERAL: _(
                 "Please use the payment link to confirm your registration for the event "
-                "<strong>%(event_name)s</strong>."
+                "<strong>%(event_name)s</strong>. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.COURSE: _(
                 "Please use the payment link to confirm your registration for the course "
-                "<strong>%(event_name)s</strong>."
+                "<strong>%(event_name)s</strong>. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.VOLUNTEERING: _(
                 "Please use the payment link to confirm your registration for the volunteering "
-                "<strong>%(event_name)s</strong>."
+                "<strong>%(event_name)s</strong>. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
         },
         "group": {
@@ -284,17 +287,20 @@ signup_email_texts = {
             Event.TypeId.GENERAL: _(
                 "You have been selected to be moved from the waiting list of the event "
                 "<strong>%(event_name)s</strong> to a participant. Please use the "
-                "payment link to confirm your participation."
+                "payment link to confirm your participation. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.COURSE: _(
                 "You have been selected to be moved from the waiting list of the course "
                 "<strong>%(event_name)s</strong> to a participant. Please use the "
-                "payment link to confirm your participation."
+                "payment link to confirm your participation. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.VOLUNTEERING: _(
                 "You have been selected to be moved from the waiting list of the volunteering "
                 "<strong>%(event_name)s</strong> to a participant. Please use the "
-                "payment link to confirm your participation."
+                "payment link to confirm your participation. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
         },
     },
@@ -474,15 +480,18 @@ recurring_event_signup_email_texts = {
         "text": {
             Event.TypeId.GENERAL: _(
                 "Please use the payment link to confirm your registration for the recurring event "
-                "<strong>%(event_name)s %(event_period)s</strong>."
+                "<strong>%(event_name)s %(event_period)s</strong>. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.COURSE: _(
                 "Please use the payment link to confirm your registration for the recurring course "
-                "<strong>%(event_name)s %(event_period)s</strong>."
+                "<strong>%(event_name)s %(event_period)s</strong>. The payment link expires in "
+                "%(expiration_hours)s hours."
             ),
             Event.TypeId.VOLUNTEERING: _(
                 "Please use the payment link to confirm your registration for the recurring "
-                "volunteering <strong>%(event_name)s %(event_period)s</strong>."
+                "volunteering <strong>%(event_name)s %(event_period)s</strong>. The payment link "
+                "expires in %(expiration_hours)s hours."
             ),
         },
         "group": {
@@ -567,17 +576,20 @@ recurring_event_signup_email_texts = {
             Event.TypeId.GENERAL: _(
                 "You have been selected to be moved from the waiting list of the recurring "
                 "event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-                "Please use the payment link to confirm your participation."
+                "Please use the payment link to confirm your participation. The payment link "
+                "expires in %(expiration_hours)s hours."
             ),
             Event.TypeId.COURSE: _(
                 "You have been selected to be moved from the waiting list of the recurring "
                 "course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-                "Please use the payment link to confirm your participation."
+                "Please use the payment link to confirm your participation. The payment link "
+                "expires in %(expiration_hours)s hours."
             ),
             Event.TypeId.VOLUNTEERING: _(
                 "You have been selected to be moved from the waiting list of the recurring "
                 "volunteering <strong>%(event_name)s %(event_period)s</strong> to a participant. "
-                "Please use the payment link to confirm your participation."
+                "Please use the payment link to confirm your participation. The payment link "
+                "expires in %(expiration_hours)s hours."
             ),
         },
     },
@@ -624,11 +636,17 @@ registration_user_access_invitation_texts = {
 }
 
 
-def _get_event_text_kwargs(event_name, event_period=None):
+def _get_event_text_kwargs(event_name, event_period=None, notification_type=None):
     kwargs = {"event_name": event_name}
 
     if event_period is not None:
         kwargs["event_period"] = event_period
+
+    if notification_type is not None and notification_type in (
+        SignUpNotificationType.CONFIRMATION_WITH_PAYMENT,
+        SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
+    ):
+        kwargs["expiration_hours"] = settings.WEB_STORE_ORDER_EXPIRATION_HOURS
 
     return kwargs
 
@@ -654,9 +672,16 @@ def _get_event_cancellation_texts(
 
 
 def _get_notification_texts(
-    text_options, event_type_id, event_name, event_period, contact_person
+    text_options,
+    event_type_id,
+    event_name,
+    event_period,
+    contact_person,
+    notification_type,
 ):
-    event_text_kwargs = _get_event_text_kwargs(event_name, event_period=event_period)
+    event_text_kwargs = _get_event_text_kwargs(
+        event_name, event_period=event_period, notification_type=notification_type
+    )
 
     if contact_person.first_name:
         texts = {
@@ -791,6 +816,7 @@ def get_signup_notification_texts(
             event_name,
             event_period,
             contact_person,
+            notification_type,
         )
 
     if notification_type == SignUpNotificationType.CANCELLATION:

--- a/registrations/notifications.py
+++ b/registrations/notifications.py
@@ -10,6 +10,12 @@ CONFIRMATION_HEADING_WITHOUT_USERNAME = _("Welcome")
 CONFIRMATION_TO_WAITING_LIST_HEADING = _(
     "Thank you for signing up for the waiting list"
 )
+CONFIRMATION_WITH_PAYMENT_HEADING = _(
+    "Payment required for registration confirmation - %(event_name)s"
+)
+CONFIRMATION_WITH_PAYMENT_HEADING_RECURRING = _(
+    "Payment required for registration confirmation - Recurring: %(event_name)s"
+)
 EVENT_CANCELLED_TEXT = _("Thank you for your interest in the event.")
 REGISTRATION_CANCELLED_HEADING = _("Registration cancelled")
 
@@ -33,8 +39,10 @@ class SignUpNotificationType:
     EVENT_CANCELLATION = "event_cancellation"
     CANCELLATION = "cancellation"
     CONFIRMATION = "confirmation"
+    CONFIRMATION_WITH_PAYMENT = "confirmation_with_payment"
     CONFIRMATION_TO_WAITING_LIST = "confirmation_to_waiting_list"
     TRANSFERRED_AS_PARTICIPANT = "transferred_as_participant"
+    TRANSFER_AS_PARTICIPANT_WITH_PAYMENT = "transfer_as_participant_with_payment"
     PAYMENT_EXPIRED = "payment_expired"
 
 
@@ -44,12 +52,14 @@ signup_notification_subjects = {
     SignUpNotificationType.CONFIRMATION: _(
         "Registration confirmation - %(event_name)s"
     ),
+    SignUpNotificationType.CONFIRMATION_WITH_PAYMENT: CONFIRMATION_WITH_PAYMENT_HEADING,
     SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: _(
         "Waiting list seat reserved - %(event_name)s"
     ),
     SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT: _(
         "Registration confirmation - %(event_name)s"
     ),
+    SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT: CONFIRMATION_WITH_PAYMENT_HEADING,
     SignUpNotificationType.PAYMENT_EXPIRED: _(
         "Registration payment expired - %(event_name)s"
     ),
@@ -153,6 +163,53 @@ signup_email_texts = {
             },
         },
     },
+    SignUpNotificationType.CONFIRMATION_WITH_PAYMENT: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "secondary_heading": {
+            Event.TypeId.GENERAL: _(
+                "Payment is required to confirm your registration to the event %(event_name)s."
+            ),
+            Event.TypeId.COURSE: _(
+                "Payment is required to confirm your registration to the course %(event_name)s."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Payment is required to confirm your registration to the volunteering "
+                "%(event_name)s."
+            ),
+        },
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "Please use the payment link to confirm your registration for the event "
+                "<strong>%(event_name)s</strong>."
+            ),
+            Event.TypeId.COURSE: _(
+                "Please use the payment link to confirm your registration for the course "
+                "<strong>%(event_name)s</strong>."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Please use the payment link to confirm your registration for the volunteering "
+                "<strong>%(event_name)s</strong>."
+            ),
+        },
+        "group": {
+            "heading": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+            "secondary_heading": {
+                Event.TypeId.GENERAL: _(
+                    "Payment is required to confirm your group registration to the event "
+                    "%(event_name)s."
+                ),
+                Event.TypeId.COURSE: _(
+                    "Payment is required to confirm your group registration to the course "
+                    "%(event_name)s."
+                ),
+                Event.TypeId.VOLUNTEERING: _(
+                    "Payment is required to confirm your group registration to the volunteering "
+                    "%(event_name)s."
+                ),
+            },
+        },
+    },
     SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: {
         "heading": CONFIRMATION_TO_WAITING_LIST_HEADING,
         "text": {
@@ -207,13 +264,37 @@ signup_email_texts = {
         "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
         "text": {
             Event.TypeId.GENERAL: _(
-                "You have been moved from the waiting list of the event <strong>%(event_name)s</strong> to a participant."  # noqa E501
+                "You have been moved from the waiting list of the event "
+                "<strong>%(event_name)s</strong> to a participant."
             ),
             Event.TypeId.COURSE: _(
-                "You have been moved from the waiting list of the course <strong>%(event_name)s</strong> to a participant."  # noqa E501
+                "You have been moved from the waiting list of the course "
+                "<strong>%(event_name)s</strong> to a participant."
             ),
             Event.TypeId.VOLUNTEERING: _(
-                "You have been moved from the waiting list of the volunteering <strong>%(event_name)s</strong> to a participant."  # noqa E501
+                "You have been moved from the waiting list of the volunteering "
+                "<strong>%(event_name)s</strong> to a participant."
+            ),
+        },
+    },
+    SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "You have been selected to be moved from the waiting list of the event "
+                "<strong>%(event_name)s</strong> to a participant. Please use the "
+                "payment link to confirm your participation."
+            ),
+            Event.TypeId.COURSE: _(
+                "You have been selected to be moved from the waiting list of the course "
+                "<strong>%(event_name)s</strong> to a participant. Please use the "
+                "payment link to confirm your participation."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "You have been selected to be moved from the waiting list of the volunteering "
+                "<strong>%(event_name)s</strong> to a participant. Please use the "
+                "payment link to confirm your participation."
             ),
         },
     },
@@ -261,12 +342,14 @@ recurring_event_signup_notification_subjects = {
     SignUpNotificationType.CONFIRMATION: _(
         "Registration confirmation - Recurring: %(event_name)s"
     ),
+    SignUpNotificationType.CONFIRMATION_WITH_PAYMENT: CONFIRMATION_WITH_PAYMENT_HEADING_RECURRING,
     SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: _(
         "Waiting list seat reserved - Recurring: %(event_name)s"
     ),
     SignUpNotificationType.TRANSFERRED_AS_PARTICIPANT: _(
         "Registration confirmation - Recurring: %(event_name)s"
     ),
+    SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT: CONFIRMATION_WITH_PAYMENT_HEADING_RECURRING,
 }
 
 
@@ -371,6 +454,55 @@ recurring_event_signup_email_texts = {
             },
         },
     },
+    SignUpNotificationType.CONFIRMATION_WITH_PAYMENT: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "secondary_heading": {
+            Event.TypeId.GENERAL: _(
+                "Payment is required to confirm your registration to the recurring event "
+                "%(event_name)s %(event_period)s."
+            ),
+            Event.TypeId.COURSE: _(
+                "Payment is required to confirm your registration to the recurring course "
+                "%(event_name)s %(event_period)s."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Payment is required to confirm your registration to the recurring volunteering "
+                "%(event_name)s %(event_period)s."
+            ),
+        },
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "Please use the payment link to confirm your registration for the recurring event "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.COURSE: _(
+                "Please use the payment link to confirm your registration for the recurring course "
+                "<strong>%(event_name)s %(event_period)s</strong>."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "Please use the payment link to confirm your registration for the recurring "
+                "volunteering <strong>%(event_name)s %(event_period)s</strong>."
+            ),
+        },
+        "group": {
+            "heading": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+            "secondary_heading": {
+                Event.TypeId.GENERAL: _(
+                    "Payment is required to confirm your group registration to the recurring "
+                    "event %(event_name)s %(event_period)s."
+                ),
+                Event.TypeId.COURSE: _(
+                    "Payment is required to confirm your group registration to the recurring "
+                    "course %(event_name)s %(event_period)s."
+                ),
+                Event.TypeId.VOLUNTEERING: _(
+                    "Payment is required to confirm your group registration to the recurring "
+                    "volunteering %(event_name)s %(event_period)s."
+                ),
+            },
+        },
+    },
     SignUpNotificationType.CONFIRMATION_TO_WAITING_LIST: {
         "heading": CONFIRMATION_TO_WAITING_LIST_HEADING,
         "text": {
@@ -425,6 +557,27 @@ recurring_event_signup_email_texts = {
             Event.TypeId.VOLUNTEERING: _(
                 "You have been moved from the waiting list of the recurring volunteering "
                 "<strong>%(event_name)s %(event_period)s</strong> to a participant."
+            ),
+        },
+    },
+    SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT: {
+        "heading": CONFIRMATION_HEADING_WITH_USERNAME,
+        "heading_without_username": CONFIRMATION_HEADING_WITHOUT_USERNAME,
+        "text": {
+            Event.TypeId.GENERAL: _(
+                "You have been selected to be moved from the waiting list of the recurring "
+                "event <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+                "Please use the payment link to confirm your participation."
+            ),
+            Event.TypeId.COURSE: _(
+                "You have been selected to be moved from the waiting list of the recurring "
+                "course <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+                "Please use the payment link to confirm your participation."
+            ),
+            Event.TypeId.VOLUNTEERING: _(
+                "You have been selected to be moved from the waiting list of the recurring "
+                "volunteering <strong>%(event_name)s %(event_period)s</strong> to a participant. "
+                "Please use the payment link to confirm your participation."
             ),
         },
     },

--- a/registrations/templates/_open_payment_link_button.html
+++ b/registrations/templates/_open_payment_link_button.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+<div class="cta-button-wrapper" style="margin: 0px 0px 40px">
+  <a href="{{payment_url}}" target="_blank" rel="noopener" class="cta-button" style="background:#0000bf;border-radius:0px;border:none;height:56px;text-align:center;text-decoration:none;vertical-align:middle;padding:16px 24px;box-sizing:border-box;display:inline-block;">
+    <span style="color:#ffffff;font-size:16px;font-weight:500;line-height:24px;">
+      {% blocktranslate %}Open payment link{% endblocktranslate %}
+    </span>
+    <img alt="" aria-hidden="true" src="{{linked_events_ui_url}}/images/email/icon-arrow-right-white.png" style="height:24px;width:24px;margin-left:16px;vertical-align:top;" />
+  </a>
+</div>

--- a/registrations/templates/common_signup_confirmation.html
+++ b/registrations/templates/common_signup_confirmation.html
@@ -33,7 +33,11 @@
               </p>
             {% endif %}
           </div>
-          {% include "_open_registration_button.html" %}
+          {% if payment_url %}
+            {% include "_open_payment_link_button.html" %}
+          {% else %}
+            {% include "_open_registration_button.html" %}
+          {% endif %}
       </div>
     </td>
   </tr>

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch, PropertyMock
 
 import pytest
+from django.conf import settings
 from django.core import mail
 from django.utils import translation
 from django.utils.timezone import localtime
@@ -1128,21 +1129,24 @@ def test_soft_deleted_signup_is_not_moved_to_attending_from_waiting_list(
             "Payment required for registration confirmation - Foo",
             "You have been selected to be moved from the waiting list of the event "
             "<strong>Foo</strong> to a participant. Please use the "
-            "payment link to confirm your participation.",
+            "payment link to confirm your participation. The payment link expires in "
+            "%(hours)s hours" % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "fi",
             "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
             "Sinut on valittu siirrettäväksi tapahtuman <strong>Foo</strong> "
             "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-            "vahvistaaksesi osallistumisesi.",
+            "vahvistaaksesi osallistumisesi. Maksulinkki vanhenee %(hours)s tunnin kuluttua."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "sv",
             "Betalning krävs för bekräftelse av registreringen - Foo",
             "Du har blivit utvald att flyttats från väntelistan för evenemanget "
             "<strong>Foo</strong> till en deltagare. Använd betalningslänken "
-            "för att bekräfta ditt deltagande.",
+            "för att bekräfta ditt deltagande. Betalningslänken går ut efter %(hours)s timmar."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
     ],
 )
@@ -1224,21 +1228,25 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist(
             "Payment required for registration confirmation - Recurring: Foo",
             "You have been selected to be moved from the waiting list of the recurring event "
             "<strong>Foo 1 Feb 2024 - 29 Feb 2024</strong> to a participant. Please use the "
-            "payment link to confirm your participation.",
+            "payment link to confirm your participation. The payment link expires in "
+            "%(hours)s hours." % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "fi",
             "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Sarja: Foo",
             "Sinut on valittu siirrettäväksi sarjatapahtuman "
             "<strong>Foo 1.2.2024 - 29.2.2024</strong> jonotuslistalta osallistujaksi. Ole hyvä "
-            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi.",
+            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+            "%(hours)s tunnin kuluttua."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "sv",
             "Betalning krävs för bekräftelse av registreringen - Serie: Foo",
             "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
             "<strong>Foo 1.2.2024 - 29.2.2024</strong> till en deltagare. Använd betalningslänken "
-            "för att bekräfta ditt deltagande.",
+            "för att bekräfta ditt deltagande. Betalningslänken går ut efter %(hours)s timmar."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
     ],
 )

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1208,7 +1208,11 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist(
     assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
 
     assert_payment_link_email_sent(
-        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+        contact_person2,
+        SignUpPayment.objects.first(),
+        expected_mailbox_length=2,
+        expected_subject=expected_subject,
+        expected_text=expected_text,
     )
 
 
@@ -1306,7 +1310,11 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist_for_
     assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
 
     assert_payment_link_email_sent(
-        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+        contact_person2,
+        SignUpPayment.objects.first(),
+        expected_mailbox_length=2,
+        expected_subject=expected_subject,
+        expected_text=expected_text,
     )
 
 

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from decimal import Decimal
 from unittest.mock import patch, PropertyMock
 
 import pytest
@@ -13,19 +14,31 @@ from events.models import Event
 from events.tests.factories import LanguageFactory
 from events.tests.utils import versioned_reverse as reverse
 from helevents.tests.factories import UserFactory
-from registrations.models import SignUp, SignUpContactPerson, SignUpPriceGroup
+from registrations.models import (
+    SignUp,
+    SignUpContactPerson,
+    SignUpPayment,
+    SignUpPriceGroup,
+)
 from registrations.tests.factories import (
     RegistrationFactory,
+    RegistrationPriceGroupFactory,
     RegistrationUserAccessFactory,
     SeatReservationCodeFactory,
     SignUpContactPersonFactory,
     SignUpFactory,
     SignUpGroupFactory,
+    SignUpPaymentFactory,
     SignUpPriceGroupFactory,
 )
 from registrations.tests.test_registration_post import hel_email
 from registrations.tests.test_signup_post import assert_create_signups
-from registrations.tests.utils import create_user_by_role
+from registrations.tests.utils import (
+    assert_payment_link_email_sent,
+    create_user_by_role,
+    get_web_store_order_response,
+)
+from web_store.tests.utils import get_mock_response
 
 # === util methods ===
 
@@ -1105,3 +1118,350 @@ def test_soft_deleted_signup_is_not_moved_to_attending_from_waiting_list(
     # The deleted signup will get a cancellation email, but the soft deleted one will not get any.
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject.startswith("Ilmoittautuminen peruttu")
+
+
+@pytest.mark.parametrize(
+    "service_language,expected_subject,expected_text",
+    [
+        (
+            "en",
+            "Payment required for registration confirmation - Foo",
+            "You have been selected to be moved from the waiting list of the event "
+            "<strong>Foo</strong> to a participant. Please use the "
+            "payment link to confirm your participation.",
+        ),
+        (
+            "fi",
+            "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
+            "Sinut on valittu siirrettäväksi tapahtuman <strong>Foo</strong> "
+            "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
+            "vahvistaaksesi osallistumisesi.",
+        ),
+        (
+            "sv",
+            "Betalning krävs för bekräftelse av registreringen - Foo",
+            "Du har blivit utvald att flyttats från väntelistan för evenemanget "
+            "<strong>Foo</strong> till en deltagare. Använd betalningslänken "
+            "för att bekräfta ditt deltagande.",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_send_email_with_payment_link_when_moving_participant_from_waitlist(
+    api_client,
+    service_language,
+    expected_subject,
+    expected_text,
+):
+    language = LanguageFactory(pk=service_language, service_language=True)
+
+    with translation.override(service_language):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.ATTENDING
+    )
+    SignUpContactPersonFactory(
+        signup=signup, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        json_return_value=get_web_store_order_response()
+    )
+    with (
+        translation.override(service_language),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup(
+            api_client, signup.id, signup_count=2, contact_person_count=2
+        )
+
+    assert SignUpPayment.objects.count() == 1
+
+    # Signup 2 status is not changed until a webhook notification updates the status.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    assert_payment_link_email_sent(
+        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+    )
+
+
+@pytest.mark.parametrize(
+    "service_language,expected_subject,expected_text",
+    [
+        (
+            "en",
+            "Payment required for registration confirmation - Recurring: Foo",
+            "You have been selected to be moved from the waiting list of the recurring event "
+            "<strong>Foo 1 Feb 2024 - 29 Feb 2024</strong> to a participant. Please use the "
+            "payment link to confirm your participation.",
+        ),
+        (
+            "fi",
+            "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Sarja: Foo",
+            "Sinut on valittu siirrettäväksi sarjatapahtuman "
+            "<strong>Foo 1.2.2024 - 29.2.2024</strong> jonotuslistalta osallistujaksi. Ole hyvä "
+            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi.",
+        ),
+        (
+            "sv",
+            "Betalning krävs för bekräftelse av registreringen - Serie: Foo",
+            "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
+            "<strong>Foo 1.2.2024 - 29.2.2024</strong> till en deltagare. Använd betalningslänken "
+            "för att bekräfta ditt deltagande.",
+        ),
+    ],
+)
+@freeze_time("2024-02-01 03:30:00+02:00")
+@pytest.mark.django_db
+def test_send_email_with_payment_link_when_moving_participant_from_waitlist_for_a_recurring_event(
+    api_client,
+    service_language,
+    expected_subject,
+    expected_text,
+):
+    now = localtime()
+    language = LanguageFactory(pk=service_language, service_language=True)
+
+    with translation.override(service_language):
+        registration = RegistrationFactory(
+            event__start_time=now,
+            event__end_time=now + timedelta(days=28),
+            event__super_event_type=Event.SuperEventType.RECURRING,
+            event__name="Foo",
+            maximum_attendee_capacity=1,
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.ATTENDING
+    )
+    SignUpContactPersonFactory(
+        signup=signup, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        json_return_value=get_web_store_order_response()
+    )
+    with (
+        translation.override(service_language),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup(
+            api_client, signup.id, signup_count=2, contact_person_count=2
+        )
+
+    assert SignUpPayment.objects.count() == 1
+
+    # Signup 2 status is not changed until a webhook notification updates the status.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    assert_payment_link_email_sent(
+        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+    )
+
+
+@pytest.mark.parametrize(
+    "price,expected_attendee_status,expected_mailbox_count",
+    [
+        (None, SignUp.AttendeeStatus.WAITING_LIST, 1),
+        (Decimal("0"), SignUp.AttendeeStatus.ATTENDING, 2),
+    ],
+)
+@pytest.mark.django_db
+def test_email_with_payment_link_not_sent_when_moving_participant_if_price_missing(
+    api_client, price, expected_attendee_status, expected_mailbox_count
+):
+    language = LanguageFactory(pk="en", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.ATTENDING
+    )
+    contact_person = SignUpContactPersonFactory(
+        signup=signup, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+
+    if price is not None:
+        registration_price_group.price = price
+        registration_price_group.save()
+
+        SignUpPriceGroupFactory(
+            signup=signup2, registration_price_group=registration_price_group
+        )
+
+    assert SignUpPayment.objects.count() == 0
+
+    with (
+        translation.override(language.pk),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        assert_delete_signup(
+            api_client, signup.id, signup_count=2, contact_person_count=2
+        )
+
+        assert mocked_create_payment_request.called is False
+
+    assert SignUpPayment.objects.count() == 0
+
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == expected_attendee_status
+
+    assert len(mail.outbox) == expected_mailbox_count
+    if expected_mailbox_count == 1:
+        assert mail.outbox[0].to[0] == contact_person.email
+        assert mail.outbox[0].subject == "Registration cancelled - Foo"
+    else:
+        assert mail.outbox[0].to[0] == contact_person2.email
+        assert mail.outbox[0].subject == "Registration confirmation - Foo"
+        assert mail.outbox[1].to[0] == contact_person.email
+        assert mail.outbox[1].subject == "Registration cancelled - Foo"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("first_name", None),
+        ("last_name", None),
+        ("email", None),
+        ("first_name", ""),
+        ("last_name", ""),
+        ("email", ""),
+        (None, None),
+    ],
+)
+@pytest.mark.django_db
+def test_email_with_payment_link_not_sent_when_moving_participant_if_contact_person_is_invalid(
+    api_client, field, value
+):
+    language = LanguageFactory(pk="en", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.ATTENDING
+    )
+    contact_person = SignUpContactPersonFactory(
+        signup=signup, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    if field:
+        SignUpContactPersonFactory(
+            signup=signup2,
+            first_name="Mickey" if field != "first_name" else value,
+            last_name="Mouse" if field != "last_name" else value,
+            email="test@test.com" if field != "email" else value,
+            service_language=language,
+        )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        status_code=status.HTTP_400_BAD_REQUEST
+    )
+    with (
+        translation.override(language.pk),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup(
+            api_client,
+            signup.id,
+            signup_count=2,
+            contact_person_count=2 if field else 1,
+        )
+
+    assert SignUpPayment.objects.count() == 0
+
+    # Signup 2 status is not changed.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    # Email has been sent to signup that was cancelled.
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to[0] == contact_person.email
+    assert mail.outbox[0].subject == "Registration cancelled - Foo"

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch, PropertyMock
 
 import pytest
+from django.conf import settings
 from django.core import mail
 from django.utils import translation
 from django.utils.timezone import localtime
@@ -1179,21 +1180,24 @@ def test_soft_deleted_signup_group_is_not_moved_to_attending_from_waiting_list(
             "Payment required for registration confirmation - Foo",
             "You have been selected to be moved from the waiting list of the event "
             "<strong>Foo</strong> to a participant. Please use the "
-            "payment link to confirm your participation.",
+            "payment link to confirm your participation. The payment link expires in "
+            "%(hours)s hours." % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "fi",
             "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
             "Sinut on valittu siirrettäväksi tapahtuman <strong>Foo</strong> "
             "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
-            "vahvistaaksesi osallistumisesi.",
+            "vahvistaaksesi osallistumisesi. Maksulinkki vanhenee %(hours)s tunnin kuluttua."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "sv",
             "Betalning krävs för bekräftelse av registreringen - Foo",
             "Du har blivit utvald att flyttats från väntelistan för evenemanget "
             "<strong>Foo</strong> till en deltagare. Använd betalningslänken "
-            "för att bekräfta ditt deltagande.",
+            "för att bekräfta ditt deltagande. Betalningslänken går ut efter %(hours)s timmar."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
     ],
 )
@@ -1276,21 +1280,25 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
             "Payment required for registration confirmation - Recurring: Foo",
             "You have been selected to be moved from the waiting list of the recurring event "
             "<strong>Foo 1 Feb 2024 - 29 Feb 2024</strong> to a participant. Please use the "
-            "payment link to confirm your participation.",
+            "payment link to confirm your participation. The payment link expires in "
+            "%(hours)s hours." % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "fi",
             "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Sarja: Foo",
             "Sinut on valittu siirrettäväksi sarjatapahtuman "
             "<strong>Foo 1.2.2024 - 29.2.2024</strong> jonotuslistalta osallistujaksi. Ole hyvä "
-            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi.",
+            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi. Maksulinkki vanhenee "
+            "%(hours)s tunnin kuluttua."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
         (
             "sv",
             "Betalning krävs för bekräftelse av registreringen - Serie: Foo",
             "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
             "<strong>Foo 1.2.2024 - 29.2.2024</strong> till en deltagare. Använd betalningslänken "
-            "för att bekräfta ditt deltagande.",
+            "för att bekräfta ditt deltagande. Betalningslänken går ut efter %(hours)s timmar."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         ),
     ],
 )

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -1260,7 +1260,11 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
     assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
 
     assert_payment_link_email_sent(
-        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+        contact_person2,
+        SignUpPayment.objects.first(),
+        expected_mailbox_length=2,
+        expected_subject=expected_subject,
+        expected_text=expected_text,
     )
 
 
@@ -1359,7 +1363,11 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
     assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
 
     assert_payment_link_email_sent(
-        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+        contact_person2,
+        SignUpPayment.objects.first(),
+        expected_mailbox_length=2,
+        expected_subject=expected_subject,
+        expected_text=expected_text,
     )
 
 

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from decimal import Decimal
 from unittest.mock import patch, PropertyMock
 
 import pytest
@@ -17,18 +18,26 @@ from registrations.models import (
     SignUp,
     SignUpContactPerson,
     SignUpGroup,
+    SignUpPayment,
     SignUpPriceGroup,
 )
 from registrations.tests.factories import (
     RegistrationFactory,
+    RegistrationPriceGroupFactory,
     RegistrationUserAccessFactory,
     SignUpContactPersonFactory,
     SignUpFactory,
     SignUpGroupFactory,
+    SignUpPaymentFactory,
     SignUpPriceGroupFactory,
 )
 from registrations.tests.test_registration_post import hel_email
-from registrations.tests.utils import create_user_by_role
+from registrations.tests.utils import (
+    assert_payment_link_email_sent,
+    create_user_by_role,
+    get_web_store_order_response,
+)
+from web_store.tests.utils import get_mock_response
 
 test_email1 = "test@test.com"
 
@@ -1137,11 +1146,6 @@ def test_soft_deleted_signup_group_is_not_moved_to_attending_from_waiting_list(
     api_client.force_authenticate(user)
 
     signup_group = SignUpGroupFactory(registration=registration)
-    SignUpFactory(
-        registration=registration,
-        signup_group=signup_group,
-        attendee_status=SignUp.AttendeeStatus.ATTENDING,
-    )
     SignUpContactPersonFactory(signup_group=signup_group, email="test@test.com")
 
     soft_deleted_signup_group = SignUpGroupFactory(registration=registration)
@@ -1165,3 +1169,351 @@ def test_soft_deleted_signup_group_is_not_moved_to_attending_from_waiting_list(
     # get any.
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject.startswith("Ilmoittautuminen peruttu")
+
+
+@pytest.mark.parametrize(
+    "service_language,expected_subject,expected_text",
+    [
+        (
+            "en",
+            "Payment required for registration confirmation - Foo",
+            "You have been selected to be moved from the waiting list of the event "
+            "<strong>Foo</strong> to a participant. Please use the "
+            "payment link to confirm your participation.",
+        ),
+        (
+            "fi",
+            "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
+            "Sinut on valittu siirrettäväksi tapahtuman <strong>Foo</strong> "
+            "jonotuslistalta osallistujaksi. Ole hyvä ja käytä oheista maksulinkkiä "
+            "vahvistaaksesi osallistumisesi.",
+        ),
+        (
+            "sv",
+            "Betalning krävs för bekräftelse av registreringen - Foo",
+            "Du har blivit utvald att flyttats från väntelistan för evenemanget "
+            "<strong>Foo</strong> till en deltagare. Använd betalningslänken "
+            "för att bekräfta ditt deltagande.",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_group_send_email_with_payment_link_when_moving_participant_from_waitlist(
+    api_client,
+    service_language,
+    expected_subject,
+    expected_text,
+):
+    language = LanguageFactory(pk=service_language, service_language=True)
+
+    with translation.override(service_language):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    SignUpFactory(
+        registration=registration,
+        signup_group=signup_group,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+    )
+    SignUpContactPersonFactory(
+        signup_group=signup_group, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        json_return_value=get_web_store_order_response()
+    )
+    with (
+        translation.override(service_language),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup_group(api_client, signup_group.id)
+
+    assert SignUpPayment.objects.count() == 1
+
+    # Signup 2 status is not changed until a webhook notification updates the status.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    assert_payment_link_email_sent(
+        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+    )
+
+
+@pytest.mark.parametrize(
+    "service_language,expected_subject,expected_text",
+    [
+        (
+            "en",
+            "Payment required for registration confirmation - Recurring: Foo",
+            "You have been selected to be moved from the waiting list of the recurring event "
+            "<strong>Foo 1 Feb 2024 - 29 Feb 2024</strong> to a participant. Please use the "
+            "payment link to confirm your participation.",
+        ),
+        (
+            "fi",
+            "Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Sarja: Foo",
+            "Sinut on valittu siirrettäväksi sarjatapahtuman "
+            "<strong>Foo 1.2.2024 - 29.2.2024</strong> jonotuslistalta osallistujaksi. Ole hyvä "
+            "ja käytä oheista maksulinkkiä vahvistaaksesi osallistumisesi.",
+        ),
+        (
+            "sv",
+            "Betalning krävs för bekräftelse av registreringen - Serie: Foo",
+            "Du har blivit utvald att flyttats från väntelistan för serieevenemanget "
+            "<strong>Foo 1.2.2024 - 29.2.2024</strong> till en deltagare. Använd betalningslänken "
+            "för att bekräfta ditt deltagande.",
+        ),
+    ],
+)
+@freeze_time("2024-02-01 03:30:00+02:00")
+@pytest.mark.django_db
+def test_group_send_email_with_payment_link_when_moving_participant_from_waitlist_for_recurring_event(
+    api_client,
+    service_language,
+    expected_subject,
+    expected_text,
+):
+    now = localtime()
+    language = LanguageFactory(pk=service_language, service_language=True)
+
+    with translation.override(service_language):
+        registration = RegistrationFactory(
+            event__start_time=now,
+            event__end_time=now + timedelta(days=28),
+            event__super_event_type=Event.SuperEventType.RECURRING,
+            event__name="Foo",
+            maximum_attendee_capacity=1,
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    SignUpFactory(
+        registration=registration,
+        signup_group=signup_group,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+    )
+    SignUpContactPersonFactory(
+        signup_group=signup_group, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        json_return_value=get_web_store_order_response()
+    )
+    with (
+        translation.override(service_language),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup_group(api_client, signup_group.id)
+
+    assert SignUpPayment.objects.count() == 1
+
+    # Signup 2 status is not changed until a webhook notification updates the status.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    assert_payment_link_email_sent(
+        contact_person2, SignUpPayment.objects.first(), expected_subject, expected_text
+    )
+
+
+@pytest.mark.parametrize(
+    "price,expected_attendee_status,expected_mailbox_count",
+    [
+        (None, SignUp.AttendeeStatus.WAITING_LIST, 1),
+        (Decimal("0"), SignUp.AttendeeStatus.ATTENDING, 2),
+    ],
+)
+@pytest.mark.django_db
+def test_group_email_with_payment_link_not_sent_when_moving_participant_if_price_missing(
+    api_client, price, expected_attendee_status, expected_mailbox_count
+):
+    language = LanguageFactory(pk="en", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    SignUpFactory(
+        registration=registration,
+        signup_group=signup_group,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+    )
+    contact_person = SignUpContactPersonFactory(
+        signup_group=signup_group, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    contact_person2 = SignUpContactPersonFactory(
+        signup=signup2,
+        first_name="Mickey",
+        last_name="Mouse",
+        email="test@test.com",
+        service_language=language,
+    )
+
+    if price is not None:
+        registration_price_group.price = price
+        registration_price_group.save()
+
+        SignUpPriceGroupFactory(
+            signup=signup2, registration_price_group=registration_price_group
+        )
+
+    assert SignUpPayment.objects.count() == 0
+
+    with (
+        translation.override(language.pk),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        assert_delete_signup_group(api_client, signup_group.id)
+
+        assert mocked_create_payment_request.called is False
+
+    assert SignUpPayment.objects.count() == 0
+
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == expected_attendee_status
+
+    assert len(mail.outbox) == expected_mailbox_count
+    if expected_mailbox_count == 1:
+        assert mail.outbox[0].to[0] == contact_person.email
+        assert mail.outbox[0].subject == "Registration cancelled - Foo"
+    else:
+        assert mail.outbox[0].to[0] == contact_person2.email
+        assert mail.outbox[0].subject == "Registration confirmation - Foo"
+        assert mail.outbox[1].to[0] == contact_person.email
+        assert mail.outbox[1].subject == "Registration cancelled - Foo"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("first_name", None),
+        ("last_name", None),
+        ("email", None),
+        ("first_name", ""),
+        ("last_name", ""),
+        ("email", ""),
+        (None, None),
+    ],
+)
+@pytest.mark.django_db
+def test_group_email_with_payment_link_not_sent_when_moving_participant_if_contact_person_invalid(
+    api_client, field, value
+):
+    language = LanguageFactory(pk="en", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(
+            event__name="Foo", maximum_attendee_capacity=1
+        )
+
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+
+    signup_group = SignUpGroupFactory(registration=registration)
+    SignUpFactory(
+        registration=registration,
+        signup_group=signup_group,
+        attendee_status=SignUp.AttendeeStatus.ATTENDING,
+    )
+    contact_person = SignUpContactPersonFactory(
+        signup_group=signup_group, service_language=language, email="test2@test.com"
+    )
+
+    signup2 = SignUpFactory(
+        registration=registration, attendee_status=SignUp.AttendeeStatus.WAITING_LIST
+    )
+    if field:
+        SignUpContactPersonFactory(
+            signup=signup2,
+            first_name="Mickey" if field != "first_name" else value,
+            last_name="Mouse" if field != "last_name" else value,
+            email="test@test.com" if field != "email" else value,
+            service_language=language,
+        )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
+
+    user = create_user_by_role("registration_admin", registration.publisher)
+    api_client.force_authenticate(user)
+
+    assert SignUpPayment.objects.count() == 0
+
+    mocked_create_payment_response = get_mock_response(
+        status_code=status.HTTP_400_BAD_REQUEST
+    )
+    with (
+        translation.override(language.pk),
+        patch("requests.post") as mocked_create_payment_request,
+    ):
+        mocked_create_payment_request.return_value = mocked_create_payment_response
+
+        assert_delete_signup_group(api_client, signup_group.id)
+
+    assert SignUpPayment.objects.count() == 0
+
+    # Signup 2 status is not changed.
+    signup2.refresh_from_db()
+    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    # Email has been sent to signup that was cancelled.
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].to[0] == contact_person.email
+    assert mail.outbox[0].subject == "Registration cancelled - Foo"

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -37,6 +37,7 @@ from registrations.tests.factories import (
 from registrations.tests.test_registration_post import hel_email
 from registrations.tests.utils import (
     assert_attending_and_waitlisted_signups,
+    assert_payment_link_email_sent,
     assert_signup_payment_data_is_correct,
     create_user_by_role,
     DEFAULT_CREATE_ORDER_ERROR_RESPONSE,
@@ -226,9 +227,20 @@ def test_registration_substitute_user_can_create_signup_group(api_client, regist
     ],
 )
 @pytest.mark.django_db
-def test_authenticated_user_can_create_signup_group_with_payment(
-    registration, api_client, user_role
-):
+def test_authenticated_user_can_create_signup_group_with_payment(api_client, user_role):
+    registration = RegistrationFactory(event__name="Foo")
+
+    user = create_user_by_role(
+        user_role,
+        registration.publisher,
+        additional_roles={
+            "regular_user_without_organization": lambda usr: None,
+        }
+        if user_role == "regular_user_without_organization"
+        else None,
+    )
+    api_client.force_authenticate(user)
+
     reservation = SeatReservationCodeFactory(seats=2, registration=registration)
 
     LanguageFactory(pk="fi", service_language=True)
@@ -236,15 +248,6 @@ def test_authenticated_user_can_create_signup_group_with_payment(
 
     registration_price_group = RegistrationPriceGroupFactory(registration=registration)
     registration_price_group2 = RegistrationPriceGroupFactory(registration=registration)
-
-    user = create_user_by_role(
-        user_role,
-        registration.publisher,
-        additional_roles={
-            "regular_user_without_organization": lambda usr: None,
-        },
-    )
-    api_client.force_authenticate(user)
 
     signup_group_data = deepcopy(default_signup_group_data)
     signup_group_data.update(
@@ -277,6 +280,7 @@ def test_authenticated_user_can_create_signup_group_with_payment(
     )
     with patch("requests.post") as mocked_web_store_api_request:
         mocked_web_store_api_request.return_value = mocked_web_store_api_response
+
         response = assert_create_signup_group(api_client, signup_group_data)
 
     assert SignUpPayment.objects.count() == 1
@@ -287,8 +291,14 @@ def test_authenticated_user_can_create_signup_group_with_payment(
         signup_group=SignUpGroup.objects.first(),
     )
 
-    # Email confirmation will be sent only when payment webhook arrives and payment has been paid.
-    assert len(mail.outbox) == 0
+    # Payment link is sent via email.
+    assert_payment_link_email_sent(
+        SignUpContactPerson.objects.first(),
+        SignUpPayment.objects.first(),
+        expected_subject="Payment required for registration confirmation - Foo",
+        expected_text="Please use the payment link to confirm your registration for the event "
+        "<strong>Foo</strong>.",
+    )
 
 
 @pytest.mark.django_db
@@ -320,9 +330,15 @@ def test_can_create_signup_group_with_create_payment_as_false_in_payload(
 
 
 @pytest.mark.django_db
-def test_create_signup_group_payment_without_pricetotal_in_response(
-    registration, api_client
-):
+def test_create_signup_group_payment_without_pricetotal_in_response(api_client):
+    registration = RegistrationFactory(event__name="Foo")
+
+    user = create_user_by_role(
+        "registration_admin",
+        registration.publisher,
+    )
+    api_client.force_authenticate(user)
+
     reservation = SeatReservationCodeFactory(seats=2, registration=registration)
 
     LanguageFactory(pk="fi", service_language=True)
@@ -330,12 +346,6 @@ def test_create_signup_group_payment_without_pricetotal_in_response(
 
     registration_price_group = RegistrationPriceGroupFactory(registration=registration)
     registration_price_group2 = RegistrationPriceGroupFactory(registration=registration)
-
-    user = create_user_by_role(
-        "registration_admin",
-        registration.publisher,
-    )
-    api_client.force_authenticate(user)
 
     signup_group_data = deepcopy(default_signup_group_data)
     signup_group_data.update(
@@ -376,7 +386,14 @@ def test_create_signup_group_payment_without_pricetotal_in_response(
         signup_group=SignUpGroup.objects.first(),
     )
 
-    assert len(mail.outbox) == 0
+    # Payment link is sent via email.
+    assert_payment_link_email_sent(
+        SignUpContactPerson.objects.first(),
+        SignUpPayment.objects.first(),
+        expected_subject="Payment required for registration confirmation - Foo",
+        expected_text="Please use the payment link to confirm your registration for the event "
+        "<strong>Foo</strong>.",
+    )
 
 
 @pytest.mark.django_db
@@ -601,12 +618,15 @@ def test_create_signup_payment_with_zero_or_negative_price(
     )
 
 
+@pytest.mark.parametrize("maximum_attendee_capacity", [0, 1])
 @pytest.mark.django_db
-def test_create_signup_group_payment_signup_is_waitlisted(api_client, registration):
-    registration.maximum_attendee_capacity = 0
-    registration.waiting_list_capacity = 1
-    registration.save(
-        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
+def test_create_signup_group_payment_signup_is_waitlisted(
+    api_client, maximum_attendee_capacity
+):
+    registration = RegistrationFactory(
+        maximum_attendee_capacity=maximum_attendee_capacity,
+        waiting_list_capacity=2 if maximum_attendee_capacity == 0 else 1,
+        event__name="Foo",
     )
 
     reservation = SeatReservationCodeFactory(seats=2, registration=registration)
@@ -640,14 +660,30 @@ def test_create_signup_group_payment_signup_is_waitlisted(api_client, registrati
 
     assert SignUpPayment.objects.count() == 0
 
-    response = create_signup_group(api_client, signup_group_data)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    assert SignUpPayment.objects.count() == 0
-
-    assert response.data["create_payment"][0] == (
-        "A payment can only be added for attending participants."
+    mocked_web_store_api_response = get_mock_response(
+        json_return_value=get_web_store_order_response(
+            payment_amount=registration_price_group.price
+        )
     )
+    with patch("requests.post") as mocked_web_store_api_request:
+        mocked_web_store_api_request.return_value = mocked_web_store_api_response
+
+        assert_create_signup_group(api_client, signup_group_data)
+
+    assert SignUpPayment.objects.count() == maximum_attendee_capacity
+
+    if maximum_attendee_capacity:
+        # Payment link is sent via email for the attending signup.
+        assert_payment_link_email_sent(
+            SignUpContactPerson.objects.first(),
+            SignUpPayment.objects.first(),
+            expected_subject="Payment required for registration confirmation - Foo",
+            expected_text="Please use the payment link to confirm your registration for the event "
+            "<strong>Foo</strong>.",
+        )
+    else:
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == "Waiting list seat reserved - Foo"
 
 
 @pytest.mark.parametrize(

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -297,7 +297,8 @@ def test_authenticated_user_can_create_signup_group_with_payment(api_client, use
         SignUpPayment.objects.first(),
         expected_subject="Payment required for registration confirmation - Foo",
         expected_text="Please use the payment link to confirm your registration for the event "
-        "<strong>Foo</strong>.",
+        "<strong>Foo</strong>. The payment link expires in %(hours)s hours."
+        % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
     )
 
 
@@ -392,7 +393,8 @@ def test_create_signup_group_payment_without_pricetotal_in_response(api_client):
         SignUpPayment.objects.first(),
         expected_subject="Payment required for registration confirmation - Foo",
         expected_text="Please use the payment link to confirm your registration for the event "
-        "<strong>Foo</strong>.",
+        "<strong>Foo</strong>. The payment link expires in %(hours)s hours."
+        % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
     )
 
 
@@ -679,7 +681,8 @@ def test_create_signup_group_payment_signup_is_waitlisted(
             SignUpPayment.objects.first(),
             expected_subject="Payment required for registration confirmation - Foo",
             expected_text="Please use the payment link to confirm your registration for the event "
-            "<strong>Foo</strong>.",
+            "<strong>Foo</strong>. The payment link expires in %(hours)s hours."
+            % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
         )
     else:
         assert len(mail.outbox) == 1

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -266,7 +266,8 @@ def test_authenticated_user_can_create_signups_with_payments(api_client, user_ro
         SignUpPayment.objects.first(),
         expected_subject="Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
         expected_text="Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>Foo</strong> "
-        "oheisen maksulinkin avulla.",
+        "oheisen maksulinkin avulla. Maksulinkki vanhenee %(hours)s tunnin kuluttua."
+        % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
     )
 
 
@@ -360,7 +361,8 @@ def test_create_signup_payment_without_pricetotal_in_response(api_client):
         SignUpPayment.objects.first(),
         expected_subject="Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
         expected_text="Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>Foo</strong> "
-        "oheisen maksulinkin avulla.",
+        "oheisen maksulinkin avulla. Maksulinkki vanhenee %(hours)s tunnin kuluttua."
+        % {"hours": settings.WEB_STORE_ORDER_EXPIRATION_HOURS},
     )
 
 

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -38,6 +38,7 @@ from registrations.tests.test_registration_post import hel_email
 from registrations.tests.test_signup_patch import description_fields
 from registrations.tests.utils import (
     assert_attending_and_waitlisted_signups,
+    assert_payment_link_email_sent,
     assert_signup_payment_data_is_correct,
     create_user_by_role,
     DEFAULT_CREATE_ORDER_ERROR_RESPONSE,
@@ -196,10 +197,12 @@ def test_authenticated_users_can_create_signups(registration, api_client, user_r
     ],
 )
 @pytest.mark.django_db
-def test_authenticated_user_can_create_signups_with_payments(
-    registration, api_client, user_role
-):
-    LanguageFactory(pk="fi", service_language=True)
+def test_authenticated_user_can_create_signups_with_payments(api_client, user_role):
+    language = LanguageFactory(pk="fi", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(event__name="Foo")
+
     reservation = SeatReservationCodeFactory(seats=1, registration=registration)
     registration_price_group = RegistrationPriceGroupFactory(registration=registration)
 
@@ -208,7 +211,9 @@ def test_authenticated_user_can_create_signups_with_payments(
         registration.publisher,
         additional_roles={
             "regular_user_without_organization": lambda usr: None,
-        },
+        }
+        if user_role == "regular_user_without_organization"
+        else None,
     )
     api_client.force_authenticate(user)
 
@@ -225,6 +230,12 @@ def test_authenticated_user_can_create_signups_with_payments(
             "create_payment": True,
         }
     )
+    signups_data["signups"][0]["contact_person"].update(
+        {
+            "native_language": language.pk,
+            "service_language": language.pk,
+        }
+    )
 
     assert SignUpPayment.objects.count() == 0
 
@@ -233,8 +244,11 @@ def test_authenticated_user_can_create_signups_with_payments(
             payment_amount=registration_price_group.price
         )
     )
-    with patch("requests.post") as mocked_web_store_api_request:
+    with translation.override(language.pk), patch(
+        "requests.post"
+    ) as mocked_web_store_api_request:
         mocked_web_store_api_request.return_value = mocked_web_store_api_response
+
         response = assert_create_signups(api_client, signups_data)
 
     assert SignUpPayment.objects.count() == 1
@@ -246,8 +260,14 @@ def test_authenticated_user_can_create_signups_with_payments(
         SignUp.objects.first(),
     )
 
-    # Email confirmation will be sent only when payment webhook arrives and payment has been paid.
-    assert len(mail.outbox) == 0
+    # Payment link is sent via email.
+    assert_payment_link_email_sent(
+        SignUpContactPerson.objects.first(),
+        SignUpPayment.objects.first(),
+        expected_subject="Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
+        expected_text="Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>Foo</strong> "
+        "oheisen maksulinkin avulla.",
+    )
 
 
 @pytest.mark.django_db
@@ -281,16 +301,20 @@ def test_can_create_signup_with_create_payment_as_false_in_payload(
 
 
 @pytest.mark.django_db
-def test_create_signup_payment_without_pricetotal_in_response(registration, api_client):
-    LanguageFactory(pk="fi", service_language=True)
-    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
-    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+def test_create_signup_payment_without_pricetotal_in_response(api_client):
+    language = LanguageFactory(pk="fi", service_language=True)
+
+    with translation.override(language.pk):
+        registration = RegistrationFactory(event__name="Foo")
 
     user = create_user_by_role(
         "registration_admin",
         registration.publisher,
     )
     api_client.force_authenticate(user)
+
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
 
     signups_data = deepcopy(default_signups_data)
     signups_data.update(
@@ -314,8 +338,11 @@ def test_create_signup_payment_without_pricetotal_in_response(registration, api_
     mocked_web_store_api_response = get_mock_response(
         json_return_value=mocked_web_store_api_json
     )
-    with patch("requests.post") as mocked_web_store_api_request:
+    with translation.override(language.pk), patch(
+        "requests.post"
+    ) as mocked_web_store_api_request:
         mocked_web_store_api_request.return_value = mocked_web_store_api_response
+
         response = assert_create_signups(api_client, signups_data)
 
     assert SignUpPayment.objects.count() == 1
@@ -327,7 +354,14 @@ def test_create_signup_payment_without_pricetotal_in_response(registration, api_
         SignUp.objects.first(),
     )
 
-    assert len(mail.outbox) == 0
+    # Payment link is sent via email.
+    assert_payment_link_email_sent(
+        SignUpContactPerson.objects.first(),
+        SignUpPayment.objects.first(),
+        expected_subject="Maksu vaaditaan ilmoittautumisen vahvistamiseksi - Foo",
+        expected_text="Voit vahvistaa ilmoittautumisesi tapahtumaan <strong>Foo</strong> "
+        "oheisen maksulinkin avulla.",
+    )
 
 
 @pytest.mark.django_db
@@ -513,19 +547,20 @@ def test_create_signup_payment_with_zero_or_negative_price(
 
 
 @pytest.mark.django_db
-def test_create_signup_payment_signup_is_waitlisted(api_client, registration):
-    registration.maximum_attendee_capacity = 0
-    registration.waiting_list_capacity = 1
-    registration.save(
-        update_fields=["maximum_attendee_capacity", "waiting_list_capacity"]
-    )
+def test_create_signup_payment_signup_is_waitlisted(api_client):
+    language = LanguageFactory(pk="en", service_language=True)
 
-    LanguageFactory(pk="fi", service_language=True)
-    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
-    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+    registration = RegistrationFactory(
+        maximum_attendee_capacity=0,
+        waiting_list_capacity=1,
+        event__name="Foo",
+    )
 
     user = create_user_by_role("registration_admin", registration.publisher)
     api_client.force_authenticate(user)
+
+    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
 
     signups_data = deepcopy(default_signups_data)
     signups_data.update(
@@ -540,17 +575,24 @@ def test_create_signup_payment_signup_is_waitlisted(api_client, registration):
             "create_payment": True,
         }
     )
-
-    assert SignUpPayment.objects.count() == 0
-
-    response = create_signups(api_client, signups_data)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    assert SignUpPayment.objects.count() == 0
-
-    assert response.data["signups"][0]["create_payment"][0] == (
-        "A payment can only be added for attending participants."
+    signups_data["signups"][0]["contact_person"].update(
+        {
+            "native_language": language.pk,
+            "service_language": language.pk,
+        }
     )
+
+    assert SignUpPayment.objects.count() == 0
+
+    assert_create_signups(api_client, signups_data)
+
+    assert SignUpPayment.objects.count() == 0
+
+    assert SignUp.objects.count() == 1
+    assert SignUp.objects.first().attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "Waiting list seat reserved - Foo"
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_web_store_webhook_post.py
+++ b/registrations/tests/test_web_store_webhook_post.py
@@ -303,6 +303,44 @@ def test_payment_paid_webhook_for_signup_payment(
     assert_payment_id_audit_logged(payment)
 
 
+@pytest.mark.django_db
+def test_payment_paid_webhook_for_signup_payment_with_waitlisted_status(
+    api_client, data_source
+):
+    api_client.credentials(apikey=data_source.api_key)
+
+    payment = create_signup_payment(user=UserFactory())
+    payment.signup.attendee_status = SignUp.AttendeeStatus.WAITING_LIST
+    payment.signup.save(update_fields=["attendee_status"])
+
+    assert payment.status == SignUpPayment.PaymentStatus.CREATED
+    assert payment.signup.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+
+    data = get_webhook_data(
+        payment.external_order_id,
+        WebStorePaymentWebhookEventType.PAYMENT_PAID.value,
+        {"paymentId": _PAYMENT_ID},
+    )
+
+    assert AuditLogEntry.objects.count() == 0
+
+    mocked_get_payment_response = get_mock_response(
+        status_code=status.HTTP_200_OK, json_return_value=DEFAULT_GET_PAYMENT_DATA
+    )
+    with patch("requests.get") as mocked_get_payment_request:
+        mocked_get_payment_request.return_value = mocked_get_payment_response
+
+        assert_payment_paid(api_client, data, payment)
+        assert_confirmation_sent_to_contact_person(payment.signup_or_signup_group)
+
+        assert mocked_get_payment_request.called is True
+
+    payment.signup.refresh_from_db()
+    assert payment.signup.attendee_status == SignUp.AttendeeStatus.ATTENDING
+
+    assert_payment_id_audit_logged(payment)
+
+
 @pytest.mark.parametrize(
     "created_by_user,has_contact_person",
     [

--- a/registrations/tests/utils.py
+++ b/registrations/tests/utils.py
@@ -76,6 +76,21 @@ def assert_invitation_email_is_sent(
     assert participant_list_url in email_body_string
 
 
+def assert_payment_link_email_sent(
+    contact_person, signup_payment, expected_subject, expected_text
+):
+    # Email has been sent to the contact person.
+    assert len(mail.outbox) == 2  # second email = cancellation email
+    email_html_body = str(mail.outbox[0].alternatives[0])
+    assert mail.outbox[0].to[0] == contact_person.email
+    assert mail.outbox[0].subject == expected_subject
+    assert expected_text in email_html_body
+
+    # Payment link is in the email.
+    assert len(signup_payment.logged_in_checkout_url) > 1
+    assert signup_payment.logged_in_checkout_url in email_html_body
+
+
 def assert_attending_and_waitlisted_signups(
     response,
     expected_status_code: int = status.HTTP_201_CREATED,

--- a/registrations/tests/utils.py
+++ b/registrations/tests/utils.py
@@ -77,10 +77,14 @@ def assert_invitation_email_is_sent(
 
 
 def assert_payment_link_email_sent(
-    contact_person, signup_payment, expected_subject, expected_text
+    contact_person,
+    signup_payment,
+    expected_mailbox_length=1,
+    expected_subject="",
+    expected_text="",
 ):
     # Email has been sent to the contact person.
-    assert len(mail.outbox) == 2  # second email = cancellation email
+    assert len(mail.outbox) == expected_mailbox_length
     email_html_body = str(mail.outbox[0].alternatives[0])
     assert mail.outbox[0].to[0] == contact_person.email
     assert mail.outbox[0].subject == expected_subject

--- a/registrations/tests/utils.py
+++ b/registrations/tests/utils.py
@@ -91,8 +91,8 @@ def assert_payment_link_email_sent(
     assert expected_text in email_html_body
 
     # Payment link is in the email.
-    assert len(signup_payment.logged_in_checkout_url) > 1
-    assert signup_payment.logged_in_checkout_url in email_html_body
+    assert len(signup_payment.checkout_url) > 1
+    assert signup_payment.checkout_url in email_html_body
 
 
 def assert_attending_and_waitlisted_signups(

--- a/web_store/tests/utils.py
+++ b/web_store/tests/utils.py
@@ -4,13 +4,19 @@ from requests import RequestException
 from rest_framework import status
 
 
-def get_mock_response(status_code=status.HTTP_201_CREATED, json_return_value=None):
+def get_mock_response(
+    status_code=status.HTTP_201_CREATED,
+    json_return_value=None,
+    exception_json_return_value=None,
+):
     response = Mock()
 
     response.status_code = status_code
     response.json.return_value = json_return_value or {}
+
     if status.is_client_error(status_code) or status.is_server_error(status_code):
         exception_response_mock = Mock(status_code=status_code)
+        exception_response_mock.json.return_value = exception_json_return_value or {}
         response.raise_for_status.side_effect = RequestException(
             response=exception_response_mock
         )


### PR DESCRIPTION
### Description
Adds two new features related to Talpa payments:

- After a payment / Talpa order has been created for a signup or signup group, an email confirmation with a payment link will be sent to the contact person.
- Signing up to the waiting list of a paid event is now possible. Previously only attending signups were allowed. When a waitlisted signup is moved to be an attending participant, a payment is created for them and the payment link is emailed to the contact person.
### Closes
[LINK-1881](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1881)

[LINK-1881]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ