### PR TITLE
LINK-1994 | Fix signup unpaid order cancellation

### DIFF
--- a/registrations/management/commands/mark_payments_expired.py
+++ b/registrations/management/commands/mark_payments_expired.py
@@ -56,9 +56,13 @@ class Command(BaseCommand):
         payment.status = SignUpPayment.PaymentStatus.EXPIRED
         payment.save(update_fields=["status"])
 
+        user = getattr(payment, "created_by", None)
+
         try:
             # Talpa recommends to cancel the order in this case.
-            order_api_client.cancel_order(payment.external_order_id)
+            order_api_client.cancel_order(
+                payment.external_order_id, user_uuid=str(getattr(user, "uuid", ""))
+            )
         except RequestException as exc:
             status_code = getattr(exc.response, "status_code", None)
 

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -263,9 +263,12 @@ def create_web_store_product_mapping(product_mapping_data: dict):
 
 def cancel_web_store_order(payment):
     client = WebStoreOrderAPIClient()
+    user = getattr(payment, "created_by", None)
 
     try:
-        resp_json = client.cancel_order(payment.external_order_id)
+        resp_json = client.cancel_order(
+            payment.external_order_id, user_uuid=str(getattr(user, "uuid", ""))
+        )
     except RequestException as request_exc:
         api_error_message = get_web_store_api_error_message(request_exc.response)
         raise WebStoreAPIError(api_error_message)

--- a/web_store/order/clients.py
+++ b/web_store/order/clients.py
@@ -25,9 +25,9 @@ class WebStoreOrderAPIClient(WebStoreAPIBaseClient):
             },
         )
 
-    def cancel_order(self, order_id: str) -> dict:
+    def cancel_order(self, order_id: str, user_uuid: str) -> dict:
         return self._make_request(
-            f"{self.order_api_base_url}/{order_id}/cancel",
+            f"{self.order_api_base_url}{order_id}/cancel",
             "post",
-            headers={"api-key": self.api_key},
+            headers={"user": user_uuid},
         )

--- a/web_store/tests/order/test_web_store_order_api_client.py
+++ b/web_store/tests/order/test_web_store_order_api_client.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 from unittest.mock import patch
-from uuid import uuid4
 
 import pytest
 from django.conf import settings
@@ -12,7 +11,8 @@ from web_store.order.clients import WebStoreOrderAPIClient
 from web_store.order.enums import WebStoreOrderStatus
 from web_store.tests.utils import get_mock_response
 
-DEFAULT_ORDER_ID = str(uuid4())
+DEFAULT_USER_UUID = "f5e87f5c-8d16-4746-8e96-5a5a88b9224e"
+DEFAULT_ORDER_ID = "c7ae2960-8284-4b92-b82e-9da882c452d7"
 DEFAULT_ITEM = {
     "productId": "product_id",
     "productName": "description",
@@ -170,7 +170,9 @@ def test_cancel_order_success():
 
     with patch("requests.post") as mocked_request:
         mocked_request.return_value = mocked_response
-        response_json = client.cancel_order(order_id=DEFAULT_ORDER_ID)
+        response_json = client.cancel_order(
+            order_id=DEFAULT_ORDER_ID, user_uuid=DEFAULT_USER_UUID
+        )
 
         assert response_json == DEFAULT_CANCEL_ORDER_DATA
 
@@ -190,4 +192,4 @@ def test_cancel_order_exception(status_code):
 
     with patch("requests.post") as mocked_request, pytest.raises(RequestException):
         mocked_request.return_value = mocked_response
-        client.cancel_order(order_id=DEFAULT_ORDER_ID)
+        client.cancel_order(order_id=DEFAULT_ORDER_ID, user_uuid=DEFAULT_USER_UUID)


### PR DESCRIPTION
### Description
Fixes unpaid order cancellation. The request path and header were wrong in the Talpa Order Experience API client, and the system was not passing the user UUID as string at all to the client or the API in the request header.
### Closes
[LINK-1994](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1994)

[LINK-1994]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ