### PR TITLE
LINK-2131: Allow payments for zero-priced customer groups

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -600,29 +600,22 @@ class Registration(CreatedModifiedBaseModel):
             return
 
         try:
-            payment = (
-                first_on_list.create_web_store_payment()
-                if first_on_list.price_group.price > 0
-                else None
-            )
-        except (ValidationError, AttributeError) as exc:
+            payment = first_on_list.create_web_store_payment()
+        except ValidationError as exc:
             logger.error(
                 f"Failed to create payment when moving waitlisted signup #{first_on_list.pk} "
                 f"to attending: {exc}"
             )
             return
 
-        if not payment:
-            self.move_first_waitlisted_to_attending(first_on_list)
-        else:
-            first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
-            first_on_list.save(update_fields=["attendee_status"])
+        first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
+        first_on_list.save(update_fields=["attendee_status"])
 
-            contact_person = first_on_list.actual_contact_person
-            contact_person.send_notification(
-                SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
-                payment_link=payment.checkout_url,
-            )
+        contact_person = first_on_list.actual_contact_person
+        contact_person.send_notification(
+            SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
+            payment_link=payment.checkout_url,
+        )
 
     def move_first_waitlisted_to_attending(self, first_on_list=None):
         first_on_list = first_on_list or self.get_waitlisted(count=1)

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -151,23 +151,6 @@ def _validate_contact_person_for_payment(contact_person: dict, errors: dict) -> 
         )
 
 
-def _validate_signups_for_payment(
-    signups: list[dict], errors: dict, field_name: str
-) -> None:
-    if any(
-        [
-            signup
-            for signup in signups
-            if signup.get("price_group")
-            and signup["price_group"]["registration_price_group"].price <= 0
-        ]
-    ):
-        errors[field_name] = _(
-            "Participants must have a price group with price greater than 0 "
-            "selected to make a payment."
-        )
-
-
 class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
     created_time = DateTimeField(
         default_timezone=pytz.UTC, required=False, allow_null=True, read_only=True
@@ -616,8 +599,6 @@ class SignUpSerializer(
                 )
 
             if validated_data.get("create_payment"):
-                _validate_signups_for_payment([validated_data], errors, "price_group")
-
                 _validate_contact_person_for_payment(
                     validated_data.get("contact_person"), errors
                 )
@@ -1201,8 +1182,6 @@ class SignUpGroupCreateSerializer(
             )
 
         if validated_data.get("create_payment"):
-            _validate_signups_for_payment(validated_data["signups"], errors, "signups")
-
             _validate_contact_person_for_payment(
                 contact_person,
                 errors,

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -1353,16 +1353,9 @@ def test_group_send_email_with_payment_link_when_moving_to_participant_for_recur
     )
 
 
-@pytest.mark.parametrize(
-    "price,expected_attendee_status,expected_mailbox_count",
-    [
-        (None, SignUp.AttendeeStatus.WAITING_LIST, 1),
-        (Decimal("0"), SignUp.AttendeeStatus.ATTENDING, 2),
-    ],
-)
 @pytest.mark.django_db
-def test_group_email_with_payment_link_not_sent_when_moving_participant_if_price_missing(
-    api_client, price, expected_attendee_status, expected_mailbox_count
+def test_group_email_with_payment_link_sent_when_moving_participant_with_zero_price(
+    api_client,
 ):
     language = LanguageFactory(pk="en", service_language=True)
 
@@ -1374,7 +1367,12 @@ def test_group_email_with_payment_link_not_sent_when_moving_participant_if_price
     user = create_user_by_role("registration_admin", registration.publisher)
     api_client.force_authenticate(user)
 
-    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
+    RegistrationWebStoreProductMappingFactory(registration=registration)
+
+    zero_price = Decimal("0.00")
+    registration_price_group = RegistrationPriceGroupFactory(
+        registration=registration, price=zero_price
+    )
 
     signup_group = SignUpGroupFactory(registration=registration)
     SignUpFactory(
@@ -1396,14 +1394,9 @@ def test_group_email_with_payment_link_not_sent_when_moving_participant_if_price
         email=test_email1,
         service_language=language,
     )
-
-    if price is not None:
-        registration_price_group.price = price
-        registration_price_group.save()
-
-        SignUpPriceGroupFactory(
-            signup=signup2, registration_price_group=registration_price_group
-        )
+    SignUpPriceGroupFactory(
+        signup=signup2, registration_price_group=registration_price_group
+    )
 
     assert SignUpPayment.objects.count() == 0
 
@@ -1411,26 +1404,28 @@ def test_group_email_with_payment_link_not_sent_when_moving_participant_if_price
         translation.override(language.pk),
         requests_mock.Mocker() as req_mock,
     ):
-        req_mock.post(f"{settings.WEB_STORE_API_BASE_URL}order/")
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/",
+            json=DEFAULT_GET_ORDER_DATA,
+        )
 
         assert_delete_signup_group(api_client, signup_group.id)
 
-        assert req_mock.call_count == 0
+        assert req_mock.call_count == 1
 
-    assert SignUpPayment.objects.count() == 0
+    assert SignUpPayment.objects.count() == 1
+    assert SignUpPayment.objects.first().amount == zero_price
 
     signup2.refresh_from_db()
-    assert signup2.attendee_status == expected_attendee_status
+    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
 
-    assert len(mail.outbox) == expected_mailbox_count
-    if expected_mailbox_count == 1:
-        assert mail.outbox[0].to[0] == contact_person.email
-        assert mail.outbox[0].subject == "Registration cancelled - Foo"
-    else:
-        assert mail.outbox[0].to[0] == contact_person2.email
-        assert mail.outbox[0].subject == "Registration confirmation - Foo"
-        assert mail.outbox[1].to[0] == contact_person.email
-        assert mail.outbox[1].subject == "Registration cancelled - Foo"
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to[0] == contact_person2.email
+    assert (
+        mail.outbox[0].subject == "Payment required for registration confirmation - Foo"
+    )
+    assert mail.outbox[1].to[0] == contact_person.email
+    assert mail.outbox[1].subject == "Registration cancelled - Foo"
 
 
 @pytest.mark.parametrize(

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -627,15 +627,16 @@ def test_create_signup_payment_contact_person_name_missing(
     )
 
 
-@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-10")])
 @pytest.mark.django_db
-def test_create_signup_payment_with_zero_or_negative_price(
-    api_client, registration, price
-):
+def test_create_signup_payment_with_zero_price(api_client, registration):
     LanguageFactory(pk="fi", service_language=True)
     reservation = SeatReservationCodeFactory(seats=1, registration=registration)
+
+    RegistrationWebStoreProductMappingFactory(registration=registration)
+
+    zero_price = Decimal("0.00")
     registration_price_group = RegistrationPriceGroupFactory(
-        registration=registration, price=price
+        registration=registration, price=zero_price
     )
 
     user = create_user_by_role("registration_admin", registration.publisher)
@@ -657,15 +658,18 @@ def test_create_signup_payment_with_zero_or_negative_price(
 
     assert SignUpPayment.objects.count() == 0
 
-    response = create_signups(api_client, signups_data)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    with requests_mock.Mocker() as req_mock:
+        req_mock.post(
+            f"{settings.WEB_STORE_API_BASE_URL}order/",
+            json=DEFAULT_GET_ORDER_DATA,
+        )
 
-    assert SignUpPayment.objects.count() == 0
+        assert_create_signups(api_client, signups_data)
 
-    assert response.data["signups"][0]["price_group"][0] == (
-        "Participants must have a price group with price greater than 0 "
-        "selected to make a payment."
-    )
+        assert req_mock.call_count == 1
+
+    assert SignUpPayment.objects.count() == 1
+    assert SignUpPayment.objects.first().amount == zero_price
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
Allows to sign up and create a Talpa payment with zero-priced customer group selections. A payment is also created when moving a waitlisted participant to the "attending" status if the participant has a customer group with a zero price.
### Closes
[LINK-2131](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2131)

[LINK-2131]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ