### PR TITLE
Fix: Enkora importer places and timestamps

### DIFF
--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -200,7 +200,7 @@ class EnkoraImporter(Importer):
     place_map = {
         1: {
             "enkora-name": "Latokartanon liikuntahalli",  # 4 TPrek paikkaa
-            "tprek-id": 45931,
+            "tprek-id": 72921,  # tprek-id appears to have changed
             "keywords": set(),
         },
         2: {
@@ -627,9 +627,24 @@ class EnkoraImporter(Importer):
             "keywords": set(),
         },
         325: {
-            "enkora-name": "Kuntosali Ruoholahti, Itämerenkatu 21, 4.krs.",  # ELIXIA Ruoholahti / Kuntokeskus
-            "tprek-id": 40101,
+            # Replacing ELIXIA Ruoholahti / Kuntokeskus (tprek:40101) for Enkora courses
+            # as it can't be displayed on liikunta.hel.fi because of contractual reasons
+            "enkora-name": "Kuntosali Ruoholahti, Itämerenkatu 21, 4.krs.",
+            "tprek-id": None,
+            "street-address": "Itämerenkatu 21",
+            "city": "Helsinki",
+            "zip-code": "00180",
+            "epsg:4326": (60.16377733194139, 24.91081911419979),
             "keywords": {SPORT_GYM},
+        },
+        327: {
+            "enkora-name": "Perhetalo Unikko",
+            "tprek-id": None,
+            "street-address": "Unikkotie 8",
+            "city": "Helsinki",
+            "zip-code": "00720",
+            "epsg:4326": (60.24545426653339, 24.99044444303867),
+            "keywords": set(),
         },
     }
 
@@ -889,7 +904,7 @@ class EnkoraImporter(Importer):
             defaults=defaults, **ds_args
         )
         org_args = dict(origin_id=org_parts[1], data_source=self.publisher_datasource)
-        defaults = dict(name="Tietotekniikka- ja viestintäosasto")
+        defaults = dict(name="Liikuntaan aktivointi")
         self.organization, _ = Organization.objects.get_or_create(
             defaults=defaults, **org_args
         )
@@ -1994,7 +2009,11 @@ class EnkoraImporter(Importer):
             try:
                 Place.objects.get(id=tprek_id)
             except ObjectDoesNotExist:
-                logger.error("Unknown place '{}'!".format(tprek_id))
+                logger.error(
+                    "Unknown place '{} for course with ID {}".format(
+                        tprek_id, course["reservation_event_group_id"]
+                    )
+                )
                 raise
 
             location["id"] = tprek_id

--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -1585,9 +1585,20 @@ class EnkoraImporter(Importer):
             if field_name not in course:
                 dates[field_name] = None
             else:
-                dates[field_name] = timezone.make_aware(
-                    course[field_name], EnkoraImporter.EEST
-                )
+                try:
+                    dates[field_name] = timezone.make_aware(
+                        course[field_name], EnkoraImporter.EEST
+                    )
+                except AttributeError:
+                    logging.error(
+                        (
+                            "Enkora event ID {}: unable to add timezone info for field name {}"
+                            ", skipping event and related sub-events"
+                        ).format(
+                            course["reservation_event_group_id"],
+                            field_name,
+                        )
+                    )
 
         # Course capacity:
         if (


### PR DESCRIPTION
- Changed tprek-id for "Latokartanon liikuntahalli" due to apparent change in source
- "ELIXIA Ruoholahti / Kuntokeskus" (tprek:40101) can't be shown as the event location so created manual place mapping with the name "Kuntosali Ruoholahti, Itämerenkatu 21, 4.krs." and accompanying information
- "Perhetalo Unikko" place added as it doesn't exist in TPR
- Updated organization name to "Liikuntaan aktivointi" based on user feedback
- Added exception handling and error logging for timestamp processing during event import
- Added course ID to error logging for when an unrecognised place is encountered