### PR TITLE
Revert "fix(regisration): check ancestor perms for accounts and merchants

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -1183,20 +1183,9 @@ class OrganizationViewSet(
                 queryset = queryset.none()
         return queryset
 
-    def _get_web_store_objects(self, organization, relation_name):
-        if self.request.user.is_superuser:
-            org_qs_filter = Q()
-        else:
-            all_admin_orgs = (
-                self.request.user.get_admin_organizations_and_descendants()
-                | self.request.user.get_registration_admin_organizations_and_descendants()
-                | self.request.user.get_financial_admin_organizations_and_descendants()
-            ).distinct()
-            org_qs_filter = Q(pk__in=all_admin_orgs)
-
-        for ancestor in organization.get_ancestors(
-            ascending=True, include_self=True
-        ).filter(org_qs_filter):
+    @staticmethod
+    def _get_web_store_objects(organization, relation_name):
+        for ancestor in organization.get_ancestors(ascending=True, include_self=True):
             if objects := list(getattr(ancestor, relation_name).filter(active=True)):
                 return objects
 

--- a/events/tests/test_organization_api.py
+++ b/events/tests/test_organization_api.py
@@ -2576,41 +2576,7 @@ def test_get_organization_web_store_merchants_from_ancestor(
     assert response.status_code == expected_status
 
     if expected_status == status.HTTP_200_OK:
-        # User is admin in parent organization, but not in child organization
-        # => should get merchants from the parent.
         assert len(response.data) == 2
-
-
-@pytest.mark.parametrize(
-    "user2_with_user_type",
-    [
-        "org_admin",
-        "org_registration_admin",
-        "org_financial_admin",
-    ],
-    indirect=["user2_with_user_type"],
-)
-@pytest.mark.django_db
-def test_org_admin_cannot_get_organization_web_store_merchants_from_ancestor_without_permissions(
-    api_client, organization, organization2, user2_with_user_type
-):
-    organization2.admin_users.remove(user2_with_user_type)
-
-    organization.parent = organization2
-    organization.save(update_fields=["parent"])
-
-    with override_settings(WEB_STORE_INTEGRATION_ENABLED=False):
-        WebStoreMerchantFactory(organization=organization2)
-        WebStoreMerchantFactory(organization=organization2)
-
-    api_client.force_authenticate(user2_with_user_type)
-
-    response = get_organization_merchants(api_client, organization.id)
-
-    # User is admin in child organization, but not in parent organization
-    # => should not get any merchants from the parent.
-    assert response.status_code == status.HTTP_200_OK
-    assert len(response.data) == 0
 
 
 @pytest.mark.parametrize(
@@ -2675,40 +2641,7 @@ def test_get_organization_web_store_accounts_from_ancestor(
     assert response.status_code == expected_status
 
     if expected_status == status.HTTP_200_OK:
-        # User is admin in parent organization, but not in child organization
-        # => should get accounts from the parent.
         assert len(response.data) == 2
-
-
-@pytest.mark.parametrize(
-    "user2_with_user_type",
-    [
-        "org_admin",
-        "org_registration_admin",
-        "org_financial_admin",
-    ],
-    indirect=["user2_with_user_type"],
-)
-@pytest.mark.django_db
-def test_org_admin_cannot_get_organization_web_store_accounts_from_ancestor_without_permissions(
-    api_client, organization, organization2, user2_with_user_type
-):
-    organization2.admin_users.remove(user2_with_user_type)
-
-    organization.parent = organization2
-    organization.save(update_fields=["parent"])
-
-    WebStoreAccountFactory(organization=organization2)
-    WebStoreAccountFactory(organization=organization2)
-
-    api_client.force_authenticate(user2_with_user_type)
-
-    response = get_organization_accounts(api_client, organization.id)
-
-    # User is admin in child organization, but not in parent organization
-    # => should not get any accounts from the parent.
-    assert response.status_code == status.HTTP_200_OK
-    assert len(response.data) == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
It was decided that for account and merchant inheritance in the registration form (when creating a registration), it is not needed to check user permissions for the ancestor organization. Therefore, changes introduced in LINK-2135 are reverted by this PR.

This reverts commit 0510fcd109aab37fba4c109d63cade3e1c0e4b6b.

### Reverts
[LINK-2135](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2135)

[LINK-2135]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ