### PR TITLE
LINK-1996 | Move signups to attending on attendee capacity increase

### DIFF
--- a/registrations/management/commands/mark_payments_expired.py
+++ b/registrations/management/commands/mark_payments_expired.py
@@ -13,7 +13,7 @@ from registrations.models import SignUp, SignUpPayment
 from registrations.notifications import SignUpNotificationType
 from registrations.utils import (
     get_access_code_for_contact_person,
-    move_first_waitlisted_to_attending,
+    move_waitlisted_to_attending,
 )
 from web_store.order.clients import WebStoreOrderAPIClient
 from web_store.payment.clients import WebStorePaymentAPIClient
@@ -77,7 +77,7 @@ class Command(BaseCommand):
         if getattr(signup_or_signup_group, "is_attending", None) or getattr(
             signup_or_signup_group, "attending_signups", None
         ):
-            move_first_waitlisted_to_attending(signup_or_signup_group)
+            move_waitlisted_to_attending(signup_or_signup_group.registration, count=1)
 
         contact_person = signup_or_signup_group.actual_contact_person
         if contact_person:

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -151,16 +151,21 @@ def strip_trailing_zeroes_from_decimal(value: Decimal):
     return value.normalize()
 
 
-def move_first_waitlisted_to_attending(signup_or_signup_group):
-    registration = signup_or_signup_group.registration
-
-    if (
+def move_waitlisted_to_attending(registration, count: int):
+    """Changes given number of wait-listed attendees in a registration to be attending."""
+    waitlisted_signups = registration.get_waitlisted(count=count)
+    price_groups_exist = (
         settings.WEB_STORE_INTEGRATION_ENABLED
         and registration.registration_price_groups.exists()
-    ):
-        registration.move_first_waitlisted_to_attending_with_payment_link()
-    else:
-        registration.move_first_waitlisted_to_attending()
+    )
+
+    for first_on_list in waitlisted_signups:
+        if price_groups_exist:
+            registration.move_first_waitlisted_to_attending_with_payment_link(
+                first_on_list=first_on_list
+            )
+        else:
+            registration.move_first_waitlisted_to_attending(first_on_list=first_on_list)
 
 
 def get_access_code_for_contact_person(contact_person, user):


### PR DESCRIPTION
### Description
When a registration's maximum attendee capacity is increased, move as many waitlisted signups to attendees as possible.
### Closes
[LINK-1996](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1996)

[LINK-1996]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ