### PR TITLE
LINK-2103 | Allow only admins to delete signups after event has started

### DIFF
--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -2278,3 +2278,55 @@ def test_web_store_partial_refund_order_or_payment_status_api_error(
     assert payment.is_fully_refunded is False
 
     assert len(mail.outbox) == 0
+
+
+@freeze_time("2024-06-26 11:00:00+03:00")
+@pytest.mark.parametrize("user_role", ["regular_user", "admin"])
+@pytest.mark.django_db
+def test_regular_user_or_non_created_admin_cannot_delete_signup_if_event_has_started(
+    api_client, organization, user_role
+):
+    user = create_user_by_role(user_role, organization)
+    api_client.force_authenticate(user)
+
+    signup = SignUpFactory(
+        registration__event__publisher=organization,
+        registration__event__start_time=localtime() - timedelta(hours=1),
+        created_by=user,
+    )
+
+    response = delete_signup(api_client, signup.pk)
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.data["detail"] == (
+        "Only an admin can delete a signup after an event has started."
+    )
+
+
+@freeze_time("2024-06-26 11:00:00+03:00")
+@pytest.mark.parametrize(
+    "user_role", ["superuser", "registration_admin", "admin", "regular_user"]
+)
+@pytest.mark.django_db
+def test_allowed_user_roles_can_delete_signup_if_event_has_started(
+    api_client, organization, user_role
+):
+    user = create_user_by_role(user_role, organization)
+    api_client.force_authenticate(user)
+
+    signup = SignUpFactory(
+        registration__event__publisher=organization,
+        registration__event__start_time=localtime() - timedelta(hours=1),
+        registration__created_by=user if user_role == "admin" else None,
+    )
+
+    if user_role == "regular_user":
+        user.email = hel_email
+        user.save(update_fields=["email"])
+
+        RegistrationUserAccessFactory(
+            registration=signup.registration,
+            email=user.email,
+            is_substitute_user=True,
+        )
+
+    assert_delete_signup(api_client, signup.pk, contact_person_count=None)


### PR DESCRIPTION
### Description
Allows only admins to delete a signup or a signup group after an event has started.
### Closes
[LINK-2103](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2103)

[LINK-2103]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ