### PR TITLE
LINK-1926 | send invitation is is_substitute_user is changed

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1503,21 +1503,14 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
     def _create_or_update_registration_user_accesses(
         registration, registration_user_accesses
     ):
-        users_to_send_invitations = []
-
         for data in registration_user_accesses:
             if current_obj := data.pop("id", None):
                 current_id = current_obj.id
-                current_email = current_obj.email
             else:
                 current_id = None
-                current_email = None
 
             try:
-                (
-                    user_instance,
-                    created,
-                ) = RegistrationUserAccess.objects.update_or_create(
+                RegistrationUserAccess.objects.update_or_create(
                     id=current_id,
                     registration=registration,
                     defaults=data,
@@ -1540,16 +1533,6 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
                     )
                 else:
                     raise
-
-            # Send invitation to new registration users or if the email is updated to an
-            # existing registration user
-            if created or (current_email != user_instance.email):
-                users_to_send_invitations.append(user_instance)
-
-        # Send invitations to registration users after updating all registration users to
-        # make sure that all instances are created or updated successfully
-        for user_instance in users_to_send_invitations:
-            user_instance.send_invitation()
 
     @staticmethod
     def _create_or_update_registration_price_groups(

--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -89,25 +89,6 @@ class RegistrationAdmin(RegistrationBaseAdmin, TranslationAdmin, VersionAdmin):
             ):
                 yield inline.get_formset(request, obj), inline
 
-    def save_related(self, request, form, formsets, change):
-        for formset in formsets:
-            if formset.model == RegistrationUserAccess:
-                formset.save(commit=False)
-
-                for added_registration_user_accesses in formset.new_objects:
-                    # Send invitation email if new registration user accesses is added
-                    added_registration_user_accesses.send_invitation()
-
-                for [
-                    changed_registration_user_access,
-                    changed_fields,
-                ] in formset.changed_objects:
-                    # Send invitation email if email address is changed
-                    if "email" in changed_fields:
-                        changed_registration_user_access.send_invitation()
-
-        super(RegistrationAdmin, self).save_related(request, form, formsets, change)
-
     def get_readonly_fields(self, request, obj=None):
         if obj:
             return ["id", "event"]

--- a/registrations/models.py
+++ b/registrations/models.py
@@ -864,6 +864,22 @@ class RegistrationUserAccess(models.Model):
             html_message=rendered_body,
         )
 
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        if self.pk:
+            old_instance = RegistrationUserAccess.objects.filter(pk=self.pk).first()
+        else:
+            old_instance = None
+
+        super().save(*args, **kwargs)
+
+        if (
+            not old_instance
+            or old_instance.email != self.email
+            or old_instance.is_substitute_user != self.is_substitute_user
+        ):
+            self.send_invitation()
+
     class Meta:
         unique_together = ("email", "registration")
 

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.test import RequestFactory, TestCase
 from django.utils import translation
 from rest_framework import status
@@ -262,6 +263,7 @@ class TestRegistrationAdmin(TestCase):
             registration_user_access = RegistrationUserAccess.objects.create(
                 registration=self.registration, email=EMAIL
             )
+            mail.outbox.clear()
             self.registration.event.name = EVENT_NAME
             self.registration.event.save()
 

--- a/registrations/tests/utils.py
+++ b/registrations/tests/utils.py
@@ -39,35 +39,32 @@ def assert_invitation_email_is_sent(
     expected_subject: Optional[str] = None,
     expected_body: Optional[str] = None,
 ) -> None:
-    assert mail.outbox[0].to[0] == email
+    first_email = mail.outbox[0]
+    assert first_email.to[0] == email
 
     ui_locale = ui_locale or "fi"
-    email_body_string = str(mail.outbox[0].alternatives[0])
+    email_body_string = str(first_email.alternatives[0])
 
     if registration_user_access.is_substitute_user:
         expected_subject = expected_subject or "Oikeudet myönnetty ilmoittautumiseen"
-        assert mail.outbox[0].subject.startswith(expected_subject)
-
         expected_body = expected_body or (
             f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty sijaisen käyttöoikeudet "
             f"tapahtuman <strong>{event_name}</strong> ilmoittautumiselle."
         )
-        assert expected_body in email_body_string
 
         service_base_url = settings.LINKED_EVENTS_UI_URL
         registration_term = "registrations"
     else:
         expected_subject = expected_subject or "Oikeudet myönnetty osallistujalistaan"
-        assert mail.outbox[0].subject.startswith(expected_subject)
-
         expected_body = expected_body or (
             f"Sähköpostiosoitteelle <strong>{email}</strong> on myönnetty oikeudet lukea "
             f"tapahtuman <strong>{event_name}</strong> osallistujalista."
         )
-        assert expected_body in email_body_string
-
         service_base_url = settings.LINKED_REGISTRATIONS_UI_URL
         registration_term = "registration"
+
+    assert first_email.subject.startswith(expected_subject)
+    assert expected_body in email_body_string
 
     participant_list_url = (
         f"{service_base_url}/{ui_locale}/{registration_term}/"
@@ -128,22 +125,22 @@ def create_user_by_role(
 
     user_role_mapping = {
         "superuser": lambda usr: None,
-        "admin": lambda usr: usr.admin_organizations.add(organization)
-        if organization
-        else None,
-        "registration_admin": lambda usr: usr.registration_admin_organizations.add(
-            organization
-        )
-        if organization
-        else None,
-        "financial_admin": lambda usr: usr.financial_admin_organizations.add(
-            organization
-        )
-        if organization
-        else None,
-        "regular_user": lambda usr: usr.organization_memberships.add(organization)
-        if organization
-        else None,
+        "admin": lambda usr: (
+            usr.admin_organizations.add(organization) if organization else None
+        ),
+        "registration_admin": lambda usr: (
+            usr.registration_admin_organizations.add(organization)
+            if organization
+            else None
+        ),
+        "financial_admin": lambda usr: (
+            usr.financial_admin_organizations.add(organization)
+            if organization
+            else None
+        ),
+        "regular_user": lambda usr: (
+            usr.organization_memberships.add(organization) if organization else None
+        ),
     }
     if isinstance(additional_roles, dict):
         user_role_mapping.update(additional_roles)


### PR DESCRIPTION
## Description
Send invitation to registration user access email also when is_substitute_user values is changes. 
Move logic to send invitation to signals to avoid duplicate code in admin side and RegistrationViewSet

## Closes
[LINK-1926](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1926)

[LINK-1926]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ