### PR TITLE
LINK-2164: Change default noreply address

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -65,7 +65,7 @@ env = environ.Env(
     DATABASE_URL=(str, "postgis:///linkedevents"),
     DATABASE_PASSWORD=(str, ""),
     DEBUG=(bool, False),
-    DEFAULT_FROM_EMAIL=(str, "noreply@linkedevents.hel.fi"),
+    DEFAULT_FROM_EMAIL=(str, "noreply-linkedevents@hel.fi"),
     ELASTICSEARCH_URL=(str, None),
     ELIS_EVENT_API_URL=(
         str,

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -98,7 +98,8 @@ def send_mass_html_mail(
 
 def get_email_noreply_address():
     return (
-        settings.DEFAULT_FROM_EMAIL or "noreply@%s" % Site.objects.get_current().domain
+        settings.DEFAULT_FROM_EMAIL
+        or "noreply-linkedevents@%s" % Site.objects.get_current().domain
     )
 
 


### PR DESCRIPTION
### Description
Change the default noreply address to `noreply-linkedevents@hel.fi`.

Related PR in DevOps for env-specific values: https://dev.azure.com/City-of-Helsinki/linkedevents/_git/linkedevents-pipelines/pullrequest/9420
### Related ticket
[LINK-2164](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2164)

[LINK-2164]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ