### PR TITLE
LINK-2078 | Always use the order refund Talpa endpoint

### DIFF
--- a/registrations/tests/test_event_cancellation_notification.py
+++ b/registrations/tests/test_event_cancellation_notification.py
@@ -36,6 +36,7 @@ from registrations.tests.factories import (
 )
 from web_store.tests.order.test_web_store_order_api_client import (
     DEFAULT_CANCEL_ORDER_DATA,
+    DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
     DEFAULT_ORDER_ID,
 )
 from web_store.tests.payment.test_web_store_payment_api_client import (
@@ -303,9 +304,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         complex_event_dict["event_status"] = "EventCancelled"
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
 
             response = self.client.put(
@@ -454,16 +455,16 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         complex_event_dict2["id"] = event2.pk
         complex_event_dict2["event_status"] = "EventCancelled"
 
-        default_get_refund_data2 = deepcopy(DEFAULT_GET_REFUND_DATA)
-        default_get_refund_data2["orderId"] = external_order_id2
+        default_get_refund_data2 = deepcopy(DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE)
+        default_get_refund_data2["refunds"][0]["orderId"] = external_order_id2
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{external_order_id2}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 json=default_get_refund_data2,
             )
 
@@ -665,21 +666,18 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         complex_event_dict2["id"] = event2.pk
         complex_event_dict2["event_status"] = "EventCancelled"
 
-        default_get_refund_data2 = deepcopy(DEFAULT_GET_REFUND_DATA)
-        default_get_refund_data2["orderId"] = external_order_id2
-
         self.assertEqual(Message.objects.count(), 0)
 
         with (
             self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
             requests_mock.Mocker() as req_mock,
         ):
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{external_order_id2}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -690,7 +688,7 @@ class EventCancellationNotificationAPITestCase(APITestCase):
             )
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-            self.assertEqual(req_mock.call_count, 3)
+            self.assertEqual(req_mock.call_count, 1)
 
         self.event.refresh_from_db()
         self.assertNotEqual(self.event.event_status, Event.Status.CANCELLED)
@@ -726,8 +724,8 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         complex_event_dict["event_status"] = "EventCancelled"
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -796,8 +794,8 @@ class EventCancellationNotificationAPITestCase(APITestCase):
             self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
             requests_mock.Mocker() as req_mock,
         ):
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -896,9 +894,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         )
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
 
             response = self.client.put(
@@ -995,9 +993,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         )
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
 
             response = self.client.put(
@@ -1079,9 +1077,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         complex_event_dict["event_status"] = "EventCancelled"
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
 
             response = self.client.put(
@@ -1233,9 +1231,9 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         self.assertEqual(SignUpPayment.objects.count(), 2)
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-                json=DEFAULT_GET_REFUND_DATA,
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+                json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
             )
 
             response = self.client.delete(
@@ -1309,8 +1307,8 @@ class EventCancellationNotificationAPITestCase(APITestCase):
         self.assertEqual(SignUpPayment.objects.count(), 2)
 
         with requests_mock.Mocker() as req_mock:
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1357,8 +1355,8 @@ class EventCancellationNotificationAPITestCase(APITestCase):
             self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"),
             requests_mock.Mocker() as req_mock,
         ):
-            req_mock.get(
-                f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+            req_mock.post(
+                f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1565,7 +1565,7 @@ def test_web_store_automatically_fully_refund_paid_signup_payment(
     )
     with (
         translation.override(language.pk),
-        patch("requests.get") as mocked_web_store_request,
+        patch("requests.post") as mocked_web_store_request,
     ):
         mocked_web_store_request.return_value = mocked_web_store_response
 
@@ -1637,9 +1637,9 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_for_recurring_
         translation.override(language.pk),
         requests_mock.Mocker() as req_mock,
     ):
-        req_mock.get(
-            f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-            json=DEFAULT_GET_REFUND_DATA,
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+            json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
         )
 
         assert_delete_signup(api_client, signup.pk)
@@ -1677,8 +1677,8 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_allow_404_exce
     assert SignUpPriceGroup.objects.count() == 1
 
     with requests_mock.Mocker() as req_mock:
-        req_mock.get(
-            f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
@@ -1714,7 +1714,7 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_errors_in_resp
     assert SignUpPayment.objects.count() == 1
     assert SignUpPriceGroup.objects.count() == 1
 
-    mocked_web_store_json = deepcopy(DEFAULT_GET_REFUND_DATA)
+    mocked_web_store_json = deepcopy(DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE)
     mocked_web_store_json["errors"] = [
         {
             "code": "refund-error",
@@ -1723,8 +1723,8 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_errors_in_resp
     ]
 
     with requests_mock.Mocker() as req_mock:
-        req_mock.get(
-            f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
             json=mocked_web_store_json,
         )
 
@@ -2221,7 +2221,7 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_api_error(api_
     mocked_web_store_response = get_mock_response(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
     )
-    with patch("requests.get") as mocked_web_store_request:
+    with patch("requests.post") as mocked_web_store_request:
         mocked_web_store_request.return_value = mocked_web_store_response
 
         response = delete_signup(api_client, signup.pk)

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -43,6 +43,7 @@ from registrations.tests.utils import (
 )
 from web_store.tests.order.test_web_store_order_api_client import (
     DEFAULT_CANCEL_ORDER_DATA,
+    DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
     DEFAULT_ORDER_ID,
 )
 from web_store.tests.payment.test_web_store_payment_api_client import (
@@ -1610,7 +1611,7 @@ def test_signup_grop_web_store_automatically_fully_refund_paid_signup_payment(
     )
     with (
         translation.override(language.pk),
-        patch("requests.get") as mocked_web_store_request,
+        patch("requests.post") as mocked_web_store_request,
     ):
         mocked_web_store_request.return_value = mocked_web_store_response
 
@@ -1693,9 +1694,9 @@ def test_web_store_automatically_fully_refund_paid_signup_group_payment_for_recu
         translation.override(language.pk),
         requests_mock.Mocker() as req_mock,
     ):
-        req_mock.get(
-            f"{settings.WEB_STORE_API_BASE_URL}payment/refund/instant/{DEFAULT_ORDER_ID}",
-            json=DEFAULT_GET_REFUND_DATA,
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/refund/instant",
+            json=DEFAULT_CREATE_INSTANT_REFUNDS_RESPONSE,
         )
 
         assert_delete_signup_group(api_client, signup_group.pk)
@@ -1869,7 +1870,7 @@ def test_signup_group_web_store_automatically_fully_refund_payment_api_error(
     mocked_web_store_response = get_mock_response(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
     )
-    with patch("requests.get") as mocked_web_store_request:
+    with patch("requests.post") as mocked_web_store_request:
         mocked_web_store_request.return_value = mocked_web_store_response
 
         response = delete_signup_group(api_client, signup_group.pk)

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -14,7 +14,6 @@ from requests import RequestException
 from registrations.exceptions import WebStoreAPIError, WebStoreRefundValidationError
 from web_store.merchant.clients import WebStoreMerchantAPIClient
 from web_store.order.clients import WebStoreOrderAPIClient
-from web_store.payment.clients import WebStorePaymentAPIClient
 from web_store.product.clients import WebStoreProductAPIClient
 
 
@@ -254,34 +253,17 @@ def create_or_update_web_store_merchant(merchant, created: bool):
         raise WebStoreAPIError(api_error_message)
 
 
-def create_web_store_refund(payment):
-    client = WebStorePaymentAPIClient()
-
-    try:
-        resp_json = client.create_instant_refund(payment.external_order_id)
-    except RequestException as request_exc:
-        if getattr(request_exc.response, "status_code", 0) == 404:
-            # Order does not exist so no need to refund => interpret as success.
-            # This might otherwise cause unnecessary exceptions in automated refunds.
-            return {}
-
-        api_error_message = get_web_store_api_error_message(request_exc.response)
-        raise WebStoreAPIError(api_error_message)
-
-    if resp_json.get("errors"):
-        # Refund has errors despite a 200/OK status_code => raise exception.
-        refund_error_messages = get_web_store_api_refunds_error_messages(resp_json)
-        raise WebStoreRefundValidationError(refund_error_messages)
-
-    return resp_json
-
-
 def create_web_store_refunds(orders_data):
     client = WebStoreOrderAPIClient()
 
     try:
         resp_json = client.create_instant_refunds(orders_data)
     except RequestException as request_exc:
+        if getattr(request_exc.response, "status_code", 0) == 404:
+            # Order does not exist so no need to refund => interpret as success.
+            # This might otherwise cause unnecessary exceptions in automated refunds.
+            return {}
+
         api_error_message = get_web_store_api_error_message(request_exc.response)
         raise WebStoreAPIError(api_error_message)
 

--- a/web_store/payment/clients.py
+++ b/web_store/payment/clients.py
@@ -16,12 +16,3 @@ class WebStorePaymentAPIClient(WebStoreAPIBaseClient):
                 "namespace": self.api_namespace,
             },
         )
-
-    def create_instant_refund(self, order_id: str) -> dict:
-        return self._make_request(
-            f"{self.payment_api_base_url}refund/instant/{order_id}",
-            "get",
-            headers={
-                "api-key": self.api_key,
-            },
-        )

--- a/web_store/tests/payment/test_web_store_payment_api_client.py
+++ b/web_store/tests/payment/test_web_store_payment_api_client.py
@@ -121,34 +121,3 @@ def test_get_payment_exception(status_code):
     with patch("requests.get") as mocked_request, pytest.raises(RequestException):
         mocked_request.return_value = mocked_response
         client.get_payment(order_id=DEFAULT_ORDER_ID)
-
-
-def test_create_refund_success():
-    client = WebStorePaymentAPIClient()
-    mocked_response = get_mock_response(
-        status_code=status.HTTP_200_OK,
-        json_return_value=DEFAULT_GET_REFUND_DATA,
-    )
-
-    with patch("requests.get") as mocked_request:
-        mocked_request.return_value = mocked_response
-        response_json = client.create_instant_refund(DEFAULT_ORDER_ID)
-
-    assert response_json == DEFAULT_GET_REFUND_DATA
-
-
-@pytest.mark.parametrize(
-    "status_code",
-    [
-        status.HTTP_403_FORBIDDEN,
-        status.HTTP_404_NOT_FOUND,
-        status.HTTP_500_INTERNAL_SERVER_ERROR,
-    ],
-)
-def test_create_refund_exception(status_code):
-    client = WebStorePaymentAPIClient()
-    mocked_response = get_mock_response(status_code=status_code)
-
-    with patch("requests.get") as mocked_request, pytest.raises(RequestException):
-        mocked_request.return_value = mocked_response
-        client.create_instant_refund(DEFAULT_ORDER_ID)


### PR DESCRIPTION
### Description
For refunds, always use the `order/refund/instant` endpoint. It has turned out that the endpoint under the Payment Experience API should not be used by client services anymore.
### Closes
[LINK-2078](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2078)

[LINK-2078]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ