### PR TITLE
LINK-1645 | Scrub sensitive data through sentry_sdk

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -16,6 +16,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django_jinja.builtins import DEFAULT_EXTENSIONS
 from easy_thumbnails.conf import Settings as thumbnail_settings  # noqa: N813
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 from sentry_sdk.serializer import add_global_repr_processor
 
 from linkedevents import __version__
@@ -278,12 +279,32 @@ if DJANGO_EXTENSIONS_AVAILABLE:
     INSTALLED_APPS.extend(["django_extensions"])
 
 COMMIT_HASH = get_release_string()
+SENTRY_DENYLIST = DEFAULT_DENYLIST + [
+    "access_code",
+    "user_name",
+    "user_email",
+    "user_phone_number",
+    "first_name",
+    "last_name",
+    "phone_number",
+    "email",
+    "city",
+    "street_address",
+    "zipcode",
+    "postal_code",
+    "date_of_birth",
+    "membership_number",
+    "native_language",
+    "service_language",
+    "extra_info",
+]
 if env("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=env("SENTRY_DSN"),
         environment=env("SENTRY_ENVIRONMENT"),
         release=COMMIT_HASH,
         integrations=[DjangoIntegration()],
+        event_scrubber=EventScrubber(denylist=SENTRY_DENYLIST),
     )
 
 MIDDLEWARE = [

--- a/linkedevents/tests/test_sentry.py
+++ b/linkedevents/tests/test_sentry.py
@@ -1,8 +1,21 @@
 import pytest
+from django.conf import settings as django_settings
+from sentry_sdk import capture_exception
+from sentry_sdk.scrubber import EventScrubber
 from sentry_sdk.serializer import global_repr_processors
 
 from events.tests.factories import ApiKeyUserFactory
 from helevents.tests.factories import UserFactory
+
+
+def _assert_sensitive_fields_scrubbed(events, fields):
+    (event,) = events
+
+    frames = event["exception"]["values"][0]["stacktrace"]["frames"]
+    (frame,) = frames
+
+    for field in fields:
+        assert frame["vars"][field] == "[Filtered]"
 
 
 @pytest.mark.django_db
@@ -22,3 +35,80 @@ def test_anonymize_user_repr_function():
 
     nonetype_repr = global_repr_processors[0](None, None)
     assert nonetype_repr == NotImplemented
+
+
+def test_custom_denylist_part1(sentry_init, sentry_capture_events):
+    sentry_init(event_scrubber=EventScrubber(denylist=django_settings.SENTRY_DENYLIST))
+    events = sentry_capture_events()
+
+    try:
+        access_code = "1234"
+        user_name = "John Doe"
+        user_email = "user@test.dev"
+        user_phone_number = "+3581234567890"
+        first_name = "John"
+        last_name = "Doe"
+        phone_number = "+3581234567890"
+        raise ValueError()
+    except ValueError:
+        capture_exception()
+
+    _assert_sensitive_fields_scrubbed(
+        events,
+        (
+            "access_code",
+            "user_name",
+            "user_email",
+            "user_phone_number",
+            "first_name",
+            "last_name",
+            "phone_number",
+        ),
+    )
+
+
+def test_custom_denylist_part2(sentry_init, sentry_capture_events):
+    sentry_init(event_scrubber=EventScrubber(denylist=django_settings.SENTRY_DENYLIST))
+    events = sentry_capture_events()
+
+    try:
+        email = "user@test.dev"
+        city = "Helsinki"
+        street_address = "Test street 1"
+        zipcode = "00100"
+        postal_code = "00100"
+        date_of_birth = "1970-01-01"
+        membership_number = "123456"
+        raise ValueError()
+    except ValueError:
+        capture_exception()
+
+    _assert_sensitive_fields_scrubbed(
+        events,
+        (
+            "email",
+            "city",
+            "street_address",
+            "zipcode",
+            "postal_code",
+            "date_of_birth",
+            "membership_number",
+        ),
+    )
+
+
+def test_custom_denylist_part3(sentry_init, sentry_capture_events):
+    sentry_init(event_scrubber=EventScrubber(denylist=django_settings.SENTRY_DENYLIST))
+    events = sentry_capture_events()
+
+    try:
+        native_language = "fi"
+        service_language = "en"
+        extra_info = "extra info"
+        raise ValueError()
+    except ValueError:
+        capture_exception()
+
+    _assert_sensitive_fields_scrubbed(
+        events, ("native_language", "service_language", "extra_info")
+    )


### PR DESCRIPTION
### Description
Makes Sentry client use `EventScrubber` to scrub sensitive information before it is sent to the Sentry server.

The unit test is split into three different ones because it seems that only at most seven variables are recorded into the Sentry event.
### Closes
[LINK-1645](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1645)

[LINK-1645]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ