### PR TITLE
LINK-1968 | Make merchant_id read-only

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1517,6 +1517,7 @@ class WebStoreMerchantSerializer(CreatedModifiedBaseSerializer):
             "paytrail_merchant_id",
             "merchant_id",
         ) + CreatedModifiedBaseSerializer.Meta.fields
+        extra_kwargs = {"merchant_id": {"read_only": True}}
 
 
 class WebStoreAccountSerializer(CreatedModifiedBaseSerializer):

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from unittest.mock import patch
 
 import pytest
 from django.utils import translation


### PR DESCRIPTION
### Description
Changes the `WebStoreMerchantSerializer.merchant_id` field to have `read_only=True`. This is because the value is set automatically based on the Talpa API response and should not be editable through the API.
### Closes
[LINK-1968](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1968)

[LINK-1968]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ