### PR TITLE
LINK-1965 | Financial admin with admin role can POST or PUT organization data

### DIFF
--- a/events/permissions.py
+++ b/events/permissions.py
@@ -162,7 +162,11 @@ class DataSourceOrganizationEditPermission(BasePermission):
                 request.data.get("web_store_merchants")
                 or request.data.get("web_store_accounts")
             ):
-                return request.user.is_authenticated and request.user.is_superuser
+                return request.user.is_authenticated and (
+                    request.user.is_superuser
+                    or request.user.admin_organizations.exists()
+                    and request.user.financial_admin_organizations.exists()
+                )
             elif (
                 request.user.is_authenticated
                 and request.user.admin_organizations.exists()
@@ -189,7 +193,11 @@ class DataSourceOrganizationEditPermission(BasePermission):
             data_keys = request.data.keys()
 
             if len(data_keys) > 1:
-                return request.user.is_superuser
+                return (
+                    request.user.is_superuser
+                    or request.user.is_financial_admin_of(obj)
+                    and utils.organization_can_be_edited_by(obj, request.user)
+                )
             else:
                 return request.user.is_superuser or request.user.is_financial_admin_of(
                     obj


### PR DESCRIPTION
### Description
It was not possible for a user with both a financial admin and an organization admin permissions to create or update an organization if the payload contained web store merchant or account data. This PR fixes the issue.
### Closes
[LINK-1965](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1965)

[LINK-1965]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ