### PR TITLE
LINK-2084 | Ensure correct default for checkout language

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -930,13 +930,14 @@ class SignUpMixin:
 
         if checkout_url := api_response.get("checkoutUrl"):
             kwargs["checkout_url"] = get_checkout_url_with_lang_param(
-                checkout_url, getattr(contact_person, "service_language_id", "fi")
+                checkout_url,
+                getattr(contact_person, "service_language_id", None) or "fi",
             )
 
         if logged_in_checkout_url := api_response.get("loggedInCheckoutUrl"):
             kwargs["logged_in_checkout_url"] = get_checkout_url_with_lang_param(
                 logged_in_checkout_url,
-                getattr(contact_person, "service_language_id", "fi"),
+                getattr(contact_person, "service_language_id", None) or "fi",
             )
 
         kwargs["created_by"] = self.created_by

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -218,7 +218,7 @@ def create_web_store_api_order(
         signup_or_group.created_by.uuid if signup_or_group.created_by_id else None
     )
 
-    service_lang = getattr(contact_person, "service_language_id", "fi")
+    service_lang = getattr(contact_person, "service_language_id", None) or "fi"
     with translation.override(service_lang):
         order_data = signup_or_group.to_web_store_order_json(
             user_uuid, contact_person=contact_person


### PR DESCRIPTION
### Description
Ensures that if the contact person's service language is `None`, the value `fi` will be used as the default language for the Talpa checkout.
### Closes
LINK-2084