### PR TITLE
LINK-1927 | Use Same VAT Percentage for All Registration Price Groups

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1695,9 +1695,7 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
                 code="unique",
             )
 
-        validate_for_duplicates(
-            value, "price_group", duplicate_error_detail_callback
-        )
+        validate_for_duplicates(value, "price_group", duplicate_error_detail_callback)
 
         if value and not all(
             [

--- a/events/api.py
+++ b/events/api.py
@@ -1686,7 +1686,7 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
         return validate_for_duplicates(value, "email", error_detail_callback)
 
     def validate_registration_price_groups(self, value):
-        def error_detail_callback(price_group):
+        def duplicate_error_detail_callback(price_group):
             return ErrorDetail(
                 _(
                     "Registration price group with price_group %(price_group)s already exists."
@@ -1695,7 +1695,30 @@ class RegistrationSerializer(LinkedEventsSerializer, RegistrationBaseSerializer)
                 code="unique",
             )
 
-        return validate_for_duplicates(value, "price_group", error_detail_callback)
+        validate_for_duplicates(
+            value, "price_group", duplicate_error_detail_callback
+        )
+
+        if value and not all(
+            [
+                price_group["vat_percentage"] == value[0]["vat_percentage"]
+                for price_group in value
+            ]
+        ):
+            raise serializers.ValidationError(
+                {
+                    "price_group": [
+                        ErrorDetail(
+                            _(
+                                "All registration price groups must have the same VAT percentage."
+                            ),
+                            code="vat_percentage",
+                        )
+                    ]
+                }
+            )
+
+        return value
 
     # LinkedEventsSerializer validates name which doesn't exist in Registration model
     def validate(self, data):

--- a/registrations/forms.py
+++ b/registrations/forms.py
@@ -1,7 +1,51 @@
+from decimal import Decimal
+
 from django import forms
+from django.conf import settings
+from django.utils.translation import gettext as _
 
 from registrations.enums import VatPercentage
-from registrations.models import RegistrationPriceGroup
+from registrations.models import Registration, RegistrationPriceGroup, VAT_PERCENTAGES
+
+
+class RegistrationAdminForm(forms.ModelForm):
+    vat_percentage = forms.TypedChoiceField(
+        choices=VAT_PERCENTAGES,
+        initial=VatPercentage.VAT_24.value,
+        coerce=Decimal,
+        label=_("VAT percentage for price groups"),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not settings.WEB_STORE_INTEGRATION_ENABLED:
+            if "vat_percentage" in self.fields:
+                del self.fields["vat_percentage"]
+        elif self.instance.pk and self.instance.registration_price_groups.exists():
+            self.initial[
+                "vat_percentage"
+            ] = self.instance.registration_price_groups.first().vat_percentage
+
+    class Meta:
+        model = Registration
+        fields = (
+            "id",
+            "event",
+            "enrolment_start_time",
+            "enrolment_end_time",
+            "minimum_attendee_capacity",
+            "maximum_attendee_capacity",
+            "waiting_list_capacity",
+            "maximum_group_size",
+            "instructions",
+            "confirmation_message",
+            "audience_min_age",
+            "audience_max_age",
+            "mandatory_fields",
+        )
+        if settings.WEB_STORE_INTEGRATION_ENABLED:
+            fields += ("vat_percentage",)
 
 
 class RegistrationPriceGroupAdminForm(forms.ModelForm):
@@ -21,7 +65,16 @@ class RegistrationPriceGroupAdminForm(forms.ModelForm):
         if self.instance.id:
             self.initial["vat_percentage"] = self.instance.vat_percentage
         else:
-            self.initial["vat_percentage"] = VatPercentage.VAT_24.value
+            self.fields["vat_percentage"].choices = [(None, "")] + self.fields[
+                "vat_percentage"
+            ].choices
+            self.initial["vat_percentage"] = None
+
+        self.fields["vat_percentage"].disabled = True
+        self.fields["vat_percentage"].required = False
+
+    def has_changed(self):
+        return True
 
     class Meta:
         model = RegistrationPriceGroup

--- a/registrations/tests/test_admin.py
+++ b/registrations/tests/test_admin.py
@@ -75,6 +75,7 @@ class TestRegistrationAdmin(TestCase):
             "/admin/registrations/registration/add/",
             {
                 "event": event2.id,
+                "vat_percentage": VatPercentage.VAT_10.value,
                 "registration_user_accesses-TOTAL_FORMS": 1,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 0,
@@ -117,6 +118,7 @@ class TestRegistrationAdmin(TestCase):
                     "/admin/registrations/registration/add/",
                     {
                         "event": event.id,
+                        "vat_percentage": VatPercentage.VAT_10.value,
                         "registration_user_accesses-TOTAL_FORMS": 1,
                         "registration_user_accesses-INITIAL_FORMS": 0,
                         "registration_price_groups-TOTAL_FORMS": 0,
@@ -164,6 +166,7 @@ class TestRegistrationAdmin(TestCase):
                     f"/admin/registrations/registration/{self.registration.id}/change/",
                     {
                         "event": self.registration.event.id,
+                        "vat_percentage": VatPercentage.VAT_10.value,
                         "registration_user_accesses-TOTAL_FORMS": 1,
                         "registration_user_accesses-INITIAL_FORMS": 0,
                         "registration_price_groups-TOTAL_FORMS": 0,
@@ -194,6 +197,7 @@ class TestRegistrationAdmin(TestCase):
                 "/admin/registrations/registration/add/",
                 {
                     "event": event2.id,
+                    "vat_percentage": VatPercentage.VAT_10.value,
                     "registration_user_accesses-TOTAL_FORMS": 2,
                     "registration_user_accesses-INITIAL_FORMS": 0,
                     "registration_user_accesses-0-email": EMAIL,
@@ -225,6 +229,7 @@ class TestRegistrationAdmin(TestCase):
                 "/admin/registrations/registration/add/",
                 {
                     "event": event2.id,
+                    "vat_percentage": VatPercentage.VAT_10.value,
                     "registration_user_accesses-TOTAL_FORMS": 1,
                     "registration_user_accesses-INITIAL_FORMS": 0,
                     "registration_user_accesses-0-email": EMAIL,
@@ -273,6 +278,7 @@ class TestRegistrationAdmin(TestCase):
                 f"/admin/registrations/registration/{self.registration.id}/change/",
                 {
                     "event": self.registration.event.id,
+                    "vat_percentage": VatPercentage.VAT_10.value,
                     "registration_user_accesses-TOTAL_FORMS": 2,
                     "registration_user_accesses-INITIAL_FORMS": 1,
                     "registration_user_accesses-0-email": EDITED_EMAIL,
@@ -310,16 +316,15 @@ class TestRegistrationAdmin(TestCase):
             "/admin/registrations/registration/add/",
             {
                 "event": event2.id,
+                "vat_percentage": VatPercentage.VAT_24.value,
                 "registration_user_accesses-TOTAL_FORMS": 0,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 2,
                 "registration_price_groups-INITIAL_FORMS": 0,
                 "registration_price_groups-0-price_group": price_group.pk,
                 "registration_price_groups-0-price": Decimal("10"),
-                "registration_price_groups-0-vat_percentage": VatPercentage.VAT_24.value,
                 "registration_price_groups-1-price_group": price_group2.pk,
                 "registration_price_groups-1-price": Decimal("5"),
-                "registration_price_groups-1-vat_percentage": VatPercentage.VAT_10.value,
             },
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
@@ -348,10 +353,10 @@ class TestRegistrationAdmin(TestCase):
         self.assertEqual(registration_price_group2.price, Decimal("5"))
         self.assertEqual(
             registration_price_group2.vat_percentage,
-            VatPercentage.VAT_10.value,
+            VatPercentage.VAT_24.value,
         )
-        self.assertEqual(registration_price_group2.price_without_vat, Decimal("4.55"))
-        self.assertEqual(registration_price_group2.vat, Decimal("0.45"))
+        self.assertEqual(registration_price_group2.price_without_vat, Decimal("4.03"))
+        self.assertEqual(registration_price_group2.vat, Decimal("0.97"))
 
     def test_add_price_groups_to_existing_registration(self):
         price_group = PriceGroupFactory(description="Adults")
@@ -364,6 +369,7 @@ class TestRegistrationAdmin(TestCase):
             f"/admin/registrations/registration/{self.registration.pk}/change/",
             {
                 "event": self.registration.event.id,
+                "vat_percentage": VatPercentage.VAT_14.value,
                 "registration_user_accesses-TOTAL_FORMS": 1,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 2,
@@ -371,11 +377,9 @@ class TestRegistrationAdmin(TestCase):
                 "registration_price_groups-0-registration": self.registration.id,
                 "registration_price_groups-0-price_group": price_group.pk,
                 "registration_price_groups-0-price": Decimal("10"),
-                "registration_price_groups-0-vat_percentage": VatPercentage.VAT_14.value,
                 "registration_price_groups-1-registration": self.registration.id,
                 "registration_price_groups-1-price_group": price_group2.pk,
                 "registration_price_groups-1-price": Decimal("5"),
-                "registration_price_groups-1-vat_percentage": VatPercentage.VAT_0.value,
             },
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
@@ -404,10 +408,10 @@ class TestRegistrationAdmin(TestCase):
         self.assertEqual(registration_price_group2.price, Decimal("5"))
         self.assertEqual(
             registration_price_group2.vat_percentage,
-            VatPercentage.VAT_0.value,
+            VatPercentage.VAT_14.value,
         )
-        self.assertEqual(registration_price_group2.price_without_vat, Decimal("5"))
-        self.assertEqual(registration_price_group2.vat, Decimal("0"))
+        self.assertEqual(registration_price_group2.price_without_vat, Decimal("4.39"))
+        self.assertEqual(registration_price_group2.vat, Decimal("0.61"))
 
     def test_cannot_add_duplicate_price_groups_to_registration(self):
         price_group = PriceGroupFactory(description="Adults")
@@ -419,6 +423,7 @@ class TestRegistrationAdmin(TestCase):
             f"/admin/registrations/registration/{self.registration.pk}/change/",
             {
                 "event": self.registration.event.id,
+                "vat_percentage": VatPercentage.VAT_24.value,
                 "registration_user_accesses-TOTAL_FORMS": 1,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 2,
@@ -426,11 +431,9 @@ class TestRegistrationAdmin(TestCase):
                 "registration_price_groups-0-registration": self.registration.id,
                 "registration_price_groups-0-price_group": price_group.pk,
                 "registration_price_groups-0-price": Decimal("10"),
-                "registration_price_groups-0-vat_percentage": VatPercentage.VAT_24.value,
                 "registration_price_groups-1-registration": self.registration.id,
                 "registration_price_groups-1-price_group": price_group.pk,
                 "registration_price_groups-1-price": Decimal("5"),
-                "registration_price_groups-1-vat_percentage": VatPercentage.VAT_24.value,
             },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -448,6 +451,7 @@ class TestRegistrationAdmin(TestCase):
             f"/admin/registrations/registration/{self.registration.pk}/change/",
             {
                 "event": self.registration.event.id,
+                "vat_percentage": VatPercentage.VAT_24.value,
                 "registration_user_accesses-TOTAL_FORMS": 1,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 2,
@@ -455,7 +459,6 @@ class TestRegistrationAdmin(TestCase):
                 "registration_price_groups-0-registration": self.registration.id,
                 "registration_price_groups-0-price_group": price_group.pk,
                 "registration_price_groups-0-price": Decimal("10.123"),
-                "registration_price_groups-0-vat_percentage": VatPercentage.VAT_24.value,
             },
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -475,6 +478,7 @@ class TestRegistrationAdmin(TestCase):
             f"/admin/registrations/registration/{self.registration.pk}/change/",
             {
                 "event": self.registration.event.id,
+                "vat_percentage": VatPercentage.VAT_24.value,
                 "registration_user_accesses-TOTAL_FORMS": 1,
                 "registration_user_accesses-INITIAL_FORMS": 0,
                 "registration_price_groups-TOTAL_FORMS": 1,
@@ -483,7 +487,6 @@ class TestRegistrationAdmin(TestCase):
                 "registration_price_groups-0-registration": self.registration.id,
                 "registration_price_groups-0-price_group": registration_price_group.price_group_id,
                 "registration_price_groups-0-price": Decimal("10"),
-                "registration_price_groups-0-vat_percentage": VatPercentage.VAT_24.value,
                 "registration_price_groups-0-DELETE": "on",
             },
         )

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -524,7 +524,7 @@ def test_create_registration_with_price_groups(user, api_client, event):
             {
                 "price_group": custom_price_group.pk,
                 "price": Decimal("15.55"),
-                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_24,
+                "vat_percentage": VatPercentage.VAT_24.value,
             },
         ],
     }
@@ -620,12 +620,12 @@ def test_cannot_create_registration_price_groups_with_different_vat_percentages(
             {
                 "price_group": default_price_group.pk,
                 "price": Decimal("10"),
-                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_24,
+                "vat_percentage": VatPercentage.VAT_24.value,
             },
             {
                 "price_group": custom_price_group.pk,
                 "price": Decimal("15.55"),
-                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_10,
+                "vat_percentage": VatPercentage.VAT_10.value,
             },
         ],
     }

--- a/registrations/tests/test_registration_put.py
+++ b/registrations/tests/test_registration_put.py
@@ -667,7 +667,7 @@ def test_update_price_groups_to_registration(api_client, event, user):
             {
                 "price_group": custom_price_group.pk,
                 "price": Decimal("15.55"),
-                "vat_percentage": VatPercentage.VAT_14.value,
+                "vat_percentage": VatPercentage.VAT_24.value,
             },
         ],
     }
@@ -698,8 +698,8 @@ def test_update_price_groups_to_registration(api_client, event, user):
             vat_percentage=registration_data["registration_price_groups"][1][
                 "vat_percentage"
             ],
-            price_without_vat=Decimal("13.64"),
-            vat=Decimal("1.91"),
+            price_without_vat=Decimal("12.54"),
+            vat=Decimal("3.01"),
         ).count()
         == 1
     )
@@ -814,6 +814,43 @@ def test_update_registration_price_groups_excluded_is_deleted(api_client, event,
         ).count()
         == 1
     )
+
+
+@pytest.mark.django_db
+def test_cannot_update_price_groups_to_registration_with_different_vat_percentages(
+    api_client, event, user
+):
+    api_client.force_authenticate(user)
+
+    registration = RegistrationFactory(event=event)
+
+    default_price_group = PriceGroup.objects.filter(publisher=None).first()
+    custom_price_group = PriceGroupFactory(publisher=event.publisher)
+
+    assert RegistrationPriceGroup.objects.count() == 0
+
+    registration_data = {
+        "event": {"@id": get_event_url(event.id)},
+        "registration_price_groups": [
+            {
+                "price_group": default_price_group.pk,
+                "price": Decimal("10"),
+                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_24,
+            },
+            {
+                "price_group": custom_price_group.pk,
+                "price": Decimal("15.55"),
+                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_14,
+            },
+        ],
+    }
+    response = update_registration(api_client, registration.pk, registration_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["registration_price_groups"]["price_group"][0] == (
+        "All registration price groups must have the same VAT percentage."
+    )
+
+    assert RegistrationPriceGroup.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/registrations/tests/test_registration_put.py
+++ b/registrations/tests/test_registration_put.py
@@ -835,12 +835,12 @@ def test_cannot_update_price_groups_to_registration_with_different_vat_percentag
             {
                 "price_group": default_price_group.pk,
                 "price": Decimal("10"),
-                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_24,
+                "vat_percentage": VatPercentage.VAT_24.value,
             },
             {
                 "price_group": custom_price_group.pk,
                 "price": Decimal("15.55"),
-                "vat_percentage": RegistrationPriceGroup.VatPercentage.VAT_14,
+                "vat_percentage": VatPercentage.VAT_14.value,
             },
         ],
     }


### PR DESCRIPTION
### Description
Enforces the use of the same VAT percentage for all registration price groups. This is applied to both the Django admin site and the API where the former uses a new general VAT field to provide a single value for all price groups and the latter has a new validation rule that allows only the same VAT value for all price groups.
### Closes
[LINK-1927](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1927)

[LINK-1927]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ