### PR TITLE
LINK-2096 | Add data_source endpoint to analytics api

### DIFF
--- a/data_analytics/api.py
+++ b/data_analytics/api.py
@@ -17,6 +17,7 @@ from data_analytics.filters import (
 )
 from data_analytics.serializers import (
     DataAnalyticsAdministrativeDivisionSerializer,
+    DataAnalyticsDataSourceSerializer,
     DataAnalyticsEventSerializer,
     DataAnalyticsKeywordSerializer,
     DataAnalyticsLanguageSerializer,
@@ -26,7 +27,7 @@ from data_analytics.serializers import (
     DataAnalyticsRegistrationSerializer,
     DataAnalyticsSignUpSerializer,
 )
-from events.models import Event, Keyword, Language, Offer, Place
+from events.models import DataSource, Event, Keyword, Language, Offer, Place
 from registrations.models import Registration, SignUp
 
 _ORDER_BY_ID = "-id"
@@ -37,6 +38,25 @@ class DataAnalyticsBaseViewSet(AuditLogApiViewMixin, viewsets.ReadOnlyModelViewS
     authentication_classes = [KnoxTokenAuthentication]
     http_method_names = ["get", "options"]
     permission_classes = [IsAuthenticated]
+
+
+class AdministrativeDivisionViewSet(DataAnalyticsBaseViewSet):
+    queryset = AdministrativeDivision.objects.order_by(_ORDER_BY_ID)
+    serializer_class = DataAnalyticsAdministrativeDivisionSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filterset_class = DataAnalyticsAdministrativeDivisionFilter
+
+
+class DataSourceViewSet(DataAnalyticsBaseViewSet):
+    queryset = DataSource.objects.order_by(_ORDER_BY_ID)
+    serializer_class = DataAnalyticsDataSourceSerializer
+
+
+class EventViewSet(DataAnalyticsBaseViewSet):
+    queryset = Event.objects.order_by(_ORDER_BY_CREATED_TIME)
+    serializer_class = DataAnalyticsEventSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filterset_class = DataAnalyticsEventFilter
 
 
 class KeywordViewSet(DataAnalyticsBaseViewSet):
@@ -51,18 +71,9 @@ class LanguageViewSet(DataAnalyticsBaseViewSet):
     serializer_class = DataAnalyticsLanguageSerializer
 
 
-class AdministrativeDivisionViewSet(DataAnalyticsBaseViewSet):
-    queryset = AdministrativeDivision.objects.order_by(_ORDER_BY_ID)
-    serializer_class = DataAnalyticsAdministrativeDivisionSerializer
-    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filterset_class = DataAnalyticsAdministrativeDivisionFilter
-
-
-class PlaceViewSet(DataAnalyticsBaseViewSet):
-    queryset = Place.objects.order_by(_ORDER_BY_CREATED_TIME)
-    serializer_class = DataAnalyticsPlaceSerializer
-    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filterset_class = DataAnalyticsPlaceFilter
+class OfferViewSet(DataAnalyticsBaseViewSet):
+    queryset = Offer.objects.order_by(_ORDER_BY_ID)
+    serializer_class = DataAnalyticsOfferSerializer
 
 
 class OrganizationViewSet(DataAnalyticsBaseViewSet):
@@ -72,16 +83,11 @@ class OrganizationViewSet(DataAnalyticsBaseViewSet):
     filterset_class = DataAnalyticsOrganizationFilter
 
 
-class EventViewSet(DataAnalyticsBaseViewSet):
-    queryset = Event.objects.order_by(_ORDER_BY_CREATED_TIME)
-    serializer_class = DataAnalyticsEventSerializer
+class PlaceViewSet(DataAnalyticsBaseViewSet):
+    queryset = Place.objects.order_by(_ORDER_BY_CREATED_TIME)
+    serializer_class = DataAnalyticsPlaceSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
-    filterset_class = DataAnalyticsEventFilter
-
-
-class OfferViewSet(DataAnalyticsBaseViewSet):
-    queryset = Offer.objects.order_by(_ORDER_BY_ID)
-    serializer_class = DataAnalyticsOfferSerializer
+    filterset_class = DataAnalyticsPlaceFilter
 
 
 class RegistrationViewSet(DataAnalyticsBaseViewSet):

--- a/data_analytics/serializers.py
+++ b/data_analytics/serializers.py
@@ -3,7 +3,15 @@ from munigeo.api import GeoModelSerializer
 from rest_framework import serializers
 
 from events.api import DivisionSerializer, EnumChoiceField
-from events.models import Event, Keyword, Language, Offer, Place, PUBLICATION_STATUSES
+from events.models import (
+    DataSource,
+    Event,
+    Keyword,
+    Language,
+    Offer,
+    Place,
+    PUBLICATION_STATUSES,
+)
 from linkedevents.serializers import TranslatedModelSerializer
 from registrations.models import Registration, SignUp
 
@@ -25,6 +33,23 @@ class DataAnalyticsAdministrativeDivisionSerializer(DivisionSerializer):
             "ocd_id",
             "municipality",
             "translations",
+        )
+
+
+class DataAnalyticsDataSourceSerializer(serializers.ModelSerializer):
+    owner = serializers.PrimaryKeyRelatedField(read_only=True)
+    has_api_key = serializers.SerializerMethodField()
+
+    def get_has_api_key(self, obj):
+        return bool(obj.api_key)
+
+    class Meta:
+        model = DataSource
+        fields = (
+            "id",
+            "name",
+            "has_api_key",
+            "owner",
         )
 
 

--- a/data_analytics/tests/test_data_source_get.py
+++ b/data_analytics/tests/test_data_source_get.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from data_analytics.tests.utils import (
+    get_detail_and_assert_object_in_response,
+    get_list_and_assert_objects_in_response,
+)
+from events.tests.factories import DataSourceFactory
+from events.tests.utils import assert_fields_exist
+
+_LIST_URL = reverse("data_analytics:datasource-list")
+
+
+def get_detail_url(data_source_pk: str):
+    return reverse("data_analytics:datasource-detail", kwargs={"pk": data_source_pk})
+
+
+def get_detail(api_client: APIClient, data_source_pk: str):
+    return api_client.get(get_detail_url(data_source_pk), format="json")
+
+
+def get_list(api_client: APIClient, query: Optional[str] = None):
+    url = _LIST_URL
+
+    if query:
+        url += f"?{query}"
+
+    return api_client.get(url, format="json")
+
+
+def assert_data_source_fields_exist(data):
+    fields = (
+        "id",
+        "name",
+        "has_api_key",
+        "owner",
+    )
+    assert_fields_exist(data, fields)
+
+
+@pytest.mark.parametrize("url_type", ["detail", "list"])
+@pytest.mark.parametrize("method", ["head", "post", "put", "patch", "delete"])
+@pytest.mark.django_db
+def test_disallowed_http_methods(user_api_client, registration, url_type, method):
+    url = _LIST_URL if url_type == "list" else get_detail_url(registration.pk)
+
+    response = getattr(user_api_client, method)(url)
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+@pytest.mark.django_db
+def test_get_data_source_detail(user_api_client, data_source):
+    response = get_detail_and_assert_object_in_response(
+        user_api_client, get_detail, data_source.pk
+    )
+
+    assert_data_source_fields_exist(response.data)
+
+
+@pytest.mark.django_db
+def test_get_data_source_list(user_api_client, data_source):
+    data_source2 = DataSourceFactory()
+
+    get_list_and_assert_objects_in_response(
+        user_api_client, get_list, [data_source.pk, data_source2.pk]
+    )

--- a/data_analytics/urls.py
+++ b/data_analytics/urls.py
@@ -6,6 +6,7 @@ app_name = "data_analytics"
 
 router = SimpleRouter()
 router.register(r"administrative_division", api.AdministrativeDivisionViewSet)
+router.register(r"data_source", api.DataSourceViewSet)
 router.register(r"event", api.EventViewSet)
 router.register(r"keyword", api.KeywordViewSet)
 router.register(r"language", api.LanguageViewSet)


### PR DESCRIPTION
### Description
Adds an endpoint for `DataSource` objects to the data analytics API. The field `has_api_key` can be used to determine if the data source is used against the API for bringing events.
### Closes
LINK-2097