### PR TITLE
feat(registration): order XLSX primarily by attendee_status

### DIFF
--- a/registrations/exports.py
+++ b/registrations/exports.py
@@ -20,7 +20,7 @@ class RegistrationSignUpsExportXLSX:
             .select_related(
                 "contact_person", "signup_group__contact_person", "protected_data"
             )
-            .order_by("first_name", "last_name")
+            .order_by("attendee_status", "first_name", "last_name")
             .only(
                 "first_name",
                 "last_name",


### PR DESCRIPTION
### Description
Changes the registration Excel export's signups list to be ordered primarily by "attendee_status" and secondarily by the current ordering.
### Closes
[LINK-2166](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2166)

[LINK-2166]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ