### PR TITLE
LINK-2053 | Remove apikey auth from web store webhooks

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -566,7 +566,7 @@ if settings.WEB_STORE_INTEGRATION_ENABLED:
 class WebStoreWebhookViewSet(AuditLogApiViewMixin, viewsets.ViewSet):
     serializer_class = None
     http_method_names = ["post"]
-    permission_classes = [IsAuthenticated]
+    permission_classes = []
 
     @staticmethod
     def _get_payment(order_id: str) -> Optional[SignUpPayment]:


### PR DESCRIPTION
### Description
Removes the DataSource api key authentication from the web store webhook endpoints. It was discussed with the Talpa developers that they will implement an api key authentication of their own into Talpa and that can be utilized by services in the (hopefully near) future. Further restrictions for the endpoint are also under discussion.

### Closes
[LINK-2053](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2053)