### PR TITLE
LINK-2043 | Action endpoints for getting merchants and accounts

### DIFF
--- a/events/permissions.py
+++ b/events/permissions.py
@@ -219,3 +219,20 @@ class UserIsAdminInAnyOrganization(BasePermission):
             return False
 
         return user.is_superuser or user.admin_organizations.exists()
+
+
+class OrganizationWebStoreMerchantsAndAccountsPermission(BasePermission):
+    def has_permission(self, request, view):
+        return (
+            request.user.is_authenticated and request.method in permissions.SAFE_METHODS
+        )
+
+    def has_object_permission(self, request: Request, view, obj):
+        if request.user.is_superuser:
+            return True
+
+        return (
+            request.user.is_admin_of(obj)
+            or request.user.is_registration_admin_of(obj)
+            or request.user.is_financial_admin_of(obj)
+        )

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -768,6 +768,12 @@ def user2_with_user_type(organization, user2, request):
     elif user_type == "org_admin":
         organization.admin_users.add(user2)
 
+    elif user_type == "org_registration_admin":
+        organization.registration_admin_users.add(user2)
+
+    elif user_type == "org_financial_admin":
+        organization.financial_admin_users.add(user2)
+
     elif user_type == "staff":
         user2.is_staff = True
         user2.save()


### PR DESCRIPTION
### Description
Makes it possible to get all active merchants and accounts for an organization through new action endpoints that are under the organization detail endpoint. Since merchants and accounts are meant to be inherited from higher organization levels, the new endpoints search for them from ancestor organizations, returning results from the first ancestor that has them.
### Closes
[LINK-2043](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2043)

[LINK-2043]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ