### PR TITLE
feat(events-api): match audience in keyword_* filters

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2701,7 +2701,10 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
         )
         for kw_set in kw_sets:
             kw_ids = [kw.id for kw in kw_set.keywords.all()]
-            subqs = Event.objects.filter(id=OuterRef("pk"), keywords__in=kw_ids)
+            subqs = Event.objects.filter(
+                Q(id=OuterRef("pk"), keywords__in=kw_ids)
+                | Q(id=OuterRef("pk"), audience__in=kw_ids)
+            )
             queryset = queryset.filter(Exists(subqs))
 
     vals = params.get("keyword_set_OR", None)
@@ -2718,7 +2721,10 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
         kw_qs = Event.keywords.through.objects.filter(
             event=OuterRef("pk"), keyword__in=all_keywords
         )
-        queryset = queryset.filter(Exists(kw_qs))
+        audience_qs = Event.audience.through.objects.filter(
+            event=OuterRef("pk"), keyword__in=all_keywords
+        )
+        queryset = queryset.filter(Exists(kw_qs) | Exists(audience_qs))
 
     if "local_ongoing_OR_set" in "".join(params):
         count = 1
@@ -2785,7 +2791,10 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                 kw_qs = Event.keywords.through.objects.filter(
                     event=OuterRef("pk"), keyword__in=vals
                 )
-                queryset = queryset.filter(Exists(kw_qs))
+                audience_qs = Event.audience.through.objects.filter(
+                    event=OuterRef("pk"), keyword__in=vals
+                )
+                queryset = queryset.filter(Exists(kw_qs) | Exists(audience_qs))
 
     val = params.get("internet_based", None)
     if val and parse_bool(val, "internet_based"):

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -31,7 +31,6 @@ from linkedevents.tests.conftest import *  # noqa
 from registrations.models import Registration
 
 from ..models import License, PublicationStatus
-from .test_event_get import get_list
 from .utils import versioned_reverse as reverse
 
 TEXT_FI = "testaus"
@@ -686,6 +685,7 @@ def api_get_list(request, event, api_client):
     the module of the test function, or use default API version
     """
     version = getattr(request.module, "version", "v1")
+    from .test_event_get import get_list
 
     def f():
         return get_list(api_client, version)
@@ -700,6 +700,7 @@ def all_api_get_list(request, event, api_client):
     the module of the test function, or use default API version
     """
     version = request.param
+    from .test_event_get import get_list
 
     def f():
         return get_list(api_client, version)

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1114,6 +1114,42 @@ def test_keywordset_search(
 
 
 @pytest.mark.django_db
+def test_keywordset_search_match_audience(
+    api_client,
+    event,
+    event2,
+    event3,
+    keyword,
+    keyword2,
+    keyword3,
+    keyword_set,
+    keyword_set2,
+):
+    keyword_set.keywords.set([keyword])
+    keyword_set.save()
+    keyword_set2.keywords.set([keyword2])
+    keyword_set.save()
+
+    event.audience.set([keyword, keyword3])
+    event.save()
+    event2.audience.set([keyword2, keyword3])
+    event2.save()
+    event3.audience.set([keyword, keyword2])
+    event3.save()
+
+    get_list_and_assert_events(f"keyword_set_AND={keyword_set.id}", [event, event3])
+    get_list_and_assert_events(f"keyword_set_AND={keyword_set2.id}", [event2, event3])
+    get_list_and_assert_events(
+        f"keyword_set_AND={keyword_set.id},{keyword_set2.id}", [event3]
+    )
+    get_list_and_assert_events(f"keyword_set_OR={keyword_set.id}", [event, event3])
+    get_list_and_assert_events(f"keyword_set_OR={keyword_set2.id}", [event2, event3])
+    get_list_and_assert_events(
+        f"keyword_set_OR={keyword_set.id},{keyword_set2.id}", [event, event2, event3]
+    )
+
+
+@pytest.mark.django_db
 def test_keyword_or_set_search(
     api_client,
     event,
@@ -1130,6 +1166,28 @@ def test_keyword_or_set_search(
     event2.keywords.add(keyword2, keyword3)
     event2.save()
     event3.keywords.add(keyword, keyword2)
+    event3.save()
+    load = f"keyword_OR_set1={keyword.id},{keyword2.id}&keyword_OR_set2={keyword3.id}"
+    get_list_and_assert_events(load, [event, event2])
+
+
+@pytest.mark.django_db
+def test_keyword_or_set_search_match_audience(
+    api_client,
+    event,
+    event2,
+    event3,
+    keyword,
+    keyword2,
+    keyword3,
+    keyword_set,
+    keyword_set2,
+):
+    event.audience.add(keyword, keyword3)
+    event.save()
+    event2.audience.add(keyword2, keyword3)
+    event2.save()
+    event3.audience.add(keyword, keyword2)
     event3.save()
     load = f"keyword_OR_set1={keyword.id},{keyword2.id}&keyword_OR_set2={keyword3.id}"
     get_list_and_assert_events(load, [event, event2])


### PR DESCRIPTION
`keyword_set_AND`, `keyword_set_OR `and `keyword_OR_set ` filters did not search from audiences when other keyword filters did. This adds lookups for audiences for those aforementioned filters

Refs LINK-1933