### PR TITLE
LINK-2146: Send VAT as decimal to Talpa

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -2055,7 +2055,9 @@ class SignUpPriceGroup(RegistrationPriceGroupBaseModel, SoftDeletableBaseModel):
             "priceNet": str(strip_trailing_zeroes_from_decimal(self.price_without_vat)),
             "priceGross": str(strip_trailing_zeroes_from_decimal(self.price)),
             "priceVat": str(strip_trailing_zeroes_from_decimal(self.vat)),
-            "vatPercentage": str(int(self.vat_percentage)),
+            "vatPercentage": str(
+                strip_trailing_zeroes_from_decimal(self.vat_percentage)
+            ),
             "meta": [
                 {
                     "key": web_store_price_group_meta_key,

--- a/registrations/tests/test_models.py
+++ b/registrations/tests/test_models.py
@@ -512,7 +512,11 @@ class TestSignUpGroup(TestCase):
                         "priceNet": price_net,
                         "priceGross": price_total,
                         "priceVat": price_vat,
-                        "vatPercentage": str(int(price_group.vat_percentage)),
+                        "vatPercentage": str(
+                            strip_trailing_zeroes_from_decimal(
+                                price_group.vat_percentage
+                            )
+                        ),
                         "meta": [
                             {
                                 "key": web_store_price_group_meta_key,
@@ -533,7 +537,11 @@ class TestSignUpGroup(TestCase):
                         "priceNet": price_net2,
                         "priceGross": price_total2,
                         "priceVat": price_vat2,
-                        "vatPercentage": str(int(price_group2.vat_percentage)),
+                        "vatPercentage": str(
+                            strip_trailing_zeroes_from_decimal(
+                                price_group2.vat_percentage
+                            )
+                        ),
                         "meta": [
                             {
                                 "key": web_store_price_group_meta_key,
@@ -977,7 +985,11 @@ class TestSignUp(TestCase):
                         "priceNet": price_net,
                         "priceGross": price_total,
                         "priceVat": price_vat,
-                        "vatPercentage": str(int(price_group.vat_percentage)),
+                        "vatPercentage": str(
+                            strip_trailing_zeroes_from_decimal(
+                                price_group.vat_percentage
+                            )
+                        ),
                         "meta": [
                             {
                                 "key": web_store_price_group_meta_key,
@@ -1410,7 +1422,9 @@ class TestSignUpPriceGroup(TestCase):
                 "priceNet": price_net,
                 "priceGross": price_total,
                 "priceVat": price_vat,
-                "vatPercentage": str(int(self.price_group.vat_percentage)),
+                "vatPercentage": str(
+                    strip_trailing_zeroes_from_decimal(self.price_group.vat_percentage)
+                ),
                 "meta": [
                     {
                         "key": web_store_price_group_meta_key,

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -64,7 +64,6 @@ def create_registration(api_client, registration_data, data_source=None):
 
 def assert_create_registration(api_client, registration_data, data_source=None):
     response = create_registration(api_client, registration_data, data_source)
-    print(response.json())
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data["event"] == registration_data["event"]
 


### PR DESCRIPTION
### Description
Linked Events wrongly sent VAT percentage casted to `int` to the Talpa API, resulting in the new general VAT percentage being "25 %" instead of "25,5 %" in Talpa. This PR fixes the issue by ensuring that it's sent as a decimal number in the same way as the rest of the payment-related decimal fields (trailing zeroes are stripped).
### Closes
[LINK-2146](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2146)