### PR TITLE
LINK-2096 | Use GeoModelSerializer in analytics API

### DIFF
--- a/data_analytics/serializers.py
+++ b/data_analytics/serializers.py
@@ -1,4 +1,5 @@
 from django_orghierarchy.models import Organization
+from munigeo.api import GeoModelSerializer
 from rest_framework import serializers
 
 from events.api import DivisionSerializer, EnumChoiceField
@@ -47,7 +48,9 @@ class DataAnalyticsKeywordSerializer(
 
 
 class DataAnalyticsPlaceSerializer(
-    DataAnalyticsCreatedModifiedBaseSerializer, TranslatedModelSerializer
+    DataAnalyticsCreatedModifiedBaseSerializer,
+    TranslatedModelSerializer,
+    GeoModelSerializer,
 ):
     parent = serializers.PrimaryKeyRelatedField(read_only=True)
     replaced_by = serializers.PrimaryKeyRelatedField(read_only=True)


### PR DESCRIPTION
### Description
Ensures that coordinates are returned using `DEFAULT_SRS` from the data analytics API.
### Closes
LINK-2096