### PR TITLE
LINK-2112: Check refund status from a new endpoint

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -1252,9 +1252,9 @@ class WebStoreRefundWebhookViewSet(WebStoreWebhookBaseViewSet):
         return refund
 
     @staticmethod
-    def _get_refund_status_from_web_store_api(order_id: str) -> Optional[str]:
+    def _get_refund_status_from_web_store_api(refund_id: str) -> Optional[str]:
         try:
-            return get_web_store_refund_payment_status(order_id=order_id)
+            return get_web_store_refund_payment_status(refund_id=refund_id)
         except WebStoreAPIError:
             raise ConflictException(_("Could not check refund status from Talpa API."))
 
@@ -1291,7 +1291,7 @@ class WebStoreRefundWebhookViewSet(WebStoreWebhookBaseViewSet):
             serializer.validated_data["event_type"]
             == WebStoreRefundWebhookEventType.REFUND_PAID.value
         ):
-            refund_status = self._get_refund_status_from_web_store_api(order_id)
+            refund_status = self._get_refund_status_from_web_store_api(refund_id)
             if refund_status != WebStoreOrderRefundStatus.PAID_ONLINE.value:
                 return Response(
                     _(
@@ -1306,7 +1306,7 @@ class WebStoreRefundWebhookViewSet(WebStoreWebhookBaseViewSet):
             serializer.validated_data["event_type"]
             == WebStoreRefundWebhookEventType.REFUND_FAILED.value
         ):
-            refund_status = self._get_refund_status_from_web_store_api(order_id)
+            refund_status = self._get_refund_status_from_web_store_api(refund_id)
             if refund_status != WebStoreOrderRefundStatus.CANCELLED.value:
                 return Response(
                     _(

--- a/registrations/tests/test_web_store_webhook_post.py
+++ b/registrations/tests/test_web_store_webhook_post.py
@@ -48,7 +48,7 @@ from web_store.tests.order.test_web_store_order_api_client import (
 )
 from web_store.tests.payment.test_web_store_payment_api_client import (
     DEFAULT_GET_PAYMENT_DATA,
-    DEFAULT_GET_REFUND_PAYMENT_DATA,
+    DEFAULT_GET_REFUND_PAYMENTS_DATA,
     DEFAULT_PAYMENT_ID,
 )
 
@@ -58,9 +58,7 @@ _DEFAULT_GET_ORDER_URL = (
 _DEFAULT_GET_PAYMENT_URL = (
     f"{settings.WEB_STORE_API_BASE_URL}payment/admin/{DEFAULT_ORDER_ID}"
 )
-_DEFAULT_GET_REFUND_URL = (
-    f"{settings.WEB_STORE_API_BASE_URL}payment/admin/refund-payment/{DEFAULT_ORDER_ID}"
-)
+_DEFAULT_GET_REFUND_URL = f"{settings.WEB_STORE_API_BASE_URL}payment/admin/refunds/{DEFAULT_REFUND_ID}/payment"
 
 
 # === util methods ===
@@ -469,7 +467,7 @@ def test_refund_paid_webhook_for_signup_payment(
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
             _DEFAULT_GET_REFUND_URL,
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
 
         assert_payment_refunded(api_client, data, payment)
@@ -534,7 +532,7 @@ def test_refund_paid_webhook_for_signup_group_payment(
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
             _DEFAULT_GET_REFUND_URL,
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
 
         assert_payment_refunded(api_client, data, payment)
@@ -605,7 +603,7 @@ def test_refund_paid_webhook_for_recurring_event_signup_payment(
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
             _DEFAULT_GET_REFUND_URL,
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
 
         assert_payment_refunded(api_client, data, payment)
@@ -676,7 +674,7 @@ def test_refund_paid_webhook_for_recurring_event_signup_group_payment(
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
             _DEFAULT_GET_REFUND_URL,
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
 
         assert_payment_refunded(api_client, data, payment)
@@ -747,7 +745,7 @@ def test_partial_refund_paid_webhook_for_signup_group_payment(
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
             _DEFAULT_GET_REFUND_URL,
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
 
         assert_payment_refunded(api_client, data, payment, partial_refund=True)
@@ -781,8 +779,8 @@ def test_refund_failed_webhook_for_signup_payment(api_client):
         {"refundId": DEFAULT_REFUND_ID},
     )
 
-    refund_payment_data = DEFAULT_GET_REFUND_PAYMENT_DATA.copy()
-    refund_payment_data["status"] = WebStoreOrderRefundStatus.CANCELLED.value
+    refund_payment_data = [DEFAULT_GET_REFUND_PAYMENTS_DATA[0].copy()]
+    refund_payment_data[0]["status"] = WebStoreOrderRefundStatus.CANCELLED.value
 
     assert AuditLogEntry.objects.count() == 0
 
@@ -818,8 +816,8 @@ def test_refund_failed_webhook_for_signup_group_payment(api_client):
         {"refundId": DEFAULT_REFUND_ID},
     )
 
-    refund_payment_data = DEFAULT_GET_REFUND_PAYMENT_DATA.copy()
-    refund_payment_data["status"] = WebStoreOrderRefundStatus.CANCELLED.value
+    refund_payment_data = [DEFAULT_GET_REFUND_PAYMENTS_DATA[0].copy()]
+    refund_payment_data[0]["status"] = WebStoreOrderRefundStatus.CANCELLED.value
 
     assert AuditLogEntry.objects.count() == 0
 
@@ -857,8 +855,8 @@ def test_partial_refund_failed_webhook_for_signup_group_payment(api_client):
         {"refundId": DEFAULT_REFUND_ID},
     )
 
-    refund_payment_data = DEFAULT_GET_REFUND_PAYMENT_DATA.copy()
-    refund_payment_data["status"] = WebStoreOrderRefundStatus.CANCELLED.value
+    refund_payment_data = [DEFAULT_GET_REFUND_PAYMENTS_DATA[0].copy()]
+    refund_payment_data[0]["status"] = WebStoreOrderRefundStatus.CANCELLED.value
 
     assert AuditLogEntry.objects.count() == 0
 
@@ -1463,8 +1461,8 @@ def test_webhook_and_web_store_refund_status_mismatch(
         {"refundId": DEFAULT_REFUND_ID},
     )
 
-    refund_payment_data = DEFAULT_GET_REFUND_PAYMENT_DATA.copy()
-    refund_payment_data["status"] = refund_payment_status
+    refund_payment_data = [DEFAULT_GET_REFUND_PAYMENTS_DATA[0].copy()]
+    refund_payment_data[0]["status"] = refund_payment_status
 
     with requests_mock.Mocker() as req_mock:
         req_mock.get(

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -336,11 +336,11 @@ def get_web_store_payment(order_id: str) -> dict:
         _raise_web_store_chained_api_exception(request_exc)
 
 
-def get_web_store_refund_payment(order_id: str) -> dict:
+def get_web_store_refund_payments(refund_id: str) -> list[dict]:
     client = WebStorePaymentAPIClient()
 
     try:
-        return client.get_refund_payment(order_id=order_id)
+        return client.get_refund_payments(refund_id=refund_id)
     except RequestException as request_exc:
         _raise_web_store_chained_api_exception(request_exc)
 
@@ -355,6 +355,11 @@ def get_web_store_payment_status(order_id: str) -> Optional[str]:
     return payment_json.get("status")
 
 
-def get_web_store_refund_payment_status(order_id: str) -> Optional[str]:
-    payment_json = get_web_store_refund_payment(order_id)
-    return payment_json.get("status")
+def get_web_store_refund_payment_status(refund_id: str) -> Optional[str]:
+    payments_list = get_web_store_refund_payments(refund_id)
+    if payments_list:
+        # Even though the API returns a list, it will contain only one payment in our case since
+        # we create a new refund each time and it will have a single payment created in Talpa.
+        return payments_list[0].get("status")
+
+    return None

--- a/web_store/clients.py
+++ b/web_store/clients.py
@@ -55,7 +55,7 @@ class WebStoreAPIBaseClient:
         method: str,
         params: Optional[Union[dict, list]] = None,
         headers: Optional[dict] = None,
-    ) -> dict[str, Any]:
+    ) -> Union[dict[str, Any], list[dict[str, Any]]]:
         request_kwargs = self._get_request_kwargs(method, params, headers)
         response = getattr(requests, method)(url, **request_kwargs)
 

--- a/web_store/payment/clients.py
+++ b/web_store/payment/clients.py
@@ -18,9 +18,9 @@ class WebStorePaymentAPIClient(WebStoreAPIBaseClient):
             headers=self.headers,
         )
 
-    def get_refund_payment(self, order_id: str) -> dict:
+    def get_refund_payments(self, refund_id: str) -> list[dict]:
         return self._make_request(
-            f"{self.payment_api_base_url}admin/refund-payment/{order_id}",
+            f"{self.payment_api_base_url}admin/refunds/{refund_id}/payment",
             "get",
             headers=self.headers,
         )

--- a/web_store/tests/payment/test_web_store_payment_api_client.py
+++ b/web_store/tests/payment/test_web_store_payment_api_client.py
@@ -34,21 +34,23 @@ DEFAULT_GET_PAYMENT_DATA = {
     "paymentMethodLabel": "string",
 }
 
-DEFAULT_GET_REFUND_PAYMENT_DATA = {
-    "refundPaymentId": "string",
-    "orderId": DEFAULT_ORDER_ID,
-    "namespace": settings.WEB_STORE_API_NAMESPACE,
-    "userId": "string",
-    "status": WebStoreOrderRefundStatus.PAID_ONLINE.value,
-    "refundMethod": "string",
-    "refundType": "string",
-    "refundGateway": "string",
-    "totalExclTax": DEFAULT_ITEM["rowPriceNet"],
-    "total": DEFAULT_ITEM["rowPriceTotal"],
-    "taxAmount": DEFAULT_ITEM["rowPriceVat"],
-    "refundTransactionId": "string",
-    "timestamp": "string",
-}
+DEFAULT_GET_REFUND_PAYMENTS_DATA = [
+    {
+        "refundPaymentId": "string",
+        "orderId": DEFAULT_ORDER_ID,
+        "namespace": settings.WEB_STORE_API_NAMESPACE,
+        "userId": "string",
+        "status": WebStoreOrderRefundStatus.PAID_ONLINE.value,
+        "refundMethod": "string",
+        "refundType": "string",
+        "refundGateway": "string",
+        "totalExclTax": DEFAULT_ITEM["rowPriceNet"],
+        "total": DEFAULT_ITEM["rowPriceTotal"],
+        "taxAmount": DEFAULT_ITEM["rowPriceVat"],
+        "refundTransactionId": "string",
+        "timestamp": "string",
+    },
+]
 
 DEFAULT_GET_REFUND_DATA = {
     "refunds": [
@@ -77,7 +79,9 @@ DEFAULT_GET_REFUND_DATA["refunds"][0]["items"][0].update(
         "originalPriceGross": DEFAULT_ITEM["rowPriceTotal"],
     }
 )
-DEFAULT_GET_REFUND_DATA["refunds"][0]["payment"].update(DEFAULT_GET_REFUND_PAYMENT_DATA)
+DEFAULT_GET_REFUND_DATA["refunds"][0]["payment"].update(
+    DEFAULT_GET_REFUND_PAYMENTS_DATA[0]
+)
 
 
 @pytest.mark.parametrize(
@@ -133,31 +137,31 @@ def test_get_payment_exception(status_code):
         assert req_mock.call_count == 1
 
 
-def test_get_refund_payment_success():
+def test_get_refund_payments_success():
     client = WebStorePaymentAPIClient()
 
     with requests_mock.Mocker() as req_mock:
         req_mock.get(
-            f"{client.payment_api_base_url}admin/refund-payment/{DEFAULT_ORDER_ID}",
-            json=DEFAULT_GET_REFUND_PAYMENT_DATA,
+            f"{client.payment_api_base_url}admin/refunds/{DEFAULT_REFUND_ID}/payment",
+            json=DEFAULT_GET_REFUND_PAYMENTS_DATA,
         )
-        response_json = client.get_refund_payment(order_id=DEFAULT_ORDER_ID)
+        response_json = client.get_refund_payments(refund_id=DEFAULT_REFUND_ID)
 
-    assert response_json == DEFAULT_GET_REFUND_PAYMENT_DATA
+    assert response_json == DEFAULT_GET_REFUND_PAYMENTS_DATA
 
 
 @pytest.mark.parametrize(
     "status_code", [status.HTTP_404_NOT_FOUND, status.HTTP_500_INTERNAL_SERVER_ERROR]
 )
-def test_get_refund_payment_exception(status_code):
+def test_get_refund_payments_exception(status_code):
     client = WebStorePaymentAPIClient()
 
     with requests_mock.Mocker() as req_mock, pytest.raises(RequestException):
         req_mock.get(
-            f"{client.payment_api_base_url}admin/refund-payment/{DEFAULT_ORDER_ID}",
+            f"{client.payment_api_base_url}admin/refunds/{DEFAULT_REFUND_ID}/payment",
             status_code=status_code,
         )
 
-        client.get_refund_payment(order_id=DEFAULT_ORDER_ID)
+        client.get_refund_payments(refund_id=DEFAULT_REFUND_ID)
 
         assert req_mock.call_count == 1


### PR DESCRIPTION
### Description
Checks Talpa refund status from a new endpoint that is soon to be added to the Talpa Payment Exprerience API. This is needed for partial payment refunds as each refund will be their own instance with their own payment, and the older existing Talpa endpoint has supported fetching only the first refund's status (as partial refunds haven't actually been supported by Talpa before).
### Closes
[LINK-2112](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2112)

[LINK-2112]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ