### PR TITLE
LINK-2163: Add has_user_editable_resources field to API

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -282,7 +282,7 @@ class KeywordViewSet(
     viewsets.GenericViewSet,
 ):
     queryset = Keyword.objects.all()
-    queryset = queryset.select_related("publisher")
+    queryset = queryset.select_related("data_source", "publisher")
     serializer_class = KeywordSerializer
     permission_classes = [
         DataSourceResourceEditPermission & OrganizationUserEditPermission
@@ -392,8 +392,13 @@ class KeywordListViewSet(
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
 ):
-    # publisher relation performs better with prefetch than selected
-    queryset = Keyword.objects.all().prefetch_related("publisher", "alt_labels")
+    # publisher relation performs better with prefetch than selected,
+    # while data_source has less queries with select
+    queryset = (
+        Keyword.objects.all()
+        .select_related("data_source")
+        .prefetch_related("publisher", "alt_labels")
+    )
     serializer_class = KeywordSerializer
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ("n_events", "id", "name", "data_source")
@@ -549,7 +554,7 @@ class KeywordSetViewSet(
     AuditLogApiViewMixin,
     viewsets.ModelViewSet,
 ):
-    queryset = KeywordSet.objects.all()
+    queryset = KeywordSet.objects.all().select_related("data_source")
     serializer_class = KeywordSetSerializer
     permission_classes = [
         DataSourceResourceEditPermission & OrganizationUserEditPermission
@@ -712,7 +717,7 @@ class PlaceRetrieveViewSet(
     viewsets.GenericViewSet,
 ):
     queryset = Place.objects.all()
-    queryset = queryset.select_related("publisher")
+    queryset = queryset.select_related("data_source", "publisher")
     serializer_class = PlaceSerializer
     permission_classes = [
         DataSourceResourceEditPermission & OrganizationUserEditPermission
@@ -1356,7 +1361,12 @@ class ImageViewSet(
     viewsets.ModelViewSet,
 ):
     queryset = Image.objects.all().select_related(
-        "publisher", "data_source", "created_by", "last_modified_by", "license"
+        "data_source",
+        "publisher",
+        "data_source",
+        "created_by",
+        "last_modified_by",
+        "license",
     )
     serializer_class = ImageSerializer
     pagination_class = LargeResultsSetPagination
@@ -2360,7 +2370,7 @@ class EventViewSet(
     # sub_event prefetches are handled in get_queryset()
     queryset = (
         Event.objects.all()
-        .select_related("publisher", "created_by", "last_modified_by")
+        .select_related("data_source", "publisher", "created_by", "last_modified_by")
         .prefetch_related(
             "audience",
             "external_links",

--- a/events/serializers.py
+++ b/events/serializers.py
@@ -123,6 +123,10 @@ class DivisionSerializer(ParlerTranslatedModelSerializer):
 
 
 class EditableLinkedEventsObjectSerializer(LinkedEventsSerializer):
+    has_user_editable_resources = serializers.BooleanField(
+        source="is_user_editable_resources", read_only=True
+    )
+
     def create(self, validated_data):
         if "data_source" not in validated_data:
             validated_data["data_source"] = self.context["data_source"]
@@ -298,6 +302,9 @@ class KeywordSetSerializer(LinkedEventsSerializer):
     )
     last_modified_time = DateTimeField(
         default_timezone=ZoneInfo("UTC"), required=False, allow_null=True
+    )
+    has_user_editable_resources = serializers.BooleanField(
+        source="is_user_editable_resources", read_only=True
     )
 
     def to_internal_value(self, data):

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -65,6 +65,7 @@ def assert_event_fields_exist(data, version="v1"):
         "images",
         "in_language",
         "info_url",
+        "has_user_editable_resources",
         "keywords",
         "last_modified_time",
         "location",

--- a/events/tests/test_event_images_v1.py
+++ b/events/tests/test_event_images_v1.py
@@ -62,6 +62,7 @@ def assert_image_fields_exist(data, version="v1"):
         "created_time",
         "cropping",
         "id",
+        "has_user_editable_resources",
         "url",
         "last_modified_time",
         "license",


### PR DESCRIPTION
### Description
Adds a new field `has_user_editable_resources` to event, image, place, keyword and keywordset endpoints. This allows the front-end to check before a form is saved if the related data source allows users to edit the given resource like an event.
### Closes
[LINK-2163](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2163)

[LINK-2163]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ