### PR TITLE
LINK-2121 | Replace and remove some deprecated code from tests

### DIFF
--- a/events/tests/test_permissions.py
+++ b/events/tests/test_permissions.py
@@ -180,7 +180,7 @@ class TestUserModelPermissions(TestCase):
         # magicmock cannot be used for object properties
         self.instance.admin_organizations.add(self.org)
         qs = self.instance.get_editable_events(total_qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs,
             [repr(event_1), repr(event_2), repr(event_3)],
             ordered=False,
@@ -191,12 +191,12 @@ class TestUserModelPermissions(TestCase):
         self.instance.admin_organizations.remove(self.org)
         self.instance.organization_memberships.add(self.org)
         qs = self.instance.get_editable_events(total_qs)
-        self.assertQuerysetEqual(qs, [repr(event_2)], transform=repr)
+        self.assertQuerySetEqual(qs, [repr(event_2)], transform=repr)
 
         # test for other users
         self.instance.organization_memberships.remove(self.org)
         qs = self.instance.get_editable_events(total_qs)
-        self.assertQuerysetEqual(qs, [], transform=repr)
+        self.assertQuerySetEqual(qs, [], transform=repr)
 
     def test_admin_get_editable_events_for_registration(self):
         # this test requires the whole User model, as admin organizations are dependent on org hierarchy
@@ -228,7 +228,7 @@ class TestUserModelPermissions(TestCase):
         # test for registration admin user
         self.instance.registration_admin_organizations.add(self.org)
         qs = self.instance.get_editable_events_for_registration(total_qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [repr(event_1), repr(event_2), repr(event_3)], transform=repr
         )
 
@@ -236,14 +236,14 @@ class TestUserModelPermissions(TestCase):
         self.instance.registration_admin_organizations.remove(self.org)
         self.instance.admin_organizations.add(self.org)
         qs = self.instance.get_editable_events_for_registration(total_qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [repr(event_1), repr(event_2), repr(event_3)], transform=repr
         )
 
         # test for other users
         self.instance.admin_organizations.remove(self.org)
         qs = self.instance.get_editable_events_for_registration(total_qs)
-        self.assertQuerysetEqual(qs, [], transform=repr)
+        self.assertQuerySetEqual(qs, [], transform=repr)
 
     def test_substitute_user_get_editable_events_for_registration(self):
         event_1 = EventFactory(
@@ -294,11 +294,11 @@ class TestUserModelPermissions(TestCase):
             is_substitute_user=True,
         )
         qs = self.instance.get_editable_events_for_registration(total_qs)
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [repr(event_1), repr(event_2), repr(event_3)], transform=repr
         )
 
         # test for other users
         RegistrationUserAccess.objects.all().delete()
         qs = self.instance.get_editable_events_for_registration(total_qs)
-        self.assertQuerysetEqual(qs, [], transform=repr)
+        self.assertQuerySetEqual(qs, [], transform=repr)

--- a/events/tests/test_signals.py
+++ b/events/tests/test_signals.py
@@ -39,12 +39,12 @@ class TestOrganizationPostSave(TestCase):
         self.org_1.save()
 
         qs = self.org_2.admin_users.all()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [repr(self.user_1), repr(self.user_2)], ordered=False, transform=repr
         )
 
         qs = self.org_2.regular_users.all()
-        self.assertQuerysetEqual(
+        self.assertQuerySetEqual(
             qs, [repr(self.user_1), repr(self.user_2)], ordered=False, transform=repr
         )
 

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -595,7 +595,7 @@ class TestSignUpGroup(TestCase):
 
         with self.assertRaises(PriceGroupValidationError) as exc:
             self.signup_group.to_web_store_order_json(self.user.uuid)
-        self.assertEquals(
+        self.assertEqual(
             exc.exception.messages[0], "No price groups exist for signup group."
         )
 
@@ -1023,7 +1023,7 @@ class TestSignUp(TestCase):
         with self.assertRaises(PriceGroupValidationError) as exc:
             self.signup.to_web_store_order_json(self.user.uuid)
 
-        self.assertEquals(
+        self.assertEqual(
             exc.exception.messages[0], "Price group does not exist for signup."
         )
 

--- a/registrations/tests/test_signup_serializer.py
+++ b/registrations/tests/test_signup_serializer.py
@@ -14,7 +14,6 @@ from registrations.tests.factories import (
 )
 
 
-@pytest.mark.no_test_audit_log
 @pytest.mark.parametrize(
     "maximum_attendee_capacity,waiting_list_capacity,expected_signups_count,"
     "expected_attending,expected_waitlisted",


### PR DESCRIPTION
### Description
- Replaces `assertQuerysetEqual` method calls with `assertQuerySetEqual` as the former is removed in Django 5.1.
- Replaces `assertEquals` method calls with `assertEqual` as the former has been marked as deprecated.
- Removes the use of the deleted `no_test_audit_log` marker from one test.
### Closes
[LINK-2121](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2121)

[LINK-2121]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ