### PR TITLE
fix(events): fix error with x_ongoing_OR_set

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2946,7 +2946,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
         )
         queryset = queryset.filter(Exists(kw_qs) | Exists(audience_qs))
 
-    if "local_ongoing_OR_set" in "".join(params):
+    if "local_ongoing_OR_set1" in "".join(params):
         count = 1
         all_ids = []
         while f"local_ongoing_OR_set{count}" in params:
@@ -2961,10 +2961,10 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                     }
                 )
             count += 1
-        ids = set.intersection(*all_ids)
+        ids = set.intersection(*all_ids) if all_ids else set()
         queryset = queryset.filter(id__in=ids)
 
-    if "internet_ongoing_OR_set" in "".join(params):
+    if "internet_ongoing_OR_set1" in "".join(params):
         count = 1
         all_ids = []
         while f"internet_ongoing_OR_set{count}" in params:
@@ -2979,10 +2979,10 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                     }
                 )
             count += 1
-        ids = set.intersection(*all_ids)
+        ids = set.intersection(*all_ids) if all_ids else set()
         queryset = queryset.filter(id__in=ids)
 
-    if "all_ongoing_OR_set" in "".join(params):
+    if "all_ongoing_OR_set1" in "".join(params):
         count = 1
         all_ids = []
         while f"all_ongoing_OR_set{count}" in params:
@@ -2998,7 +2998,7 @@ def _filter_event_queryset(queryset, params, srs=None):  # noqa: C901
                     {k for k, v in cached_ids.items() if rc.search(v, concurrent=True)}
                 )
             count += 1
-        ids = set.intersection(*all_ids)
+        ids = set.intersection(*all_ids) if all_ids else set()
         queryset = queryset.filter(id__in=ids)
 
     if "keyword_OR_set" in "".join(params):

--- a/events/tests/conftest.py
+++ b/events/tests/conftest.py
@@ -100,13 +100,11 @@ def kw_name_set_2():
     return "known_keywordset"
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def offer(event2):
     return Offer.objects.create(event=event2, is_free=True)
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_minimal_event_dict(make_keyword_id):
     def _make_minimal_event_dict(data_source, organization, location_id):
@@ -140,13 +138,11 @@ def make_minimal_event_dict(make_keyword_id):
     return _make_minimal_event_dict
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def minimal_event_dict(data_source, organization, location_id, make_minimal_event_dict):
     return make_minimal_event_dict(data_source, organization, location_id)
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_minimal_event_dict_class(request, make_minimal_event_dict):
     def _make_minimal_event_dict(self, *args):
@@ -209,7 +205,6 @@ def administrative_division2(administrative_division_type):
     return division
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def place_dict(data_source, organization):
     return {
@@ -229,7 +224,6 @@ def place_dict(data_source, organization):
     }
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def place(data_source, organization, administrative_division):
     return Place.objects.create(
@@ -241,7 +235,6 @@ def place(data_source, organization, administrative_division):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def make_event(data_source, organization, place, user):
     def _make_event(origin_id, start_time=None, end_time=None):
@@ -268,7 +261,6 @@ def make_event(data_source, organization, place, user):
     return _make_event
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def event(data_source, organization, place, user):
     return Event.objects.create(
@@ -285,7 +277,6 @@ def event(data_source, organization, place, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def past_event(data_source, organization, place, user):
     return Event.objects.create(
@@ -302,7 +293,6 @@ def past_event(data_source, organization, place, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def place2(other_data_source, organization2):
     return Place.objects.create(
@@ -324,7 +314,6 @@ def place3(data_source, organization):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def event2(other_data_source, organization2, place2, user2, keyword):
     return Event.objects.create(
@@ -373,7 +362,6 @@ def event4(place3, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def draft_event(place, user):
     return Event.objects.create(
@@ -388,14 +376,12 @@ def draft_event(place, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def location_id(place):
     obj_id = reverse(PlaceSerializer.view_name, kwargs={"pk": place.id})
     return obj_id
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def make_location_id():
     def _make_location_id(place):
@@ -405,7 +391,6 @@ def make_location_id():
     return _make_location_id
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword_dict(data_source, organization):
     return {
@@ -419,7 +404,6 @@ def keyword_dict(data_source, organization):
     }
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_image():
     def _make_image(data_source, organization, image_name, image_url):
@@ -433,7 +417,6 @@ def make_image():
     return _make_image
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_keyword():
     def _make_keyword(data_source, organization, kw_name):
@@ -465,43 +448,36 @@ def make_keyword():
     return _make_keyword
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def image(data_source, organization, image_name, image_url, make_image):
     return make_image(data_source, organization, image_name, image_url)
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def image2(data_source, organization, image_name_2, image_url_2, make_image):
     return make_image(data_source, organization, image_name_2, image_url_2)
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def image3(data_source, organization, image_name_3, image_url_3, make_image):
     return make_image(data_source, organization, image_name_3, image_url_3)
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword(data_source, organization, kw_name, make_keyword):
     return make_keyword(data_source, organization, kw_name)
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword2(data_source, organization, kw_name_2, make_keyword):
     return make_keyword(data_source, organization, kw_name_2)
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword3(data_source, organization, kw_name_3, make_keyword):
     return make_keyword(data_source, organization, kw_name_3)
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_keyword_id(make_keyword):
     def _make_keyword_id(data_source, organization, kw_name):
@@ -512,13 +488,11 @@ def make_keyword_id(make_keyword):
     return _make_keyword_id
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword_id(data_source, organization, kw_name, make_keyword_id):
     return make_keyword_id(data_source, organization, kw_name)
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_keyword_set():
     def _make_keyword_set(data_source, organization, kw_set_name):
@@ -532,7 +506,6 @@ def make_keyword_set():
     return _make_keyword_set
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword_set_dict(data_source, organization):
     return {
@@ -547,7 +520,6 @@ def keyword_set_dict(data_source, organization):
     }
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword_set(
     make_keyword_set, data_source, keyword, keyword2, organization, kw_name_set
@@ -557,7 +529,6 @@ def keyword_set(
     return kw_set
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keyword_set2(
     make_keyword_set, other_data_source, keyword3, organization, kw_name_set_2
@@ -567,7 +538,6 @@ def keyword_set2(
     return kw_set
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def languages():
     lang_objs = [
@@ -580,13 +550,11 @@ def languages():
     return lang_objs
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def keywordlabel(kw_name, languages):
     return KeywordLabel.objects.create(name=kw_name, language=languages[0])
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def languages_class(request):
     lang_objs = [
@@ -600,7 +568,6 @@ def language_id(language):
     return obj_id
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_complex_event_dict(make_keyword_id):
     def _make_complex_event_dict(data_source, organization, location_id, languages):
@@ -661,7 +628,6 @@ def make_complex_event_dict(make_keyword_id):
     return _make_complex_event_dict
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def complex_event_dict(
     data_source, organization, location_id, languages, make_complex_event_dict
@@ -669,7 +635,6 @@ def complex_event_dict(
     return make_complex_event_dict(data_source, organization, location_id, languages)
 
 
-@pytest.mark.django_db
 @pytest.fixture(scope="class")
 def make_complex_event_dict_class(request, make_complex_event_dict):
     def _make_complex_event_dict(self, *args):
@@ -708,7 +673,6 @@ def all_api_get_list(request, event, api_client):
     return f
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def registration(event, user):
     return Registration.objects.create(
@@ -722,7 +686,6 @@ def registration(event, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def registration2(event2, user2):
     return Registration.objects.create(
@@ -736,7 +699,6 @@ def registration2(event2, user2):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def registration3(event3, user):
     return Registration.objects.create(
@@ -747,7 +709,6 @@ def registration3(event3, user):
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def registration4(event4, user):
     return Registration.objects.create(

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -197,6 +197,70 @@ def test_get_event_detail_check_fields_exist(api_client, event):
     assert_event_fields_exist(response.data)
 
 
+@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
+@pytest.mark.django_db
+def test_get_event_list_returns_events_from_cache_with_local_ongoing_or_set(
+    django_cache, api_client
+):
+    event1 = EventFactory()
+    event2 = EventFactory()
+    EventFactory.create_batch(10)
+    django_cache.set("local_ids", {event1.id: "keyword", event2.id: "avainsana"})
+
+    get_list_and_assert_events("local_ongoing_OR_set1=keyword", [event1])
+
+
+@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
+@pytest.mark.django_db
+def test_get_event_list_returns_events_from_cache_with_internet_ongoing_or_set(
+    django_cache, api_client
+):
+    event1 = EventFactory()
+    event2 = EventFactory()
+    EventFactory.create_batch(10)
+    django_cache.set("internet_ids", {event1.id: "keyword", event2.id: "avainsana"})
+
+    get_list_and_assert_events("internet_ongoing_OR_set1=keyword", [event1])
+
+
+@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
+@pytest.mark.django_db
+def test_get_event_list_returns_events_from_cache_with_all_ongoing_or_set(
+    django_cache, api_client
+):
+    event1 = EventFactory()
+    event2 = EventFactory()
+    event3 = EventFactory()
+    event4 = EventFactory()
+    EventFactory.create_batch(10)
+    django_cache.set("local_ids", {event1.id: "keyword", event2.id: "avainsana"})
+    django_cache.set("internet_ids", {event3.id: "keyword", event4.id: "avainsana"})
+
+    get_list_and_assert_events("all_ongoing_OR_set1=keyword", [event1, event3])
+
+
+@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query",
+    [
+        "local_ongoing_OR_set1=xxxxxxxxx",
+        "all_ongoing_OR_set1=xxxxxxxxx",
+        "internet_ongoing_OR_set1=xxxxxxxxx",
+    ],
+)
+def test_get_event_list_returns_empty_list_on_invalid_ongoing_or_set_value(
+    django_cache, api_client, query
+):
+    event1 = EventFactory()
+    event2 = EventFactory()
+    EventFactory.create_batch(10)
+    django_cache.set("local_ids", {event1.id: "keyword", event2.id: "keyword2"})
+    django_cache.set("internet_ids", {event1.id: "keyword", event2.id: "keyword2"})
+
+    get_list_and_assert_events(query, [])
+
+
 @pytest.mark.django_db
 def test_get_unknown_event_detail_check_404(api_client):
     response = api_client.get(reverse("event-detail", kwargs={"pk": "möö"}))

--- a/linkedevents/tests/conftest.py
+++ b/linkedevents/tests/conftest.py
@@ -119,7 +119,6 @@ def other_data_source():
     return DataSource.objects.create(id=OTHER_DATA_SOURCE_ID, api_key="test_api_key2")
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def organization_class():
     return OrganizationClass.objects.create(
@@ -127,7 +126,6 @@ def organization_class():
     )
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def organization(data_source, user):
     """Organization with a single admin user (user)."""
@@ -142,7 +140,6 @@ def organization(data_source, user):
     return org
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def organization2(other_data_source, user2):
     """Organization with a single admin user (user2)."""
@@ -157,7 +154,6 @@ def organization2(other_data_source, user2):
     return org
 
 
-@pytest.mark.django_db
 @pytest.fixture
 def organization3(other_data_source, user2):
     """Organization with a single admin user (user2)."""


### PR DESCRIPTION
If no events were found, the filter caused a crash (TypeError, set.intersection needs values). This fixes the issue.

This also fixes another issue; this error was encountered with the query param `local_ongoing_OR_set=xxxxxxx`, which shouldn't even trigger the filter (according to the implementation) since it requires an ascending number at the end, starting from 1. E.g. `blabla_OR_set1=x,blabla_OR_set2=y` is valid.

There's also something terribly wrong with the regex that the ongoing OR set filters use. Apparently, this was encountered in https://github.com/City-of-Helsinki/linkedevents/commit/f581b16a2b9df1bf0f21a404f29e87a4766bee40, since there are tests marked as xfail for the function.

Added some test cases for the filter (there were none before), but marked them as xfail because the filter doesn't seem to work as described in documentation.