### PR TITLE
LINK-1915, LINK-1916 | Fine-tune anonymization

### DIFF
--- a/registrations/management/commands/anonymize_past_signups.py
+++ b/registrations/management/commands/anonymize_past_signups.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from django.db.models.functions import Greatest
 
 from django.conf import settings
 from django.core.management import BaseCommand
@@ -15,6 +16,14 @@ class Command(BaseCommand):
         "days in the ANONYMIZATION_THRESHOLD_DAYS environment variable."
     )
 
+    def _build_compare_time_annotation(self):
+        return {
+            "compare_time": Greatest(
+                "registration__event__end_time",
+                "registration__enrolment_end_time",
+            ),
+        }
+
     def handle(self, *args, **options):
         threshold_time = localtime() - timedelta(
             days=settings.ANONYMIZATION_THRESHOLD_DAYS
@@ -26,9 +35,10 @@ class Command(BaseCommand):
         )
         signup_groups = (
             SignUpGroup.objects.prefetch_related("signups")
+            .annotate(**self._build_compare_time_annotation())
             .select_for_update()
             .filter(
-                registration__event__end_time__lt=threshold_time,
+                compare_time__lt=threshold_time,
                 anonymization_time__isnull=True,
             )
         )
@@ -40,9 +50,13 @@ class Command(BaseCommand):
 
         # Anonymize all signups without a group
         self.stdout.write("Start anonymizing past signups")
-        signups = SignUp.objects.select_for_update().filter(
-            registration__event__end_time__lt=threshold_time,
-            anonymization_time__isnull=True,
+        signups = (
+            SignUp.objects.annotate(**self._build_compare_time_annotation())
+            .select_for_update()
+            .filter(
+                compare_time__lt=threshold_time,
+                anonymization_time__isnull=True,
+            )
         )
 
         with transaction.atomic():

--- a/registrations/management/commands/anonymize_past_signups.py
+++ b/registrations/management/commands/anonymize_past_signups.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
-from django.db.models.functions import Greatest
 
 from django.conf import settings
 from django.core.management import BaseCommand
 from django.db import transaction
+from django.db.models.functions import Greatest
 from django.utils.timezone import localtime
 
 from registrations.models import SignUp, SignUpGroup

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -653,7 +653,7 @@ class SignUpProtectedDataBaseModel(models.Model):
     )
 
     def anonymize(self):
-        self.extra_info = anonymize_replacement
+        self.extra_info = None
         self.save()
 
     class Meta:

--- a/registrations/tests/test_commands.py
+++ b/registrations/tests/test_commands.py
@@ -128,6 +128,48 @@ def test_anonymize_past_signups():
     assert past_signup.anonymization_time is not None
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "enrolment_time_delta,event_time_delta,should_anonymize",
+    [
+        (0, -31, False),
+        (31, -31, False),
+        (-29, -31, False),
+        (-31, -31, True),
+        (-31, 0, False),
+        (-31, 31, False),
+        (-31, -29, False),
+    ],
+)
+def test_anonymize_if_enrolment_end_time_and_end_time_are_over_30_days_in_past(
+    enrolment_time_delta, event_time_delta, should_anonymize
+):
+    event = EventFactory(end_time=localtime() + timedelta(days=event_time_delta))
+    registration = RegistrationFactory(
+        event=event,
+        enrolment_end_time=localtime() + timedelta(days=enrolment_time_delta),
+    )
+    signup_group = SignUpGroupFactory(registration=registration)
+    signup_in_group = SignUpFactory(
+        registration=registration, signup_group=signup_group
+    )
+    signup = SignUpFactory(registration=registration)
+
+    call_command("anonymize_past_signups")
+
+    signup_group.refresh_from_db()
+    signup_in_group.refresh_from_db()
+    signup.refresh_from_db()
+    if should_anonymize:
+        assert signup_group.anonymization_time is not None
+        assert signup_in_group.anonymization_time is not None
+        assert signup.anonymization_time is not None
+    else:
+        assert signup_group.anonymization_time is None
+        assert signup_in_group.anonymization_time is None
+        assert signup.anonymization_time is None
+
+
 @freezegun.freeze_time("2024-02-16 16:45:00+02:00")
 @pytest.mark.django_db(transaction=True)
 def test_delete_expired_seatreservations():

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -254,7 +254,7 @@ class TestSignUpGroup(TestCase):
         signup_group.anonymize()
 
         # Signup group should be anonymized
-        assert signup_group_protected_data.extra_info == anonymize_replacement
+        assert signup_group_protected_data.extra_info is None
         assert contact_person.email == anonymize_replacement
         assert contact_person.first_name == anonymize_replacement
         assert contact_person.last_name == anonymize_replacement
@@ -280,7 +280,7 @@ class TestSignUpGroup(TestCase):
             == signup_data["protected_data"]["date_of_birth"]
         )
         # Extra info is anonymized
-        assert signup_protected_data.extra_info == anonymize_replacement
+        assert signup_protected_data.extra_info is None
         assert signup.anonymization_time is not None
         assert signup.created_by is None
         assert signup.last_modified_by is None
@@ -536,7 +536,7 @@ class TestSignUp(TestCase):
             == signup_data["protected_data"]["date_of_birth"]
         )
         # Extra info is anonymized
-        assert protected_data.extra_info == anonymize_replacement
+        assert protected_data.extra_info is None
         assert signup.anonymization_time is not None
         assert signup.created_by is None
         assert signup.last_modified_by is None


### PR DESCRIPTION
## Description
- Use enrolment_end_time value of registration in anonymization if it's later than end_time of event.
- Set extra_info field as None in anonymizaation

## Closes
[LINK-1916](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1916)
[LINK-1915](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1915)


[LINK-1916]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-1915]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ