### PR TITLE
LINK-1959 | Add is_superuser field to UserSerializer

### DIFF
--- a/helevents/serializers.py
+++ b/helevents/serializers.py
@@ -36,6 +36,7 @@ class UserSerializer(serializers.ModelSerializer):
             "uuid",
             "department_name",
             "is_staff",
+            "is_superuser",
             "display_name",
             "is_external",
             "is_strongly_identified",

--- a/helevents/tests/test_user_get.py
+++ b/helevents/tests/test_user_get.py
@@ -33,6 +33,7 @@ def assert_user_fields_exist(data, version="v1"):
         "department_name",
         "organization",
         "is_staff",
+        "is_superuser",
         "display_name",
         "admin_organizations",
         "registration_admin_organizations",


### PR DESCRIPTION
### Description
Adds the `is_superuser` field to `UserSerializer`.
### Closes
[LINK-1959](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1959)