### PR TITLE
LINK-2133: User-friendlier web store API error message

### DIFF
--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -1625,7 +1625,7 @@ def test_create_organization_with_web_store_merchant_api_field_exception(
     json_return_value = {
         "errors": [{"code": "test", "message": "Merchant already exists."}]
     }
-    with requests_mock.Mocker() as req_mock:
+    with translation.override("en"), requests_mock.Mocker() as req_mock:
         req_mock.post(
             merchant_create_url,
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1638,8 +1638,7 @@ def test_create_organization_with_web_store_merchant_api_field_exception(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data[0] == (
-        f"Talpa web store API error (status_code: {status.HTTP_400_BAD_REQUEST}): "
-        f"{json_return_value['errors']}"
+        f"Payment API experienced an error (code: {status.HTTP_400_BAD_REQUEST})"
     )
 
     assert Organization.objects.count() == 1
@@ -1665,7 +1664,7 @@ def test_create_organization_with_web_store_merchant_api_unknown_exception(
     assert Organization.objects.count() == 1
     assert WebStoreMerchant.objects.count() == 0
 
-    with requests_mock.Mocker() as req_mock:
+    with translation.override("en"), requests_mock.Mocker() as req_mock:
         req_mock.post(
             merchant_create_url, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -1676,7 +1675,7 @@ def test_create_organization_with_web_store_merchant_api_unknown_exception(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data[0] == (
-        f"Unknown Talpa web store API error (status_code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
+        f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
     )
 
     assert Organization.objects.count() == 1
@@ -1704,7 +1703,7 @@ def test_update_organization_with_web_store_merchant_api_field_exception(
     json_return_value = {
         "errors": [{"code": "test", "message": "Merchant already exists."}]
     }
-    with requests_mock.Mocker() as req_mock:
+    with translation.override("en"), requests_mock.Mocker() as req_mock:
         req_mock.post(
             merchant_create_url,
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1717,8 +1716,7 @@ def test_update_organization_with_web_store_merchant_api_field_exception(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data[0] == (
-        f"Talpa web store API error (status_code: {status.HTTP_400_BAD_REQUEST}): "
-        f"{json_return_value['errors']}"
+        f"Payment API experienced an error (code: {status.HTTP_400_BAD_REQUEST})"
     )
 
     assert WebStoreMerchant.objects.count() == 0
@@ -1742,7 +1740,7 @@ def test_update_organization_with_web_store_merchant_api_unknown_exception(
 
     assert WebStoreMerchant.objects.count() == 0
 
-    with requests_mock.Mocker() as req_mock:
+    with translation.override("en"), requests_mock.Mocker() as req_mock:
         req_mock.post(
             merchant_create_url, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
@@ -1753,7 +1751,7 @@ def test_update_organization_with_web_store_merchant_api_unknown_exception(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data[0] == (
-        f"Unknown Talpa web store API error (status_code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
+        f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
     )
 
     assert WebStoreMerchant.objects.count() == 0

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-27 06:40+0000\n"
+"POT-Creation-Date: 2024-08-28 10:44+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -815,7 +815,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Refund not found with order ID %(order_id)s and refund ID %(refund_id)s."
-msgstr "Maksua ei löytynyt tilauksen ID:llä %(order_id)s ja hyvityksen ID:llä %(refund_id)s."
+msgstr "Hyvitystä ei löytynyt tilauksen ID:llä %(order_id)s ja hyvityksen ID:llä %(refund_id)s."
 
 #: registrations/api.py:753
 msgid "Could not check refund status from Talpa API."
@@ -824,12 +824,14 @@ msgstr "Hyvityksen tilaa ei voitu tarkistaa Talpa-rajapinnasta."
 #: registrations/api.py:792
 msgid "Refund marked as paid in webhook payload, but not in Talpa API."
 msgstr ""
-"Hyvitys on merkitty maksetuksi webhook-notifikaatiossa, mutta ei Talpa-rajapinnassa."
+"Hyvitys on merkitty maksetuksi webhook-notifikaatiossa, mutta ei Talpa-"
+"rajapinnassa."
 
 #: registrations/api.py:807
 msgid "Refund marked as failed in webhook payload, but not in Talpa API."
 msgstr ""
-"Hyvitys on merkitty epäonnistuneeksi webhook-notifikaatiossa, mutta ei Talpa-rajapinnassa."
+"Hyvitys on merkitty epäonnistuneeksi webhook-notifikaatiossa, mutta ei Talpa-"
+"rajapinnassa."
 
 #: registrations/auth.py:25
 msgid "Invalid webhook API key."
@@ -2588,19 +2590,15 @@ msgstr "Käyttöoikeuskutsu"
 msgid "View the participants"
 msgstr "Katso osallistujat"
 
-#: registrations/utils.py:212
-msgid "Unknown Talpa web store API error"
-msgstr ""
-
 #: registrations/utils.py:215
+msgid "Unknown Talpa web store API error"
+msgstr "Talpa-rajapinnassa tapahtui tuntematon virhe"
+
+#: registrations/utils.py:218
 msgid "Talpa web store API error"
-msgstr ""
+msgstr "Talpa-rajapinnassa tapahtui virhe"
 
-#~ msgid ""
-#~ "Payment marked as cancelled in webhook payload, but not in Talpa API."
-#~ msgstr ""
-#~ "Maksu on merkitty perutuksi webhook-notifikaatiossa, mutta ei Talpa-"
-#~ "rajapinnassa."
-
-#~ msgid "VAT code"
-#~ msgstr "ALV-koodi"
+#: registrations/utils.py:230
+#, python-format
+msgid "Payment API experienced an error (code: %(status_code)s)"
+msgstr "Maksurajapinnassa tapahtui virhe (koodi: %(status_code)s)"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-27 06:40+0000\n"
+"POT-Creation-Date: 2024-08-28 10:44+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2582,18 +2582,15 @@ msgstr "Åtkomstinbjudan"
 msgid "View the participants"
 msgstr "Se deltagarna"
 
-#: registrations/utils.py:212
-msgid "Unknown Talpa web store API error"
-msgstr ""
-
 #: registrations/utils.py:215
+msgid "Unknown Talpa web store API error"
+msgstr "Okänt Talpa webbshop API-fel"
+
+#: registrations/utils.py:218
 msgid "Talpa web store API error"
-msgstr ""
+msgstr "Talpa webbshop API-fel"
 
-#~ msgid ""
-#~ "Payment marked as cancelled in webhook payload, but not in Talpa API."
-#~ msgstr ""
-#~ "Betalning markerad som avbruten i webhook-avisering, men inte i Talpa API."
-
-#~ msgid "VAT code"
-#~ msgstr "Momskod"
+#: registrations/utils.py:230
+#, python-format
+msgid "Payment API experienced an error (code: %(status_code)s)"
+msgstr "Ett fel uppstod i betalnings-API (kod: %(status_code)s)"

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1842,8 +1842,7 @@ def test_web_store_partial_refund_api_exception_when_deleting_signup_from_group_
         response = delete_signup(api_client, signup.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            "Unknown Talpa web store API error "
-            f"(status_code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == 2
@@ -1955,8 +1954,7 @@ def test_web_store_automatically_fully_refund_paid_signup_payment_api_error(api_
         response = delete_signup(api_client, signup.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == 2
@@ -2088,8 +2086,7 @@ def test_web_store_automatically_cancel_unpaid_created_signup_payment_api_error(
         response = delete_signup(api_client, signup.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == 3
@@ -2146,8 +2143,7 @@ def test_web_store_cancel_unpaid_signup_order_or_payment_status_api_error(
         response = delete_signup(api_client, signup.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == expected_calls_count
@@ -2219,8 +2215,7 @@ def test_web_store_partial_refund_order_or_payment_status_api_error(
         response = delete_signup(api_client, signup.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == expected_calls_count

--- a/registrations/tests/test_signup_group_delete.py
+++ b/registrations/tests/test_signup_group_delete.py
@@ -1659,8 +1659,7 @@ def test_signup_group_web_store_automatically_fully_refund_payment_api_error(
         response = delete_signup_group(api_client, signup_group.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == 2
@@ -1719,8 +1718,7 @@ def test_signup_group_web_store_automatically_cancel_unpaid_created_signup_payme
         response = delete_signup_group(api_client, signup_group.pk)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data[0] == (
-            f"Unknown Talpa web store API error (status_code: "
-            f"{status.HTTP_500_INTERNAL_SERVER_ERROR})"
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})"
         )
 
         assert req_mock.call_count == 3

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -587,14 +587,12 @@ def test_create_signup_group_payment_without_pricetotal_in_response(api_client):
         (
             status.HTTP_400_BAD_REQUEST,
             DEFAULT_CREATE_ORDER_ERROR_RESPONSE,
-            f"Talpa web store API error (status_code: {status.HTTP_400_BAD_REQUEST}): "
-            f"{DEFAULT_CREATE_ORDER_ERROR_RESPONSE['errors']}",
+            f"Payment API experienced an error (code: {status.HTTP_400_BAD_REQUEST})",
         ),
         (
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             {},
-            f"Unknown Talpa web store API error "
-            f"(status_code: {status.HTTP_500_INTERNAL_SERVER_ERROR})",
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})",
         ),
     ],
 )

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -514,14 +514,12 @@ def test_create_signup_payment_without_pricetotal_in_response(api_client):
         (
             status.HTTP_400_BAD_REQUEST,
             DEFAULT_CREATE_ORDER_ERROR_RESPONSE,
-            f"Talpa web store API error (status_code: {status.HTTP_400_BAD_REQUEST}): "
-            f"{DEFAULT_CREATE_ORDER_ERROR_RESPONSE['errors']}",
+            f"Payment API experienced an error (code: {status.HTTP_400_BAD_REQUEST})",
         ),
         (
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             {},
-            f"Unknown Talpa web store API error "
-            f"(status_code: {status.HTTP_500_INTERNAL_SERVER_ERROR})",
+            f"Payment API experienced an error (code: {status.HTTP_500_INTERNAL_SERVER_ERROR})",
         ),
     ],
 )


### PR DESCRIPTION
### Description
Instead of including the technical error message returned by the Talpa API, make the Linked Events API return a more generic and user-friendly error message while still logging the error details that Talpa returned.
### Closes
[LINK-2133](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2133)

[LINK-2133]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ