### PR TITLE
LINK-2108: fix x_ongoing_OR_set filters

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from datetime import timezone as datetime_timezone
 from functools import partial, reduce
 from operator import or_
-from typing import Iterable, Optional
+from typing import Iterable, Literal, Optional
 
 import django.forms
 import django_filters
@@ -2717,12 +2717,19 @@ def parse_duration_string(duration):
     return int(val) * mul
 
 
-def _terms_to_regex(terms, operator):
+def _terms_to_regex(terms, operator: Literal["AND", "OR"]):
     """
     Create a compiled regex from of the provided terms of the form
     r'(\b(term1){e<2}')|(\b(term2){e<2})" This would match a string
     with terms aligned in any order allowing two edits per term.
     """
+    if operator == "AND":
+        regex_join = ""
+    elif operator == "OR":
+        regex_join = "|"
+    else:
+        raise ValueError("Invalid operator")
+
     vals = terms.split(",")
     valexprs = []
     for val in vals:
@@ -2733,10 +2740,6 @@ def _terms_to_regex(terms, operator):
         escaped_val = regex.escape(val)
         expr = r"(\b" + f"({escaped_val}){{e<{e}}})"
         valexprs.append(expr)
-    if operator == "AND":
-        regex_join = ""
-    elif operator == "OR":
-        regex_join = "|"
     expr = f"{regex_join.join(valexprs)}"
     return regex.compile(expr, regex.IGNORECASE)
 

--- a/events/api.py
+++ b/events/api.py
@@ -2732,7 +2732,7 @@ def _terms_to_regex(terms, operator):
             e = 2
         escaped_val = regex.escape(val)
         expr = r"(\b" + f"({escaped_val}){{e<{e}}})"
-        valexprs.extend(expr)
+        valexprs.append(expr)
     if operator == "AND":
         regex_join = ""
     elif operator == "OR":

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -402,18 +402,13 @@ class TestImageAPI(APITestCase):
     "val,operator,expected_regex",
     [
         ("1234567", "AND", r"(\b(1234567){e<1})"),
-        pytest.param("1234567", "OR", r"(\b(1234567){e<1})", marks=pytest.mark.xfail),
+        ("1234567", "OR", r"(\b(1234567){e<1})"),
         # >=8 chars
         ("12345678", "AND", r"(\b(12345678){e<2})"),
-        pytest.param("12345678", "OR", r"(\b(12345678){e<2})", marks=pytest.mark.xfail),
+        ("12345678", "OR", r"(\b(12345678){e<2})"),
         # Multiple terms, different lengths
         ("1234567,12345678", "AND", r"(\b(1234567){e<1})(\b(12345678){e<2})"),
-        pytest.param(
-            "1234567,12345678",
-            "OR",
-            r"(\b(1234567){e<1})|(\b(12345678){e<2})",
-            marks=pytest.mark.xfail,
-        ),
+        ("1234567,12345678", "OR", r"(\b(1234567){e<1})|(\b(12345678){e<2})"),
         # Sanitization
         ("(foo", "AND", r"(\b(\(foo){e<1})"),
         ("(.*)", "AND", r"(\b(\(\.\*\)){e<1})"),

--- a/events/tests/test_api.py
+++ b/events/tests/test_api.py
@@ -416,3 +416,8 @@ class TestImageAPI(APITestCase):
 )
 def test__terms_to_regex(val, operator, expected_regex):
     assert _terms_to_regex(val, operator).pattern == expected_regex
+
+
+def test__terms_to_regex_raises_value_error_on_invalid_operator():
+    with pytest.raises(ValueError):
+        _terms_to_regex("1234567", "FOO")

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -197,7 +197,6 @@ def test_get_event_detail_check_fields_exist(api_client, event):
     assert_event_fields_exist(response.data)
 
 
-@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
 @pytest.mark.django_db
 def test_get_event_list_returns_events_from_cache_with_local_ongoing_or_set(
     django_cache, api_client
@@ -210,7 +209,6 @@ def test_get_event_list_returns_events_from_cache_with_local_ongoing_or_set(
     get_list_and_assert_events("local_ongoing_OR_set1=keyword", [event1])
 
 
-@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
 @pytest.mark.django_db
 def test_get_event_list_returns_events_from_cache_with_internet_ongoing_or_set(
     django_cache, api_client
@@ -223,7 +221,6 @@ def test_get_event_list_returns_events_from_cache_with_internet_ongoing_or_set(
     get_list_and_assert_events("internet_ongoing_OR_set1=keyword", [event1])
 
 
-@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
 @pytest.mark.django_db
 def test_get_event_list_returns_events_from_cache_with_all_ongoing_or_set(
     django_cache, api_client
@@ -239,7 +236,6 @@ def test_get_event_list_returns_events_from_cache_with_all_ongoing_or_set(
     get_list_and_assert_events("all_ongoing_OR_set1=keyword", [event1, event3])
 
 
-@pytest.mark.xfail(reason="_terms_to_regex doesn't work with OR operator")
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "query",


### PR DESCRIPTION
Previously `_terms_to_regex` generated regex like this:
`(|\\|b|(|f|o|o|)|{|e|<|2|}|)|(|\\|b|(|b|a|r|)|{|e|<|2|}|)`

Now generates:
`(\\b(foo){e<2})|(\\b(bar){e<2})`

This should fix the issues with `x_ongoing_OR_set` filters.