### PR TITLE
fix: safer mandatory fields validation

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -528,11 +528,13 @@ class SignUpSerializer(
         return instance
 
     def _validate_mandatory_fields(self, registration, validated_data, errors):
+        falsy_values = ("", None)
+
         for field in registration.mandatory_fields:
             if self.partial and field not in validated_data.keys():
                 # Don't validate field if request method is PATCH and field is missing from the payload.
                 continue
-            elif not validated_data.get(field):
+            elif validated_data.get(field) in falsy_values:
                 errors[field] = _("This field must be specified.")
 
     def _validate_date_of_birth(self, registration, validated_data, errors):

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1496,7 +1496,7 @@ class SeatReservationCodeSerializer(serializers.ModelSerializer):
             waiting_list_count = registration.current_waiting_list_count
             waiting_list_capacity_left = waiting_list_capacity - waiting_list_count
 
-            # Prevent to reserve seats to waiting ist if all available seats in waiting list
+            # Prevent to reserve seats to waiting list if all available seats in waiting list
             # are already reserved
             if (
                 validated_data["seats"]


### PR DESCRIPTION
### Description
Restores the use of `falsy_values` in the validation of mandatory fields when creating or updating a `SignUp`. Reasoning is given in the following comment of a previous PR: https://github.com/City-of-Helsinki/linkedevents/pull/967#discussion_r1734558582. 

Also fixes a typo in a comment in `registrations.serializers`.
### Closes
LINK-2126