### PR TITLE
LINK-2130 | Faster registration and GDPR delete transaction tests

### DIFF
--- a/helevents/tests/test_gdpr_api_delete.py
+++ b/helevents/tests/test_gdpr_api_delete.py
@@ -101,9 +101,11 @@ def _assert_gdpr_delete(
 # === tests ===
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(GDPR_DISABLE_API_DELETION=False)
-def test_authenticated_user_can_delete_own_data(api_client, settings):
+def test_authenticated_user_can_delete_own_data(
+    api_client, settings, django_capture_on_commit_callbacks
+):
     user = UserFactory()
 
     _create_default_data(user)
@@ -121,7 +123,8 @@ def test_authenticated_user_can_delete_own_data(api_client, settings):
             )
             api_client.credentials(HTTP_AUTHORIZATION=auth_header)
 
-            response = _delete_gdpr_data(api_client, user.uuid)
+            with django_capture_on_commit_callbacks(execute=True):
+                response = _delete_gdpr_data(api_client, user.uuid)
             assert response.status_code == status.HTTP_204_NO_CONTENT
 
             assert mocked_signup_post_delete.called is True
@@ -135,10 +138,10 @@ def test_authenticated_user_can_delete_own_data(api_client, settings):
     assert event.user_organization is None
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(GDPR_DISABLE_API_DELETION=False)
 def test_authenticated_user_can_delete_own_data_event_user_details_not_nulled(
-    api_client, settings
+    api_client, settings, django_capture_on_commit_callbacks
 ):
     user = UserFactory()
 
@@ -159,7 +162,8 @@ def test_authenticated_user_can_delete_own_data_event_user_details_not_nulled(
             )
             api_client.credentials(HTTP_AUTHORIZATION=auth_header)
 
-            response = _delete_gdpr_data(api_client, user.uuid)
+            with django_capture_on_commit_callbacks(execute=True):
+                response = _delete_gdpr_data(api_client, user.uuid)
             assert response.status_code == status.HTTP_204_NO_CONTENT
 
             assert mocked_signup_post_delete.called is True

--- a/registrations/tests/management/test_delete_expired_seat_reservations.py
+++ b/registrations/tests/management/test_delete_expired_seat_reservations.py
@@ -15,46 +15,51 @@ from registrations.utils import code_validity_duration
 
 
 @freezegun.freeze_time("2024-02-16 16:45:00+02:00")
-@pytest.mark.django_db(transaction=True)
-def test_delete_expired_seatreservations():
-    registration = RegistrationFactory(
-        maximum_attendee_capacity=5, waiting_list_capacity=5
-    )
+@pytest.mark.django_db
+def test_delete_expired_seatreservations(django_capture_on_commit_callbacks):
+    with django_capture_on_commit_callbacks(execute=True):
+        registration = RegistrationFactory(
+            maximum_attendee_capacity=5, waiting_list_capacity=5
+        )
 
     now = localtime()
     expired_timestamp = now - timedelta(minutes=code_validity_duration(1) + 1)
     expired_timestamp2 = now - timedelta(minutes=code_validity_duration(2) + 1)
     exactly_expiration_threshold = now - timedelta(minutes=code_validity_duration(1))
 
-    expired_reservation = SeatReservationCodeFactory(registration=registration, seats=1)
-    SeatReservationCode.objects.filter(pk=expired_reservation.pk).update(
-        timestamp=expired_timestamp
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        expired_reservation = SeatReservationCodeFactory(
+            registration=registration, seats=1
+        )
+        SeatReservationCode.objects.filter(pk=expired_reservation.pk).update(
+            timestamp=expired_timestamp
+        )
 
-    non_expired_reservation = SeatReservationCodeFactory(
-        registration=registration, seats=1
-    )
-    non_expired_reservation2 = SeatReservationCodeFactory(
-        registration=registration, seats=1
-    )
-    SeatReservationCode.objects.filter(pk=non_expired_reservation2.pk).update(
-        timestamp=exactly_expiration_threshold
-    )
+        non_expired_reservation = SeatReservationCodeFactory(
+            registration=registration, seats=1
+        )
+        non_expired_reservation2 = SeatReservationCodeFactory(
+            registration=registration, seats=1
+        )
+        SeatReservationCode.objects.filter(pk=non_expired_reservation2.pk).update(
+            timestamp=exactly_expiration_threshold
+        )
 
-    expired_reservation2 = SeatReservationCodeFactory(
-        registration=registration, seats=2
-    )
-    SeatReservationCode.objects.filter(pk=expired_reservation2.pk).update(
-        timestamp=expired_timestamp2
-    )
+        expired_reservation2 = SeatReservationCodeFactory(
+            registration=registration, seats=2
+        )
+        SeatReservationCode.objects.filter(pk=expired_reservation2.pk).update(
+            timestamp=expired_timestamp2
+        )
 
     registration.refresh_from_db()
-    assert registration.remaining_attendee_capacity == 1
+    assert registration.remaining_attendee_capacity == 3
     assert registration.remaining_waiting_list_capacity == 5
 
     assert SeatReservationCode.objects.count() == 4
 
-    call_command("delete_expired_seat_reservations")
+    with django_capture_on_commit_callbacks(execute=True):
+        call_command("delete_expired_seat_reservations")
 
     assert SeatReservationCode.objects.count() == 2
     assert Counter(SeatReservationCode.objects.values_list("pk", flat=True)) == Counter(


### PR DESCRIPTION
### Description
Make some tests in the `registrations` and `helevents` apps faster by using `django_capture_on_commit_callbacks` instead of `django_db(transaction=True)`.
### Closes
[LINK-2130](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2130)

[LINK-2130]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ