### PR TITLE
LINK-1808 | Command for removing expired admin permissions

### DIFF
--- a/events/management/commands/remove_unused_permissions.py
+++ b/events/management/commands/remove_unused_permissions.py
@@ -1,0 +1,92 @@
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.db.models.functions import Greatest
+from django.utils import timezone
+
+from helevents.models import User
+from registrations.models import RegistrationUserAccess
+
+
+class Command(BaseCommand):
+    help = "Remove unused admin and registration user permissions after expiration time has passed."
+
+    @staticmethod
+    def _handle_event_admins(datetime_now):
+        admins_count = 0
+
+        threshold_time = datetime_now - relativedelta(
+            months=settings.EVENT_ADMIN_EXPIRATION_MONTHS
+        )
+        for user in User.objects.filter(
+            last_login__lt=threshold_time, admin_organizations__isnull=False
+        ):
+            user.admin_organizations.clear()
+            admins_count += 1
+
+        return admins_count
+
+    @staticmethod
+    def _handle_financial_admins(datetime_now):
+        admins_count = 0
+
+        threshold_time = datetime_now - relativedelta(
+            months=settings.FINANCIAL_ADMIN_EXPIRATION_MONTHS
+        )
+        for user in User.objects.filter(
+            last_login__lt=threshold_time, financial_admin_organizations__isnull=False
+        ):
+            user.financial_admin_organizations.clear()
+            admins_count += 1
+
+        return admins_count
+
+    @staticmethod
+    def _handle_registration_admins(datetime_now):
+        admins_count = 0
+
+        threshold_time = datetime_now - relativedelta(
+            months=settings.REGISTRATION_ADMIN_EXPIRATION_MONTHS
+        )
+        for user in User.objects.filter(
+            last_login__lt=threshold_time,
+            registration_admin_organizations__isnull=False,
+        ):
+            user.registration_admin_organizations.clear()
+            admins_count += 1
+
+        return admins_count
+
+    @staticmethod
+    def _handle_registration_users(datetime_now):
+        registration_users_count = 0
+
+        threshold_time = datetime_now - relativedelta(
+            months=settings.REGISTRATION_USER_EXPIRATION_MONTHS
+        )
+        for registration_user in RegistrationUserAccess.objects.annotate(
+            compare_time=Greatest(
+                "registration__event__end_time",
+                "registration__enrolment_end_time",
+            )
+        ).filter(compare_time__lt=threshold_time):
+            registration_user.delete()
+            registration_users_count += 1
+
+        return registration_users_count
+
+    def handle(self, *args, **options):
+        now = timezone.now()
+
+        event_admins = self._handle_event_admins(now)
+        financial_admins = self._handle_financial_admins(now)
+        registration_admins = self._handle_registration_admins(now)
+        registration_users = self._handle_registration_users(now)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{event_admins} event admin, {financial_admins} financial admin, "
+                f"{registration_admins} registration admin and {registration_users} "
+                "registration user access permissions removed."
+            )
+        )

--- a/events/tests/management/test_remove_unused_permissions.py
+++ b/events/tests/management/test_remove_unused_permissions.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+
+import freezegun
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.conf import settings as django_settings
+from django.core.management import call_command
+from django.utils.timezone import localtime
+
+from helevents.tests.factories import UserFactory
+from registrations.models import RegistrationUserAccess
+from registrations.tests.factories import RegistrationUserAccessFactory
+
+
+def _test_remove_unused_admin_permissions(
+    organization, organization2, admin_relation: str, expiration_months: int
+):
+    now = localtime()
+
+    expired_months_ago = now - relativedelta(months=expiration_months + 1)
+    active_months_ago = now - relativedelta(months=expiration_months, days=-1)
+
+    expired_admin = UserFactory(last_login=expired_months_ago)
+    getattr(expired_admin, admin_relation).add(organization)
+
+    expired_admin2 = UserFactory(last_login=expired_months_ago)
+    getattr(expired_admin2, admin_relation).add(organization)
+    getattr(expired_admin2, admin_relation).add(organization2)
+
+    active_admin = UserFactory(last_login=active_months_ago)
+    getattr(active_admin, admin_relation).add(organization)
+
+    assert getattr(expired_admin, admin_relation).count() == 1
+    assert getattr(expired_admin2, admin_relation).count() == 2
+    assert getattr(active_admin, admin_relation).count() == 1
+
+    call_command("remove_unused_permissions")
+
+    expired_admin.refresh_from_db()
+    assert getattr(expired_admin, admin_relation).count() == 0
+
+    expired_admin2.refresh_from_db()
+    assert getattr(expired_admin2, admin_relation).count() == 0
+
+    active_admin.refresh_from_db()
+    assert getattr(active_admin, admin_relation).count() == 1
+
+
+def _set_registration_comparison_datetimes(
+    registration, expiration_comparison_source: str, n_months_ago: datetime
+):
+    if expiration_comparison_source == "registration":
+        registration.enrolment_end_time = n_months_ago
+        registration.save(update_fields=["enrolment_end_time"])
+
+        registration.event.start_time = n_months_ago - relativedelta(days=2)
+        registration.event.end_time = n_months_ago - relativedelta(days=1)
+        registration.event.save(update_fields=["start_time", "end_time"])
+    else:
+        registration.enrolment_end_time = n_months_ago - relativedelta(days=1)
+        registration.save(update_fields=["enrolment_end_time"])
+
+        registration.event.start_time = n_months_ago - relativedelta(days=1)
+        registration.event.end_time = n_months_ago
+        registration.event.save(update_fields=["start_time", "end_time"])
+
+
+def _test_remove_unused_registration_user_permissions(
+    registration, registration2, registration3, expiration_comparison_source
+):
+    now = localtime()
+    expiration_months = django_settings.REGISTRATION_USER_EXPIRATION_MONTHS
+
+    expired_months_ago = now - relativedelta(months=expiration_months + 1)
+    active_months_ago = now - relativedelta(months=expiration_months, days=-1)
+
+    RegistrationUserAccessFactory(registration=registration, email="expired@test.com")
+    _set_registration_comparison_datetimes(
+        registration, expiration_comparison_source, expired_months_ago
+    )
+
+    RegistrationUserAccessFactory(
+        registration=registration2, email="expired2@hel.fi", is_substitute_user=True
+    )
+    _set_registration_comparison_datetimes(
+        registration2, expiration_comparison_source, expired_months_ago
+    )
+
+    active_user_access = RegistrationUserAccessFactory(
+        registration=registration3, email="active@test.com"
+    )
+    _set_registration_comparison_datetimes(
+        registration3, expiration_comparison_source, active_months_ago
+    )
+
+    assert RegistrationUserAccess.objects.count() == 3
+
+    call_command("remove_unused_permissions")
+
+    assert RegistrationUserAccess.objects.count() == 1
+    assert RegistrationUserAccess.objects.first().pk == active_user_access.pk
+
+
+@freezegun.freeze_time("2024-05-28 03:30:00+03:00")
+@pytest.mark.django_db
+def test_remove_unused_event_admin_permissions(organization, organization2):
+    _test_remove_unused_admin_permissions(
+        organization,
+        organization2,
+        "admin_organizations",
+        expiration_months=django_settings.EVENT_ADMIN_EXPIRATION_MONTHS,
+    )
+
+
+@freezegun.freeze_time("2024-05-28 03:30:00+03:00")
+@pytest.mark.django_db
+def test_remove_unused_financial_admin_permissions(organization, organization2):
+    _test_remove_unused_admin_permissions(
+        organization,
+        organization2,
+        "financial_admin_organizations",
+        expiration_months=django_settings.FINANCIAL_ADMIN_EXPIRATION_MONTHS,
+    )
+
+
+@freezegun.freeze_time("2024-05-28 03:30:00+03:00")
+@pytest.mark.django_db
+def test_remove_unused_registration_admin_permissions(organization, organization2):
+    _test_remove_unused_admin_permissions(
+        organization,
+        organization2,
+        "registration_admin_organizations",
+        expiration_months=django_settings.REGISTRATION_ADMIN_EXPIRATION_MONTHS,
+    )
+
+
+@freezegun.freeze_time("2024-05-28 03:30:00+03:00")
+@pytest.mark.django_db
+def test_remove_unused_registration_user_permissions_based_on_event_end_time(
+    registration, registration2, registration3
+):
+    _test_remove_unused_registration_user_permissions(
+        registration, registration2, registration3, "event"
+    )
+
+
+@freezegun.freeze_time("2024-05-28 03:30:00+03:00")
+@pytest.mark.django_db
+def test_remove_unused_registration_user_permissions_based_on_registration_end_time(
+    registration, registration2, registration3
+):
+    _test_remove_unused_registration_user_permissions(
+        registration, registration2, registration3, "registration"
+    )

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -99,8 +99,10 @@ env = environ.Env(
     EXTERNAL_USER_PUBLISHER_ID=(str, "others"),
     ENKORA_API_USER=(str, "JoeEnkora"),
     ENKORA_API_PASSWORD=(str, None),
+    EVENT_ADMIN_EXPIRATION_MONTHS=(int, 12),
     EXTRA_INSTALLED_APPS=(list, []),
     FIELD_ENCRYPTION_KEYS=(list, []),
+    FINANCIAL_ADMIN_EXPIRATION_MONTHS=(int, 6),
     FULL_TEXT_WEIGHT_OVERRIDES=(dict, {}),
     GDPR_API_QUERY_SCOPE=(str, ""),
     GDPR_API_DELETE_SCOPE=(str, ""),
@@ -153,6 +155,8 @@ env = environ.Env(
     TOKEN_AUTH_FIELD_FOR_CONSENTS=(list, ["https://api.hel.fi/auth"]),
     TOKEN_AUTH_REQUIRE_SCOPE_PREFIX=(bool, False),
     TRUST_X_FORWARDED_HOST=(bool, False),
+    REGISTRATION_ADMIN_EXPIRATION_MONTHS=(int, 6),
+    REGISTRATION_USER_EXPIRATION_MONTHS=(int, 2),
     WEB_STORE_API_BASE_URL=(str, ""),
     WEB_STORE_API_KEY=(str, ""),
     WEB_STORE_API_NAMESPACE=(str, ""),
@@ -711,6 +715,11 @@ REST_KNOX = {
     "TOKEN_PREFIX": "",
     "TOKEN_TTL": timedelta(days=30),
 }
+
+EVENT_ADMIN_EXPIRATION_MONTHS = env("EVENT_ADMIN_EXPIRATION_MONTHS")
+FINANCIAL_ADMIN_EXPIRATION_MONTHS = env("FINANCIAL_ADMIN_EXPIRATION_MONTHS")
+REGISTRATION_ADMIN_EXPIRATION_MONTHS = env("REGISTRATION_ADMIN_EXPIRATION_MONTHS")
+REGISTRATION_USER_EXPIRATION_MONTHS = env("REGISTRATION_USER_EXPIRATION_MONTHS")
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.


### PR DESCRIPTION
### Description
Command for removing expired admin and registration user access permissions. Env variables are also added to allow controlling the expiration thresholds.
### Closes
[LINK-1808](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1808)

[LINK-1808]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ