### PR TITLE
LINK-2073 | Translated fields to data analytics API

### DIFF
--- a/data_analytics/serializers.py
+++ b/data_analytics/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from events.api import DivisionSerializer, EnumChoiceField
 from events.models import Event, Keyword, Language, Offer, Place, PUBLICATION_STATUSES
+from linkedevents.serializers import TranslatedModelSerializer
 from registrations.models import Registration, SignUp
 
 
@@ -26,7 +27,9 @@ class DataAnalyticsAdministrativeDivisionSerializer(DivisionSerializer):
         )
 
 
-class DataAnalyticsKeywordSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
+class DataAnalyticsKeywordSerializer(
+    DataAnalyticsCreatedModifiedBaseSerializer, TranslatedModelSerializer
+):
     alt_labels = serializers.SlugRelatedField(
         slug_field="name", many=True, read_only=True
     )
@@ -43,7 +46,9 @@ class DataAnalyticsKeywordSerializer(DataAnalyticsCreatedModifiedBaseSerializer)
         fields += DataAnalyticsCreatedModifiedBaseSerializer.Meta.fields
 
 
-class DataAnalyticsPlaceSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
+class DataAnalyticsPlaceSerializer(
+    DataAnalyticsCreatedModifiedBaseSerializer, TranslatedModelSerializer
+):
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
     replaced_by = serializers.PrimaryKeyRelatedField(read_only=True)
     divisions = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
@@ -52,13 +57,15 @@ class DataAnalyticsPlaceSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
         model = Place
         fields = (
             "id",
+            "name",
             "parent",
             "replaced_by",
             "position",
+            "address_country",
             "address_region",
+            "address_locality",
             "postal_code",
             "post_office_box_num",
-            "address_country",
             "divisions",
             "deleted",
             "n_events",
@@ -66,7 +73,7 @@ class DataAnalyticsPlaceSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
         fields += DataAnalyticsCreatedModifiedBaseSerializer.Meta.fields
 
 
-class DataAnalyticsLanguageSerializer(serializers.ModelSerializer):
+class DataAnalyticsLanguageSerializer(TranslatedModelSerializer):
     class Meta:
         model = Language
         fields = ("id", "name", "service_language")
@@ -82,7 +89,9 @@ class DataAnalyticsOfferSerializer(serializers.ModelSerializer):
         )
 
 
-class DataAnalyticsOrganizationSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
+class DataAnalyticsOrganizationSerializer(
+    DataAnalyticsCreatedModifiedBaseSerializer, TranslatedModelSerializer
+):
     classification = serializers.PrimaryKeyRelatedField(read_only=True)
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
     data_source = serializers.PrimaryKeyRelatedField(read_only=True)
@@ -101,7 +110,9 @@ class DataAnalyticsOrganizationSerializer(DataAnalyticsCreatedModifiedBaseSerial
         fields += DataAnalyticsCreatedModifiedBaseSerializer.Meta.fields
 
 
-class DataAnalyticsEventSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
+class DataAnalyticsEventSerializer(
+    DataAnalyticsCreatedModifiedBaseSerializer, TranslatedModelSerializer
+):
     publisher = serializers.PrimaryKeyRelatedField(read_only=True)
     replaced_by = serializers.PrimaryKeyRelatedField(read_only=True)
     super_event = serializers.PrimaryKeyRelatedField(read_only=True)
@@ -118,6 +129,7 @@ class DataAnalyticsEventSerializer(DataAnalyticsCreatedModifiedBaseSerializer):
         model = Event
         fields = (
             "id",
+            "name",
             "publisher",
             "deleted",
             "date_published",

--- a/data_analytics/tests/test_event_get.py
+++ b/data_analytics/tests/test_event_get.py
@@ -52,6 +52,7 @@ def get_list(api_client: APIClient, query: Optional[str] = None):
 def assert_event_fields_exist(data):
     fields = (
         "id",
+        "name",
         "publisher",
         "deleted",
         "date_published",

--- a/data_analytics/tests/test_place_get.py
+++ b/data_analytics/tests/test_place_get.py
@@ -47,13 +47,15 @@ def get_list(api_client: APIClient, query: Optional[str] = None):
 def assert_place_fields_exist(data):
     fields = (
         "id",
+        "name",
         "parent",
         "replaced_by",
         "position",
-        "address_region",
         "postal_code",
         "post_office_box_num",
         "address_country",
+        "address_locality",
+        "address_region",
         "divisions",
         "deleted",
         "n_events",

--- a/linkedevents/serializers.py
+++ b/linkedevents/serializers.py
@@ -30,7 +30,21 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
             self.translated_fields = []
             return
 
-        self.translated_fields = trans_opts.fields.keys()
+        if (
+            meta_fields := getattr(self.Meta, "fields", None)
+        ) and meta_fields != "__all__":
+            self.translated_fields = [
+                field for field in trans_opts.fields.keys() if field in meta_fields
+            ]
+        elif meta_excluded_fields := getattr(self.Meta, "exclude", None):
+            self.translated_fields = [
+                field
+                for field in trans_opts.fields.keys()
+                if field not in meta_excluded_fields
+            ]
+        else:
+            self.translated_fields = trans_opts.fields.keys()
+
         lang_codes = utils.get_fixed_lang_codes()
         # Remove the pre-existing data in the bundle.
         for field_name in self.translated_fields:

--- a/linkedevents/serializers.py
+++ b/linkedevents/serializers.py
@@ -32,7 +32,7 @@ class TranslatedModelSerializer(serializers.ModelSerializer):
 
         if (
             meta_fields := getattr(self.Meta, "fields", None)
-        ) and meta_fields != "__all__":
+        ) and meta_fields != serializers.ALL_FIELDS:
             self.translated_fields = [
                 field for field in trans_opts.fields.keys() if field in meta_fields
             ]


### PR DESCRIPTION
### Description

- Adds "name" and the non-translated field "address_locality" to `DataAnalyticsPlaceSerializer`.
- Adds "name" to `DataAnalyticsEventSerialiazer`.
- Ensures that `TranslatedModelSerializer` is used with such data analytics serializers that expose translated fields.
- Fixes an issue with `TranslatedModelSerializer` where it exposed all of the translated fields even if they weren't given in the sub-classed serializer's `fields`.
### Closes
[LINK-2073](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2073)

[LINK-2073]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ