### PR TITLE
refactor: use zoneinfo instead of pytz, reduce complexity of two serializer methods

### DIFF
--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -4,8 +4,8 @@ import re
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 from typing import Generator, Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 import requests
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class EnkoraImporter(Importer):
     name = "enkora"
     supported_languages = ["fi", "sv", "en"]
-    EEST = pytz.timezone("Europe/Helsinki")
+    EEST = ZoneInfo("Europe/Helsinki")
 
     ERRORS_ALLOWED_BEFORE_STOP = 20
 

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
-import pytz
 from django.conf import settings
 from django.utils.timezone import localdate, localtime
 from django.utils.translation import gettext_lazy as _
@@ -170,11 +170,17 @@ def _validate_signups_for_payment(
 
 class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
     created_time = DateTimeField(
-        default_timezone=pytz.UTC, required=False, allow_null=True, read_only=True
+        default_timezone=ZoneInfo("UTC"),
+        required=False,
+        allow_null=True,
+        read_only=True,
     )
 
     last_modified_time = DateTimeField(
-        default_timezone=pytz.UTC, required=False, allow_null=True, read_only=True
+        default_timezone=ZoneInfo("UTC"),
+        required=False,
+        allow_null=True,
+        read_only=True,
     )
 
     created_by = serializers.StringRelatedField(required=False, allow_null=True)
@@ -1394,7 +1400,9 @@ class SignUpGroupSerializer(
 class SeatReservationCodeSerializer(serializers.ModelSerializer):
     seats = serializers.IntegerField(required=True)
 
-    timestamp = DateTimeField(default_timezone=pytz.UTC, required=False, read_only=True)
+    timestamp = DateTimeField(
+        default_timezone=ZoneInfo("UTC"), required=False, read_only=True
+    )
 
     expiration = serializers.SerializerMethodField()
 

--- a/registrations/tests/test_seatsreservation_put.py
+++ b/registrations/tests/test_seatsreservation_put.py
@@ -7,7 +7,6 @@ from rest_framework import status
 from audit_log.models import AuditLogEntry
 from events.tests.utils import versioned_reverse as reverse
 from registrations.tests.factories import SeatReservationCodeFactory
-from registrations.tests.test_seatsreservation_post import assert_reserve_seats
 from registrations.tests.utils import create_user_by_role
 
 
@@ -113,12 +112,14 @@ def test_code_value_is_required(user_api_client, registration):
 
 @pytest.mark.django_db
 def test_code_value_must_match(user_api_client, registration):
-    reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+    reservation = SeatReservationCodeFactory(
+        seats=1, registration=registration, code="86e5f626-c9d0-4759-8a7a-9146d24c280d"
+    )
 
     reservation_data = {
         "seats": 1,
         "registration": registration.id,
-        "code": "invalid_code",
+        "code": "d76449af-49d9-4016-ad79-27faa147f461",
     }
     response = update_seats_reservation(
         user_api_client, reservation.id, reservation_data
@@ -153,7 +154,6 @@ def test_cannot_update_expired_reservation(user_api_client, registration):
         "registration": registration.id,
         "code": reservation.code,
     }
-    assert_reserve_seats(user_api_client, reservation_data)
 
     response = update_seats_reservation(
         user_api_client, reservation.id, reservation_data

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail
@@ -143,7 +143,7 @@ def create_events_ics_file_content(events, language="fi"):
     cal.add("prodid", "-//linkedevents.hel.fi//NONSGML API//EN")
     cal.add("version", "2.0")
 
-    local_tz = pytz.timezone(settings.TIME_ZONE)
+    local_tz = ZoneInfo(settings.TIME_ZONE)
     with translation.override(language):
         for event in events:
             calendar_event = _create_calendar_event_from_event(event, local_tz)
@@ -232,7 +232,7 @@ def create_web_store_api_order(
         )
 
     order_data["lastValidPurchaseDateTime"] = localized_expiration_datetime.astimezone(
-        pytz.timezone("Europe/Helsinki")
+        ZoneInfo("Europe/Helsinki")
     ).strftime("%Y-%m-%dT%H:%M:%S")
 
     client = WebStoreOrderAPIClient()


### PR DESCRIPTION
### Description
To reduce issues raised by SonarCloud, the following have been done in this PR:
- Use `zoneinfo` instead of `pytz` in `registration.utils`, `registration.serializers`, `registration.commands.mark_payments_expired` and `events.importer.enkora`.
- Refactor the methods `SeatReservationSerializer.validate` and `SignUpSerializer.validate` to have smaller cognitive complexities.
### Closes
[LINK-2124](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2124)
[LINK-2126](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2126)

[LINK-2124]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-2126]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ