### PR TITLE
LINK-2139: Validation for duplicate event links

### DIFF
--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -1112,3 +1112,55 @@ def test_create_event_with_large_minimum_and_maximum_attendee_capacity(
     event = Event.objects.first()
     assert event.minimum_attendee_capacity == 500000
     assert event.maximum_attendee_capacity == 1000000
+
+
+@pytest.mark.django_db
+def test_create_event_external_link_texts_are_cleaned(
+    user_api_client, minimal_event_dict
+):
+    minimal_event_dict["external_links"] = [
+        {
+            "name": "<p>Test</p>",
+            "link": "https://example.com",
+            "language": "fi",
+        }
+    ]
+
+    response = user_api_client.post(
+        reverse("event-list"), minimal_event_dict, format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.data["external_links"][0] == {
+        "name": "&lt;p&gt;Test&lt;/p&gt;",
+        "link": "https://example.com",
+        "language": "fi",
+    }
+
+
+@pytest.mark.django_db
+def test_create_event_duplicate_external_links_are_not_allowed(
+    user_api_client, minimal_event_dict
+):
+    name = "Test"
+    link = "https://example.com"
+    language = "fi"
+
+    minimal_event_dict["external_links"] = [
+        {"name": name, "link": link, "language": language} for _ in range(2)
+    ]
+
+    response = user_api_client.post(
+        reverse("event-list"), minimal_event_dict, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.data["external_links"]["name"]
+        == f"Duplicate link given with name {name}."
+    )
+    assert response.data["external_links"]["language"] == (
+        f"Duplicate link given with language {language}."
+    )
+    assert (
+        response.data["external_links"]["link"]
+        == f"Duplicate link given with link {link}."
+    )

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-06 12:29+0000\n"
+"POT-Creation-Date: 2024-09-10 13:19+0000\n"
 "PO-Revision-Date: 2015-04-29 12:26+0140\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -621,43 +621,58 @@ msgstr "Käyttäjällä ei ole oikeuksia tähän organisaatioon"
 msgid "Deprecated keyword not allowed ({})"
 msgstr ""
 
-#: events/serializers.py:999
+#: events/serializers.py:974
+#, python-format
+msgid "Duplicate link given with name %(name)s."
+msgstr ""
+
+#: events/serializers.py:976
+#, python-format
+msgid "Duplicate link given with language %(language)s."
+msgstr ""
+
+#: events/serializers.py:978
+#, python-format
+msgid "Duplicate link given with link %(link)s."
+msgstr ""
+
+#: events/serializers.py:1030
 msgid "You have to set either user_email or user_phone_number."
 msgstr ""
 
-#: events/serializers.py:1008
+#: events/serializers.py:1039
 msgid "User consent is required if personal information fields are filled."
 msgstr ""
 
-#: events/serializers.py:1011
+#: events/serializers.py:1042
 msgid "This field must be specified before an event is published."
 msgstr "Kenttä on täytettävä ennen kuin tapahtuman voi julkaista."
 
-#: events/serializers.py:1025
+#: events/serializers.py:1056
 msgid "Short description length must be 160 characters or less"
 msgstr ""
 
-#: events/serializers.py:1041
+#: events/serializers.py:1072
 msgid "Price info must be specified before an event is published."
 msgstr ""
 
-#: events/serializers.py:1075
+#: events/serializers.py:1101
 msgid "End time cannot be in the past. Please set a future end time."
 msgstr ""
 "Päättymisaika ei voi olla menneisyydessä. Ole hyvä ja anna tulevaisuudessa "
 "oleva päättymisaika."
 
-#: events/serializers.py:1180
+#: events/serializers.py:1206
 msgid "Cannot edit a past event."
 msgstr ""
 
-#: events/serializers.py:1195
+#: events/serializers.py:1221
 msgid ""
 "POSTPONED and RESCHEDULED statuses cannot be set directly.Changing event "
 "start_time or marking start_time nullwill reschedule or postpone an event."
 msgstr ""
 
-#: events/serializers.py:1216
+#: events/serializers.py:1242
 msgid ""
 "Public events cannot be set back to SCHEDULED if theyhave already been "
 "CANCELLED, POSTPONED or RESCHEDULED."
@@ -2488,8 +2503,8 @@ msgid ""
 "participant list."
 msgstr ""
 "Sähköpostiosoitteelle <strong>%(email)s</strong> on myönnetty oikeudet lukea "
-"kurssin <strong>%(event_name)s</strong> osallistujalista. "
-"Osallistujalistan lukeminen vaatii Suomi.fi-tunnistautumisen."
+"kurssin <strong>%(event_name)s</strong> osallistujalista. Osallistujalistan "
+"lukeminen vaatii Suomi.fi-tunnistautumisen."
 
 #: registrations/notifications.py:753
 #, python-format

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-06 12:29+0000\n"
+"POT-Creation-Date: 2024-09-10 13:19+0000\n"
 "PO-Revision-Date: 2023-06-19 12:05+0300\n"
 "Last-Translator: <harri.rissanen@vincit.fi>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -619,41 +619,56 @@ msgstr "Användaren har inga rättigheter till denna organisation"
 msgid "Deprecated keyword not allowed ({})"
 msgstr ""
 
-#: events/serializers.py:999
+#: events/serializers.py:974
+#, python-format
+msgid "Duplicate link given with name %(name)s."
+msgstr ""
+
+#: events/serializers.py:976
+#, python-format
+msgid "Duplicate link given with language %(language)s."
+msgstr ""
+
+#: events/serializers.py:978
+#, python-format
+msgid "Duplicate link given with link %(link)s."
+msgstr ""
+
+#: events/serializers.py:1030
 msgid "You have to set either user_email or user_phone_number."
 msgstr ""
 
-#: events/serializers.py:1008
+#: events/serializers.py:1039
 msgid "User consent is required if personal information fields are filled."
 msgstr ""
 
-#: events/serializers.py:1011
+#: events/serializers.py:1042
 msgid "This field must be specified before an event is published."
 msgstr "Detta fält måste anges innan ett evenemanget publiceras."
 
-#: events/serializers.py:1025
+#: events/serializers.py:1056
 msgid "Short description length must be 160 characters or less"
 msgstr ""
 
-#: events/serializers.py:1041
+#: events/serializers.py:1072
 msgid "Price info must be specified before an event is published."
 msgstr ""
 
-#: events/serializers.py:1075
+#: events/serializers.py:1101
 msgid "End time cannot be in the past. Please set a future end time."
 msgstr "Sluttiden kan inte ligga i det förflutna. Ange en framtida sluttid."
 
-#: events/serializers.py:1180
+#: events/serializers.py:1206
 msgid "Cannot edit a past event."
 msgstr ""
 
-#: events/serializers.py:1195
+#: events/serializers.py:1221
 msgid ""
 "POSTPONED and RESCHEDULED statuses cannot be set directly.Changing event "
 "start_time or marking start_time nullwill reschedule or postpone an event."
 msgstr ""
 
-#: events/serializers.py:1216
+#: events/serializers.py:1242
 msgid ""
 "Public events cannot be set back to SCHEDULED if theyhave already been "
 "CANCELLED, POSTPONED or RESCHEDULED."
@@ -2467,8 +2482,8 @@ msgid ""
 "participant list."
 msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
-"deltagarlistan för evenemanget <strong>%(event_name)s</strong>. "
-"Användning av Suomi.fi-identifiering krävs för att kunna läsa deltagarlistan."
+"deltagarlistan för evenemanget <strong>%(event_name)s</strong>. Användning "
+"av Suomi.fi-identifiering krävs för att kunna läsa deltagarlistan."
 
 #: registrations/notifications.py:748
 #, python-format
@@ -2479,8 +2494,8 @@ msgid ""
 "participant list."
 msgstr ""
 "E-postadressen <strong>%(email)s</strong> har beviljats rättigheter att läsa "
-"deltagarlistan för kursen <strong>%(event_name)s</strong>."
-"Användning av Suomi.fi-identifiering krävs för att kunna läsa deltagarlistan."
+"deltagarlistan för kursen <strong>%(event_name)s</strong>.Användning av "
+"Suomi.fi-identifiering krävs för att kunna läsa deltagarlistan."
 
 #: registrations/notifications.py:753
 #, python-format


### PR DESCRIPTION
### Description
Duplicate event links / external links have resulted in a 500 internal error. This PR introduces validation that will result in a more user-friendly 400 validation error instead.
### Closes
[LINK-2139](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2139)

[LINK-2139]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ