### PR TITLE
LINK-2168: Hide the Knox tokens section from the admin site

### DIFF
--- a/data_analytics/admin.py
+++ b/data_analytics/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from knox import crypto
+from knox.models import AuthToken
 from knox.settings import CONSTANTS, knox_settings
 
 from data_analytics.forms import DataAnalyticsApiTokenAdminForm
@@ -43,4 +44,5 @@ class DataAnalyticsApiTokenAdmin(admin.ModelAdmin):
         obj.save()
 
 
+admin.site.unregister(AuthToken)
 admin.site.register(DataAnalyticsApiToken, DataAnalyticsApiTokenAdmin)

--- a/data_analytics/tests/test_admin.py
+++ b/data_analytics/tests/test_admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.test import TestCase
 from django.utils import timezone, translation
 from knox import crypto
+from knox.models import AuthToken
 from knox.settings import CONSTANTS, knox_settings
 from rest_framework import status
 
@@ -34,6 +35,9 @@ class TestLocalAuthTokenAdmin(TestCase):
 
     def setUp(self):
         self.client.force_login(self.admin)
+
+    def test_knox_auth_token_admin_is_not_registered(self):
+        self.assertFalse(admin.site.is_registered(AuthToken))
 
     def test_local_auth_token_admin_is_registered(self):
         self.assertTrue(admin.site.is_registered(DataAnalyticsApiToken))


### PR DESCRIPTION
### Description
Hides Knox tokens from the Django admin site by unregistering the `knox.AuthToken` model. This is done because the `data_analytics.DataAnalyticsApiToken` model is used instead of the default model offered by the `django-rest-knox` package.
### Closes
[LINK-2168](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2168)

[LINK-2168]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ