### PR TITLE
LINK-2080 | Add lang parameter to checkout URLs

### DIFF
--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -351,6 +351,7 @@ def test_authenticated_user_can_create_signup_group_with_payment(api_client, use
         response.data["payment"],
         user,
         signup_group=SignUpGroup.objects.first(),
+        service_language="en",
     )
 
     # Payment link is sent via email.
@@ -456,6 +457,7 @@ def test_signup_group_update_web_store_product_mapping_if_merchant_id_has_change
         response.data["payment"],
         user,
         signup_group=SignUpGroup.objects.first(),
+        service_language="en",
     )
 
 
@@ -547,6 +549,7 @@ def test_create_signup_group_payment_without_pricetotal_in_response(api_client):
         response.data["payment"],
         user,
         signup_group=SignUpGroup.objects.first(),
+        service_language="en",
     )
 
     # Payment link is sent via email.

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -40,8 +40,6 @@ from registrations.tests.factories import (
     SignUpContactPersonFactory,
     SignUpFactory,
     SignUpGroupFactory,
-    WebStoreAccountFactory,
-    WebStoreMerchantFactory,
 )
 from registrations.tests.test_registration_post import hel_email
 from registrations.tests.test_signup_patch import description_fields
@@ -304,6 +302,7 @@ def test_authenticated_user_can_create_signups_with_payments(api_client, user_ro
         response.data[0]["payment"],
         user,
         SignUp.objects.first(),
+        service_language=language.pk,
     )
 
     # Payment link is sent via email.
@@ -332,7 +331,7 @@ def test_authenticated_user_can_create_signups_with_payments(api_client, user_ro
 def test_update_web_store_product_mapping_if_merchant_id_has_changed(
     api_client, registration, user_role
 ):
-    LanguageFactory(pk="fi", service_language=True)
+    language = LanguageFactory(pk="fi", service_language=True)
 
     with override_settings(WEB_STORE_INTEGRATION_ENABLED=False):
         registration_merchant = RegistrationWebStoreMerchantFactory(
@@ -403,6 +402,7 @@ def test_update_web_store_product_mapping_if_merchant_id_has_changed(
         response.data[0]["payment"],
         user,
         SignUp.objects.first(),
+        service_language=language.pk,
     )
 
 
@@ -494,6 +494,7 @@ def test_create_signup_payment_without_pricetotal_in_response(api_client):
         response.data[0]["payment"],
         user,
         SignUp.objects.first(),
+        service_language=language.pk,
     )
 
     # Payment link is sent via email.

--- a/registrations/tests/test_utils.py
+++ b/registrations/tests/test_utils.py
@@ -12,7 +12,27 @@ from registrations.tests.factories import SignUpContactPersonFactory, SignUpFact
 from registrations.utils import (
     create_event_ics_file_content,
     get_access_code_for_contact_person,
+    get_checkout_url_with_lang_param,
 )
+
+
+def _get_checkout_url_and_language_code_test_params():
+    test_params = []
+
+    for lang_code in ["fi", "sv", "en"]:
+        for checkout_url, param_prefix in [
+            ("https://checkout.dev/v1/123/?user=abcdefg", "&"),
+            ("https://logged-in-checkout.dev/v1/123/", "?"),
+        ]:
+            test_params.append(
+                (
+                    checkout_url,
+                    lang_code,
+                    f"{checkout_url}{param_prefix}lang={lang_code}",
+                )
+            )
+
+    return test_params
 
 
 @pytest.mark.django_db
@@ -199,3 +219,16 @@ def test_get_access_code_for_contact_person(
         assert str(UUID(access_code)) == access_code
     else:
         assert access_code is None
+
+
+@pytest.mark.parametrize(
+    "checkout_url, lang_code, expected_checkout_url",
+    _get_checkout_url_and_language_code_test_params(),
+)
+def test_get_checkout_url_with_lang_param(
+    checkout_url, lang_code, expected_checkout_url
+):
+    new_checkout_url = get_checkout_url_with_lang_param(checkout_url, lang_code)
+
+    assert new_checkout_url == expected_checkout_url
+    assert checkout_url != new_checkout_url

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -168,6 +168,13 @@ def move_waitlisted_to_attending(registration, count: int):
             registration.move_first_waitlisted_to_attending(first_on_list=first_on_list)
 
 
+def get_checkout_url_with_lang_param(checkout_url: str, lang_code: str) -> str:
+    if "?" in checkout_url:
+        return f"{checkout_url}&lang={lang_code}"
+    else:
+        return f"{checkout_url}?lang={lang_code}"
+
+
 def get_access_code_for_contact_person(contact_person, user):
     if not contact_person:
         return None
@@ -203,11 +210,12 @@ def get_web_store_api_refunds_error_messages(response_json):
     return [str(error) for error in response_json["errors"]]
 
 
-def create_web_store_api_order(signup_or_group, localized_expiration_datetime):
+def create_web_store_api_order(
+    signup_or_group, contact_person, localized_expiration_datetime
+):
     user_uuid = (
         signup_or_group.created_by.uuid if signup_or_group.created_by_id else None
     )
-    contact_person = getattr(signup_or_group, "contact_person", None)
 
     service_lang = getattr(contact_person, "service_language_id", "fi")
     with translation.override(service_lang):


### PR DESCRIPTION
### Description
Adds a "lang" GET parameter after the Talpa checkout URLs.
### Closes
[LINK-2080](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2080)

[LINK-2080]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ