### PR TITLE
fix: use correct timezone for lastValidPurchaseDateTime

### DIFF
--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -225,7 +225,7 @@ def create_web_store_api_order(
         )
 
     order_data["lastValidPurchaseDateTime"] = localized_expiration_datetime.astimezone(
-        pytz.UTC
+        pytz.timezone("Europe/Helsinki")
     ).strftime("%Y-%m-%dT%H:%M:%S")
 
     client = WebStoreOrderAPIClient()


### PR DESCRIPTION
Talpa uses the Helsinki timezone when checking `lastValidPurchaseDateTime`. This PR ensured that the same timezone is used when sending the timestamp to the Talpa Order Experience API.

Note to those who test this change: there is a known bug in the Talpa checkout UI that makes the "Time left for purchase" display to show a value such as "23:59:59" instead of "48:00:00". This is to be fixed by the Talpa devs.