### PR TITLE
LINK-1799 | Cancel signups on event deletion or cancellation

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3651,7 +3651,11 @@ class EventViewSet(
         ):
             raise DRFPermissionDenied()
 
-        serializer.save()
+        try:
+            serializer.save()
+        except WebStoreAPIError as exc:
+            raise serializers.ValidationError(exc.messages)
+
         response = Response(data=serializer.data)
 
         original_event = Event.objects.get(id=response.data["id"])
@@ -3682,7 +3686,10 @@ class EventViewSet(
             ):
                 raise DRFPermissionDenied()
 
-        super().perform_update(serializer)
+        try:
+            super().perform_update(serializer)
+        except WebStoreAPIError as exc:
+            raise serializers.ValidationError(exc.messages)
 
     @transaction.atomic
     def bulk_update(self, request, *args, **kwargs):
@@ -3784,7 +3791,11 @@ class EventViewSet(
             instance.publisher, instance.publication_status, instance.created_by
         ):
             raise DRFPermissionDenied()
-        instance.soft_delete()
+
+        try:
+            instance.soft_delete()
+        except WebStoreAPIError as exc:
+            raise serializers.ValidationError(exc.messages)
 
     def retrieve(self, request, *args, **kwargs):
         try:

--- a/events/models.py
+++ b/events/models.py
@@ -1114,7 +1114,6 @@ class Event(
     class MPTTMeta:
         parent_attr = "super_event"
 
-    @transaction.atomic
     def save(self, *args, **kwargs):
         if self._has_circular_replacement():
             raise ValidationError(
@@ -1136,6 +1135,7 @@ class Event(
         old_location = None
 
         # needed for notifications
+        old_event_status = None
         old_publication_status = None
         old_deleted = None
         created = True
@@ -1146,6 +1146,7 @@ class Event(
                 created = False
                 old_location = event.location
                 old_publication_status = event.publication_status
+                old_event_status = event.event_status
                 old_deleted = event.deleted
             except Event.DoesNotExist:
                 pass
@@ -1163,42 +1164,84 @@ class Event(
                     }
                 )
 
-        super().save(*args, **kwargs)
+        event_cancelled = (
+            old_event_status != self.event_status
+            and self.event_status == Event.Status.CANCELLED
+        )
+        event_deleted = old_deleted is False and self.deleted is True
 
-        # needed to cache location event numbers
-        if not old_location and self.location:
-            Place.objects.filter(id=self.location.id).update(n_events_changed=True)
-        if old_location and not self.location:
-            # drafts (or imported events) may not always have location set
-            Place.objects.filter(id=old_location.id).update(n_events_changed=True)
-        if old_location and self.location and old_location != self.location:
-            Place.objects.filter(id__in=(old_location.id, self.location.id)).update(
-                n_events_changed=True
-            )
+        registration_to_cancel = None
+        registration_cancelled = False
+        if (
+            (event_deleted or event_cancelled)
+            and (registration_to_cancel := getattr(self, "registration", None))
+            and registration_to_cancel.has_payments
+        ):
+            # Registration signups needs to be cancelled or notified if related event is
+            # cancelled or deleted. If there are Talpa payments, handle the signups
+            # individually outside of the event transaction due to API calls to the Talpa API.
+            registration_to_cancel.cancel_signups(is_event_cancellation=True)
+            registration_cancelled = True
 
-        # send notifications
-        if (
-            old_publication_status == PublicationStatus.DRAFT
-            and self.publication_status == PublicationStatus.PUBLIC
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+
+            # needed to cache location event numbers
+            if not old_location and self.location:
+                Place.objects.filter(id=self.location.id).update(n_events_changed=True)
+            if old_location and not self.location:
+                # drafts (or imported events) may not always have location set
+                Place.objects.filter(id=old_location.id).update(n_events_changed=True)
+            if old_location and self.location and old_location != self.location:
+                Place.objects.filter(id__in=(old_location.id, self.location.id)).update(
+                    n_events_changed=True
+                )
+
+            # send notifications
+            if (
+                old_publication_status == PublicationStatus.DRAFT
+                and self.publication_status == PublicationStatus.PUBLIC
+            ):
+                self.send_published_notification()
+            if self.publication_status == PublicationStatus.DRAFT and event_deleted:
+                self.send_deleted_notification()
+            if (
+                created
+                and self.publication_status == PublicationStatus.DRAFT
+                and not self.is_created_with_apikey
+                # Only send super event notification to avoid spamming from
+                # child events when recurring event.
+                and not (
+                    self.super_event
+                    and self.super_event.super_event_type
+                    == Event.SuperEventType.RECURRING
+                )
+                # Do not send draft emails from events created by admins.
+                and not self.publisher.admin_users.filter(
+                    id=self.created_by_id
+                ).exists()
+            ):
+                self.send_draft_posted_notification()
+
+            if (event_deleted or event_cancelled) and not registration_cancelled:
+                # If there weren't any Talpa payments, cancel the registration or notify the
+                # contact persons in the event transaction so that all changes can be reverted
+                # in case of an exception.
+                self.cancel_registration_signups_or_notify_contact_person(
+                    registration_to_cancel
+                )
+
+    def cancel_registration_signups_or_notify_contact_person(self, registration=None):
+        if registration:
+            registration.cancel_signups(is_event_cancellation=True)
+        elif (
+            self.super_event_id is not None
+            and self.super_event.super_event_type == Event.SuperEventType.RECURRING
+            and (registration := getattr(self.super_event, "registration", None))
         ):
-            self.send_published_notification()
-        if self.publication_status == PublicationStatus.DRAFT and (
-            old_deleted is False and self.deleted is True
-        ):
-            self.send_deleted_notification()
-        if (
-            created
-            and self.publication_status == PublicationStatus.DRAFT
-            and not self.is_created_with_apikey
-            # Only send super event notification to avoid spamming from child events when recurring event.
-            and not (
-                self.super_event
-                and self.super_event.super_event_type == Event.SuperEventType.RECURRING
+            registration.send_event_cancellation_notifications(
+                is_sub_event_cancellation=True
             )
-            # Do not send draft emails from events created by admins.
-            and not self.publisher.admin_users.filter(id=self.created_by_id).exists()
-        ):
-            self.send_draft_posted_notification()
 
     def __str__(self):
         name = ""

--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -1,17 +1,9 @@
 from django.db import transaction
 from django.db.models import Q
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from events.models import Event
-from registrations.models import (
-    Registration,
-    SeatReservationCode,
-    SignUp,
-    SignUpContactPerson,
-    SignUpGroup,
-    SignUpNotificationType,
-)
+from registrations.models import Registration, SeatReservationCode, SignUp, SignUpGroup
 from registrations.utils import get_signup_create_url, move_waitlisted_to_attending
 
 
@@ -61,54 +53,6 @@ def _recalculate_registration_capacities(registration_id: int) -> None:
         move_waitlisted_to_attending(
             registration, count=new_remaining_attendee_capacity
         )
-
-
-def _send_event_cancellation_notification(event):
-    is_recurring_sub_event_cancellation = (
-        event.super_event_id is not None
-        and event.super_event.super_event_type == Event.SuperEventType.RECURRING
-        and getattr(event, "registration", None) is None
-    )
-
-    if is_recurring_sub_event_cancellation:
-        # When a sub-event is cancelled, a registration might have been done to the super event
-        # => notify that registration's contact person.
-        qs_filter = Q(event_id=event.super_event_id)
-    else:
-        qs_filter = Q(event_id=event.pk)
-
-    registration_ids = Registration.objects.filter(qs_filter).values_list(
-        "pk", flat=True
-    )
-
-    for contact_person in SignUpContactPerson.objects.filter(
-        Q(email__isnull=False)
-        & ~Q(email="")
-        & (
-            Q(signup__registration_id__in=registration_ids)
-            | Q(signup_group__registration_id__in=registration_ids)
-        )
-    ):
-        contact_person.send_notification(
-            SignUpNotificationType.EVENT_CANCELLATION,
-            is_sub_event_cancellation=is_recurring_sub_event_cancellation,
-        )
-
-
-@receiver(
-    pre_save,
-    sender=Event,
-    dispatch_uid="notify_signups_on_event_cancellation_pre_save",
-)
-def notify_signups_on_event_cancellation_pre_save(
-    sender: type[Event], instance: Event, **kwargs: dict
-) -> None:
-    if not (instance.pk and instance.event_status == Event.Status.CANCELLED):
-        return
-
-    old_instance = Event.objects.filter(pk=instance.pk).first()
-    if old_instance and old_instance.event_status != instance.event_status:
-        _send_event_cancellation_notification(instance)
 
 
 @receiver(

--- a/registrations/tests/test_event_cancellation_notification.py
+++ b/registrations/tests/test_event_cancellation_notification.py
@@ -1,11 +1,16 @@
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import Optional
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
+import requests_mock
+from django.conf import settings
 from django.core import mail
 from django.utils import translation
 from django.utils.timezone import localtime
+from mailer.models import Message
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -14,7 +19,7 @@ from events.tests.conftest import TEXT_EN, TEXT_FI, TEXT_SV
 from events.tests.factories import EventFactory, LanguageFactory, PlaceFactory
 from events.tests.utils import versioned_reverse as reverse
 from helevents.tests.factories import UserFactory
-from registrations.models import SignUp, SignUpContactPerson, SignUpGroup
+from registrations.models import SignUp, SignUpContactPerson, SignUpGroup, SignUpPayment
 from registrations.notifications import (
     recurring_event_signup_email_texts,
     recurring_event_signup_notification_subjects,
@@ -27,6 +32,14 @@ from registrations.tests.factories import (
     SignUpContactPersonFactory,
     SignUpFactory,
     SignUpGroupFactory,
+    SignUpPaymentFactory,
+)
+from web_store.tests.order.test_web_store_order_api_client import (
+    DEFAULT_CANCEL_ORDER_DATA,
+    DEFAULT_ORDER_ID,
+)
+from web_store.tests.payment.test_web_store_payment_api_client import (
+    DEFAULT_GET_REFUND_DATA,
 )
 
 
@@ -72,45 +85,10 @@ class EventCancellationNotificationAPITestCase(APITestCase):
     def setUp(self):
         self.client.force_authenticate(self.user)
 
-    @classmethod
-    def _create_signups_and_contact_persons_for_registration(
-        cls, registration, number_of_signups=2
-    ):
-        assert number_of_signups <= len(cls.languages)
-
-        for idx in range(0, number_of_signups):
-            signup = SignUpFactory(registration=registration)
-            SignUpContactPersonFactory(
-                signup=signup,
-                email=f"test-signup{idx}@test.com",
-                service_language=cls.languages[idx],
-            )
-
-    def test_event_put_cancellation_email_sent_to_contact_persons(self):
-        contact_person_count = SignUpContactPerson.objects.count()
-        self.assertEqual(contact_person_count, 3)
-
-        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
-
-        complex_event_dict = self.make_complex_event_dict(
-            self.event.data_source,
-            self.event.publisher,
-            self.location_id,
-            self.languages,
-        )
-        complex_event_dict["event_status"] = "EventCancelled"
-
-        response = self.client.put(
-            self.event_detail_url,
-            complex_event_dict,
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.event.refresh_from_db()
-        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
-
-        self.assertEqual(len(mail.outbox), contact_person_count)
+    def assertCancellationEmailsSent(self, contact_person_count):
+        # Both event cancellation and signup cancellation emails will be sent
+        # so two emails per each of the three contact persons.
+        self.assertEqual(len(mail.outbox), contact_person_count * 2)
 
         notification_subject = signup_notification_subjects[
             SignUpNotificationType.EVENT_CANCELLATION
@@ -136,44 +114,10 @@ class EventCancellationNotificationAPITestCase(APITestCase):
                 )
                 self.assertTrue(str(notification_texts["text"]) in html_message)
 
-    def test_event_put_cancellation_email_sent_to_contact_persons_for_recurring_event(
-        self,
-    ):
-        self.event.super_event_type = Event.SuperEventType.RECURRING
-        self.event.start_time = localtime()
-        self.event.end_time = self.event.start_time + timedelta(days=30)
-        self.event.save(update_fields=["super_event_type", "start_time", "end_time"])
-
-        contact_person_count = SignUpContactPerson.objects.count()
-        self.assertEqual(contact_person_count, 3)
-
-        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
-
-        complex_event_dict = self.make_complex_event_dict(
-            self.event.data_source,
-            self.event.publisher,
-            self.location_id,
-            self.languages,
-        )
-        complex_event_dict.update(
-            {
-                "event_status": "EventCancelled",
-                "start_time": self.event.start_time,
-                "end_time": self.event.end_time,
-            }
-        )
-
-        response = self.client.put(
-            self.event_detail_url,
-            complex_event_dict,
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.event.refresh_from_db()
-        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
-
-        self.assertEqual(len(mail.outbox), contact_person_count)
+    def assertCancellationEmailsSentForRecurringEvent(self, contact_person_count):
+        # Both event cancellation and signup cancellation emails will be sent
+        # so two emails per each of the three contact persons.
+        self.assertEqual(len(mail.outbox), contact_person_count * 2)
 
         notification_subject = recurring_event_signup_notification_subjects[
             SignUpNotificationType.EVENT_CANCELLATION
@@ -205,55 +149,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
                 )
                 self.assertTrue(str(notification_texts["text"]) in html_message)
 
-    def test_recurring_sub_event_put_cancellation_email_sent_to_contact_persons_of_super_event(
-        self,
-    ):
-        self.event.super_event_type = Event.SuperEventType.RECURRING
-        self.event.start_time = localtime()
-        self.event.end_time = self.event.start_time + timedelta(days=30)
-        self.event.save(update_fields=["super_event_type", "start_time", "end_time"])
-
-        sub_event = EventFactory(
-            data_source=self.event.data_source,
-            publisher=self.event.publisher,
-            super_event=self.event,
-            start_time=self.event.start_time,
-            end_time=self.event.start_time + timedelta(hours=1),
-        )
-        sub_event_detail_url = reverse("event-detail", kwargs={"pk": sub_event.pk})
-
-        contact_person_count = SignUpContactPerson.objects.count()
-        self.assertEqual(contact_person_count, 3)
-
-        self.assertNotEqual(sub_event.event_status, Event.Status.CANCELLED)
-
-        complex_event_dict = self.make_complex_event_dict(
-            sub_event.data_source,
-            sub_event.publisher,
-            self.location_id,
-            self.languages,
-        )
-        complex_event_dict.update(
-            {
-                "event_status": "EventCancelled",
-                "start_time": sub_event.start_time,
-                "end_time": sub_event.end_time,
-            }
-        )
-
-        response = self.client.put(
-            sub_event_detail_url,
-            complex_event_dict,
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.event.refresh_from_db()
-        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
-
-        sub_event.refresh_from_db()
-        self.assertEqual(sub_event.event_status, Event.Status.CANCELLED)
-
+    def assertCancellationEmailsSentForRecurringSubEvent(self, contact_person_count):
+        # Only sub-event cancellation emails are sent. Signups related to the recurring super-event
+        # are not cancelled so no additional emails are sent about them.
         self.assertEqual(len(mail.outbox), contact_person_count)
 
         notification_subject = signup_notification_subjects[
@@ -286,10 +184,849 @@ class EventCancellationNotificationAPITestCase(APITestCase):
                 )
                 self.assertTrue(str(notification_texts["text"]) in html_message)
 
-    def test_event_put_cancellation_email_not_sent_to_contact_persons_if_cancelled_again(
+    @classmethod
+    def _create_signups_and_contact_persons_for_registration(
+        cls, registration, number_of_signups=2
+    ):
+        assert number_of_signups <= len(cls.languages)
+
+        for idx in range(0, number_of_signups):
+            signup = SignUpFactory(registration=registration)
+            SignUpContactPersonFactory(
+                signup=signup,
+                email=f"test-signup{idx}@test.com",
+                service_language=cls.languages[idx],
+            )
+
+    @staticmethod
+    def _create_signup_payments(payments_kwargs: Optional[list[dict]] = None):
+        if payments_kwargs:
+            for payment_kwargs in payments_kwargs:
+                SignUpPaymentFactory(**payment_kwargs)
+        else:
+            signup_group = SignUpGroup.objects.first()
+            SignUpPaymentFactory(
+                signup=None,
+                signup_group=signup_group,
+                external_order_id=DEFAULT_ORDER_ID,
+                status=SignUpPayment.PaymentStatus.PAID,
+            )
+
+            signup_without_group = SignUp.objects.filter(
+                registration_id=signup_group.registration_id,
+                signup_group_id__isnull=True,
+            ).first()
+            SignUpPaymentFactory(
+                signup=signup_without_group,
+                external_order_id=DEFAULT_ORDER_ID,
+                status=SignUpPayment.PaymentStatus.PAID,
+            )
+
+    @staticmethod
+    def _create_sub_event(
+        event,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ):
+        sub_event = EventFactory(
+            data_source=event.data_source,
+            publisher=event.publisher,
+            super_event=event,
+            start_time=start_time or event.start_time,
+            end_time=end_time or event.start_time + timedelta(hours=1),
+        )
+        sub_event_detail_url = reverse("event-detail", kwargs={"pk": sub_event.pk})
+
+        return sub_event, sub_event_detail_url
+
+    @staticmethod
+    def _make_super_event(
+        event,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ):
+        event.super_event_type = Event.SuperEventType.RECURRING
+        event.start_time = start_time or localtime()
+        event.end_time = end_time or event.start_time + timedelta(days=30)
+        event.save(update_fields=["super_event_type", "start_time", "end_time"])
+
+    def test_event_put_signups_cancelled_and_cancellation_emails_sent_to_contact_persons(
+        self,
+    ):
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        response = self.client.put(
+            self.event_detail_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+
+        self.assertCancellationEmailsSent(contact_person_count)
+
+    def test_event_put_signups_cancelled_and_payments_refunded(self):
+        self._create_signup_payments()
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 2)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertCancellationEmailsSent(contact_person_count)
+
+    def test_event_put_signups_cancelled_and_payments_cancelled(self):
+        # Create two payments with the status "CREATED". These will be cancelled instead of
+        # refunded as they are not paid yet.
+        signup_group = SignUpGroup.objects.first()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": None,
+                    "signup_group": signup_group,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+                {
+                    "signup": SignUp.objects.filter(
+                        registration_id=signup_group.registration_id,
+                        signup_group_id__isnull=True,
+                    ).first(),
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+            ]
+        )
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/{DEFAULT_ORDER_ID}/cancel",
+                json=DEFAULT_CANCEL_ORDER_DATA,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 2)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertCancellationEmailsSent(contact_person_count)
+
+    def test_event_bulk_update_signups_cancelled_and_payments_refunded(self):
+        registration2 = RegistrationFactory(event__publisher=self.event.publisher)
+        event2 = registration2.event
+
+        signup_group2 = SignUpGroupFactory(registration=registration2)
+        SignUpFactory(signup_group=signup_group2, registration=registration2)
+        SignUpContactPersonFactory(
+            signup_group=signup_group2,
+            email="test-group2@test.com",
+            service_language=self.languages[2],
+        )
+
+        signup6 = SignUpFactory(registration=registration2)
+        SignUpContactPersonFactory(
+            signup=signup6,
+            email="test-signup6@test.com",
+            service_language=self.languages[2],
+        )
+
+        external_order_id2 = str(uuid4())
+
+        self._create_signup_payments()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": None,
+                    "signup_group": signup_group2,
+                    "external_order_id": external_order_id2,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+                {
+                    "signup": signup6,
+                    "external_order_id": external_order_id2,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+            ]
+        )
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 5)
+        self.assertEqual(SignUpGroup.objects.count(), 2)
+        self.assertEqual(SignUp.objects.count(), 6)
+        self.assertEqual(SignUpPayment.objects.count(), 4)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+        self.assertNotEqual(event2.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["id"] = self.event.pk
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        complex_event_dict2 = self.make_complex_event_dict(
+            event2.data_source,
+            event2.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict2["id"] = event2.pk
+        complex_event_dict2["event_status"] = "EventCancelled"
+
+        default_get_refund_data2 = deepcopy(DEFAULT_GET_REFUND_DATA)
+        default_get_refund_data2["orderId"] = external_order_id2
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{external_order_id2}",
+                json=default_get_refund_data2,
+            )
+
+            response = self.client.put(
+                reverse("event-list"),
+                [complex_event_dict, complex_event_dict2],
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 4)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        event2.refresh_from_db()
+        self.assertEqual(event2.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertCancellationEmailsSent(contact_person_count)
+
+    def test_event_bulk_update_signups_cancelled_and_payments_cancelled(self):
+        registration2 = RegistrationFactory(event__publisher=self.event.publisher)
+        event2 = registration2.event
+
+        signup_group = SignUpGroup.objects.first()
+
+        signup_group2 = SignUpGroupFactory(registration=registration2)
+        SignUpFactory(signup_group=signup_group2, registration=registration2)
+        SignUpContactPersonFactory(
+            signup_group=signup_group2,
+            email="test-group2@test.com",
+            service_language=self.languages[2],
+        )
+
+        signup6 = SignUpFactory(registration=registration2)
+        SignUpContactPersonFactory(
+            signup=signup6,
+            email="test-signup6@test.com",
+            service_language=self.languages[2],
+        )
+
+        external_order_id2 = str(uuid4())
+
+        self._create_signup_payments(
+            [
+                {
+                    "signup": None,
+                    "signup_group": signup_group,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+                {
+                    "signup": SignUp.objects.filter(
+                        registration_id=signup_group.registration_id,
+                        signup_group_id__isnull=True,
+                    ).first(),
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+                {
+                    "signup": None,
+                    "signup_group": signup_group2,
+                    "external_order_id": external_order_id2,
+                },
+                {
+                    "signup": signup6,
+                    "external_order_id": external_order_id2,
+                },
+            ]
+        )
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 5)
+        self.assertEqual(SignUpGroup.objects.count(), 2)
+        self.assertEqual(SignUp.objects.count(), 6)
+        self.assertEqual(SignUpPayment.objects.count(), 4)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+        self.assertNotEqual(event2.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["id"] = self.event.pk
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        complex_event_dict2 = self.make_complex_event_dict(
+            event2.data_source,
+            event2.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict2["id"] = event2.pk
+        complex_event_dict2["event_status"] = "EventCancelled"
+
+        cancel_order_data2 = deepcopy(DEFAULT_CANCEL_ORDER_DATA)
+        cancel_order_data2["orderId"] = external_order_id2
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/{DEFAULT_ORDER_ID}/cancel",
+                json=DEFAULT_CANCEL_ORDER_DATA,
+            )
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/{external_order_id2}/cancel",
+                json=cancel_order_data2,
+            )
+
+            response = self.client.put(
+                reverse("event-list"),
+                [complex_event_dict, complex_event_dict2],
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 4)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        event2.refresh_from_db()
+        self.assertEqual(event2.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertCancellationEmailsSent(contact_person_count)
+
+    def test_event_bulk_update_web_store_api_exception(self):
+        registration2 = RegistrationFactory(event__publisher=self.event.publisher)
+        event2 = registration2.event
+
+        signup_group2 = SignUpGroupFactory(registration=registration2)
+        SignUpFactory(signup_group=signup_group2, registration=registration2)
+        SignUpContactPersonFactory(
+            signup_group=signup_group2,
+            email="test-group2@test.com",
+            service_language=self.languages[2],
+        )
+
+        signup6 = SignUpFactory(registration=registration2)
+        SignUpContactPersonFactory(
+            signup=signup6,
+            email="test-signup6@test.com",
+            service_language=self.languages[2],
+        )
+
+        external_order_id2 = str(uuid4())
+
+        self._create_signup_payments()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": None,
+                    "signup_group": signup_group2,
+                    "external_order_id": external_order_id2,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+                {
+                    "signup": signup6,
+                    "external_order_id": external_order_id2,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+            ]
+        )
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 5)
+        self.assertEqual(SignUpGroup.objects.count(), 2)
+        self.assertEqual(SignUp.objects.count(), 6)
+        self.assertEqual(SignUpPayment.objects.count(), 4)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+        self.assertNotEqual(event2.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["id"] = self.event.pk
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        complex_event_dict2 = self.make_complex_event_dict(
+            event2.data_source,
+            event2.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict2["id"] = event2.pk
+        complex_event_dict2["event_status"] = "EventCancelled"
+
+        default_get_refund_data2 = deepcopy(DEFAULT_GET_REFUND_DATA)
+        default_get_refund_data2["orderId"] = external_order_id2
+
+        self.assertEqual(Message.objects.count(), 0)
+
+        with (
+            self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
+            requests_mock.Mocker() as req_mock,
+        ):
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{external_order_id2}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+            response = self.client.put(
+                reverse("event-list"),
+                [complex_event_dict, complex_event_dict2],
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+            self.assertEqual(req_mock.call_count, 3)
+
+        self.event.refresh_from_db()
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        event2.refresh_from_db()
+        self.assertNotEqual(event2.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 5)
+        self.assertEqual(SignUpGroup.objects.count(), 2)
+        self.assertEqual(SignUp.objects.count(), 6)
+        self.assertEqual(SignUpPayment.objects.count(), 4)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(Message.objects.count(), 0)
+
+    def test_event_put_web_store_api_exception(self):
+        self._create_signup_payments()
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data[0],
+                "Payment refund or cancellation failed for SignUpGroup with ID "
+                f"{SignUpGroup.objects.first().pk}.",
+            )
+
+            self.assertEqual(req_mock.call_count, 1)
+
+        self.event.refresh_from_db()
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_put_signup_web_store_api_exception(self):
+        signup_group = SignUpGroup.objects.first()
+        signup = SignUp.objects.first()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": signup,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+                {
+                    "signup": None,
+                    "signup_group": signup_group,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+            ]
+        )
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(Message.objects.count(), 0)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with (
+            self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
+            requests_mock.Mocker() as req_mock,
+        ):
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data[0],
+                f"Payment refund or cancellation failed for SignUpGroup with ID {signup_group.pk}.",
+            )
+
+            self.assertEqual(req_mock.call_count, 1)
+
+        self.event.refresh_from_db()
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(Message.objects.count(), 0)
+
+    def test_event_put_signups_cancelled_and_cancellation_emails_sent_for_recurring_event(
+        self,
+    ):
+        self._make_super_event(self.event)
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict.update(
+            {
+                "event_status": "EventCancelled",
+                "start_time": self.event.start_time,
+                "end_time": self.event.end_time,
+            }
+        )
+
+        response = self.client.put(
+            self.event_detail_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+
+        self.assertCancellationEmailsSentForRecurringEvent(contact_person_count)
+
+    def test_event_put_cancellation_emails_sent_and_payments_refunded_for_recurring_event(
+        self,
+    ):
+        self._create_signup_payments()
+        self._make_super_event(self.event)
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict.update(
+            {
+                "event_status": "EventCancelled",
+                "start_time": self.event.start_time,
+                "end_time": self.event.end_time,
+            }
+        )
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 2)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertCancellationEmailsSentForRecurringEvent(contact_person_count)
+
+    def test_recurring_sub_event_put_cancellation_emails_sent_signups_not_cancelled_for_super_event(
+        self,
+    ):
+        self._make_super_event(self.event)
+        sub_event, sub_event_detail_url = self._create_sub_event(self.event)
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertNotEqual(sub_event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            sub_event.data_source,
+            sub_event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict.update(
+            {
+                "event_status": "EventCancelled",
+                "start_time": sub_event.start_time,
+                "end_time": sub_event.end_time,
+            }
+        )
+
+        response = self.client.put(
+            sub_event_detail_url,
+            complex_event_dict,
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.event.refresh_from_db()
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        sub_event.refresh_from_db()
+        self.assertEqual(sub_event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertCancellationEmailsSentForRecurringSubEvent(contact_person_count)
+
+    def test_recurring_sub_event_put_cancellation_emails_sent_payments_not_refunded_for_super_event(
+        self,
+    ):
+        self._create_signup_payments()
+        self._make_super_event(self.event)
+        sub_event, sub_event_detail_url = self._create_sub_event(self.event)
+
+        contact_person_count = SignUpContactPerson.objects.count()
+        self.assertEqual(contact_person_count, 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertNotEqual(sub_event.event_status, Event.Status.CANCELLED)
+
+        complex_event_dict = self.make_complex_event_dict(
+            sub_event.data_source,
+            sub_event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict.update(
+            {
+                "event_status": "EventCancelled",
+                "start_time": sub_event.start_time,
+                "end_time": sub_event.end_time,
+            }
+        )
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+
+            response = self.client.put(
+                sub_event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 0)
+
+        self.event.refresh_from_db()
+        self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        sub_event.refresh_from_db()
+        self.assertEqual(sub_event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertCancellationEmailsSentForRecurringSubEvent(contact_person_count)
+
+    def test_event_put_signups_not_cancelled_and_cancellation_emails_not_sent_if_cancelled_again(
         self,
     ):
         self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
 
         Event.objects.filter(pk=self.event.pk).update(
             event_status=Event.Status.CANCELLED
@@ -312,6 +1049,57 @@ class EventCancellationNotificationAPITestCase(APITestCase):
 
         self.event.refresh_from_db()
         self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_put_signups_not_cancelled_and_payments_not_refunded_if_cancelled_again(
+        self,
+    ):
+        self._create_signup_payments()
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        Event.objects.filter(pk=self.event.pk).update(
+            event_status=Event.Status.CANCELLED
+        )
+
+        complex_event_dict = self.make_complex_event_dict(
+            self.event.data_source,
+            self.event.publisher,
+            self.location_id,
+            self.languages,
+        )
+        complex_event_dict["event_status"] = "EventCancelled"
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+
+            response = self.client.put(
+                self.event_detail_url,
+                complex_event_dict,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            self.assertEqual(req_mock.call_count, 0)
+
+        self.event.refresh_from_db()
+        self.assertEqual(self.event.event_status, Event.Status.CANCELLED)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
 
         self.assertEqual(len(mail.outbox), 0)
 
@@ -415,8 +1203,12 @@ class EventCancellationNotificationAPITestCase(APITestCase):
 
         self.assertEqual(len(mail.outbox), 0)
 
-    def test_event_delete_cancellation_email_not_sent_to_contact_persons(self):
+    def test_event_delete_signups_cancelled_and_cancellation_emails_sent_to_contact_persons(
+        self,
+    ):
         self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
 
         response = self.client.delete(
             self.event_detail_url,
@@ -424,4 +1216,168 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+
+        # Event cancellation notifications + signup cancellation notifications
+        # => 3 people * 2 notifications = 6 notifications.
+        self.assertEqual(len(mail.outbox), 6)
+
+    def test_event_delete_cancellation_emails_sent_and_payments_refunded(self):
+        self._create_signup_payments()
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                json=DEFAULT_GET_REFUND_DATA,
+            )
+
+            response = self.client.delete(
+                self.event_detail_url,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+            self.assertEqual(req_mock.call_count, 2)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertEqual(len(mail.outbox), 6)
+
+    def test_event_delete_cancellation_emails_sent_and_payments_cancelled(self):
+        # Create two payments with the status "CREATED". These will be cancelled instead of
+        # refunded as they are not paid yet.
+        signup_group = SignUpGroup.objects.first()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": None,
+                    "signup_group": signup_group,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+                {
+                    "signup": SignUp.objects.filter(
+                        registration_id=signup_group.registration_id,
+                        signup_group_id__isnull=True,
+                    ).first(),
+                    "external_order_id": DEFAULT_ORDER_ID,
+                },
+            ]
+        )
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/{DEFAULT_ORDER_ID}/cancel",
+                json=DEFAULT_CANCEL_ORDER_DATA,
+            )
+
+            response = self.client.delete(
+                self.event_detail_url,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+            self.assertEqual(req_mock.call_count, 2)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 0)
+        self.assertEqual(SignUpGroup.objects.count(), 0)
+        self.assertEqual(SignUp.objects.count(), 0)
+        self.assertEqual(SignUpPayment.objects.count(), 0)
+
+        self.assertEqual(len(mail.outbox), 6)
+
+    def test_event_delete_web_store_api_exception(self):
+        self._create_signup_payments()
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
+        with requests_mock.Mocker() as req_mock:
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+            response = self.client.delete(
+                self.event_detail_url,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data[0],
+                "Payment refund or cancellation failed for SignUpGroup with ID "
+                f"{SignUpGroup.objects.first().pk}.",
+            )
+
+            self.assertEqual(req_mock.call_count, 1)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 2)
+
         self.assertEqual(len(mail.outbox), 0)
+
+    def test_event_delete_signup_web_store_api_exception(self):
+        signup = SignUp.objects.first()
+        self._create_signup_payments(
+            [
+                {
+                    "signup": signup,
+                    "external_order_id": DEFAULT_ORDER_ID,
+                    "status": SignUpPayment.PaymentStatus.PAID,
+                },
+            ]
+        )
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 1)
+
+        self.assertEqual(Message.objects.count(), 0)
+
+        with (
+            self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
+            requests_mock.Mocker() as req_mock,
+        ):
+            req_mock.get(
+                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+            response = self.client.delete(
+                self.event_detail_url,
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(
+                response.data[0],
+                f"Payment refund or cancellation failed for SignUp with ID {signup.pk}.",
+            )
+
+            self.assertEqual(req_mock.call_count, 1)
+
+        self.assertEqual(SignUpContactPerson.objects.count(), 3)
+        self.assertEqual(SignUpGroup.objects.count(), 1)
+        self.assertEqual(SignUp.objects.count(), 4)
+        self.assertEqual(SignUpPayment.objects.count(), 1)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(Message.objects.count(), 0)

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -198,6 +198,23 @@ class TestRegistration(TestCase):
                 ):
                     self.registration.get_waitlisted(count=count)
 
+    def test_has_payments_with_signups(self):
+        self.assertFalse(self.registration.has_payments)
+
+        SignUpPaymentFactory(signup__registration=self.registration)
+
+        self.assertTrue(self.registration.has_payments)
+
+    def test_has_payments_with_signup_groups(self):
+        self.assertFalse(self.registration.has_payments)
+
+        SignUpPaymentFactory(
+            signup=None,
+            signup_group=SignUpGroupFactory(registration=self.registration),
+        )
+
+        self.assertTrue(self.registration.has_payments)
+
 
 class TestRegistrationUserAccess(TestCase):
     def setUp(self):


### PR DESCRIPTION
### Description
This PR implements the following three requirements:

- When an event that has a registration is soft-deleted or cancelled, the related registration's signups and signup groups need to be cancelled and their contact persons notified. 
- When a sub-event of a super event is soft-deleted or cancelled, only event cancellation notifications should be sent and the signups should remain if the registration is linked to the super event only. 
- Payments should be cancelled or refunded in case signup and signup groups cancellations are performed.

### Closes
[LINK-1799](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1799)

[LINK-1799]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ