### PR TITLE
LINK-1999 | Mark transferred signup with payment as attending

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -558,6 +558,9 @@ class Registration(CreatedModifiedBaseModel):
         if not payment:
             self.move_first_waitlisted_to_attending(first_on_list)
         else:
+            first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
+            first_on_list.save(update_fields=["attendee_status"])
+
             contact_person = first_on_list.actual_contact_person
             contact_person.send_notification(
                 SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,

--- a/registrations/tests/management/test_mark_payments_expired.py
+++ b/registrations/tests/management/test_mark_payments_expired.py
@@ -332,7 +332,7 @@ def test_mark_payments_expired_signup_moved_to_waitlisted_with_payment_link():
     assert SignUp.objects.count() == 1
 
     waitlisted_signup.refresh_from_db()
-    assert waitlisted_signup.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert waitlisted_signup.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     new_payment = SignUpPayment.objects.first()
     assert new_payment.signup_id == waitlisted_signup.pk
@@ -504,7 +504,7 @@ def test_mark_payments_expired_payment_cancelled_signup_moved_to_waitlisted_with
     assert SignUp.objects.count() == 1
 
     waitlisted_signup.refresh_from_db()
-    assert waitlisted_signup.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert waitlisted_signup.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     new_payment = SignUpPayment.objects.first()
     assert new_payment.signup_id == waitlisted_signup.pk

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1219,9 +1219,8 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist(
 
     assert SignUpPayment.objects.count() == 1
 
-    # Signup 2 status is not changed until a webhook notification updates the status.
     signup2.refresh_from_db()
-    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     assert_payment_link_email_sent(
         contact_person2,
@@ -1328,9 +1327,8 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist_for_
 
     assert SignUpPayment.objects.count() == 1
 
-    # Signup 2 status is not changed until a webhook notification updates the status.
     signup2.refresh_from_db()
-    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     assert_payment_link_email_sent(
         contact_person2,

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -1268,9 +1268,8 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
 
     assert SignUpPayment.objects.count() == 1
 
-    # Signup 2 status is not changed until a webhook notification updates the status.
     signup2.refresh_from_db()
-    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     assert_payment_link_email_sent(
         contact_person2,
@@ -1313,7 +1312,7 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
 )
 @freeze_time("2024-02-01 03:30:00+02:00")
 @pytest.mark.django_db
-def test_group_send_email_with_payment_link_when_moving_participant_from_waitlist_for_recurring_event(
+def test_group_send_email_with_payment_link_when_moving_to_participant_for_recurring_event(
     api_client,
     service_language,
     expected_subject,
@@ -1378,9 +1377,8 @@ def test_group_send_email_with_payment_link_when_moving_participant_from_waitlis
 
     assert SignUpPayment.objects.count() == 1
 
-    # Signup 2 status is not changed until a webhook notification updates the status.
     signup2.refresh_from_db()
-    assert signup2.attendee_status == SignUp.AttendeeStatus.WAITING_LIST
+    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
     assert_payment_link_email_sent(
         contact_person2,


### PR DESCRIPTION
### Description
Immediately mark a signup with a newly-created payment as "attending" when they are transferred from the waiting list to attending for a registration that requires a payment. This is what normally happens when signup is created as attending.

### Closes
[LINK-1999](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1999)

[LINK-1999]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ