### PR TITLE
Revert "fix(registration): allow customer groups with zero price"

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -600,22 +600,29 @@ class Registration(CreatedModifiedBaseModel):
             return
 
         try:
-            payment = first_on_list.create_web_store_payment()
-        except ValidationError as exc:
+            payment = (
+                first_on_list.create_web_store_payment()
+                if first_on_list.price_group.price > 0
+                else None
+            )
+        except (ValidationError, AttributeError) as exc:
             logger.error(
                 f"Failed to create payment when moving waitlisted signup #{first_on_list.pk} "
                 f"to attending: {exc}"
             )
             return
 
-        first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
-        first_on_list.save(update_fields=["attendee_status"])
+        if not payment:
+            self.move_first_waitlisted_to_attending(first_on_list)
+        else:
+            first_on_list.attendee_status = SignUp.AttendeeStatus.ATTENDING
+            first_on_list.save(update_fields=["attendee_status"])
 
-        contact_person = first_on_list.actual_contact_person
-        contact_person.send_notification(
-            SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
-            payment_link=payment.checkout_url,
-        )
+            contact_person = first_on_list.actual_contact_person
+            contact_person.send_notification(
+                SignUpNotificationType.TRANSFER_AS_PARTICIPANT_WITH_PAYMENT,
+                payment_link=payment.checkout_url,
+            )
 
     def move_first_waitlisted_to_attending(self, first_on_list=None):
         first_on_list = first_on_list or self.get_waitlisted(count=1)

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -162,6 +162,23 @@ def _validate_contact_person_for_payment(contact_person: dict, errors: dict) -> 
         )
 
 
+def _validate_signups_for_payment(
+    signups: list[dict], errors: dict, field_name: str
+) -> None:
+    if any(
+        [
+            signup
+            for signup in signups
+            if signup.get("price_group")
+            and signup["price_group"]["registration_price_group"].price <= 0
+        ]
+    ):
+        errors[field_name] = _(
+            "Participants must have a price group with price greater than 0 "
+            "selected to make a payment."
+        )
+
+
 class CreatedModifiedBaseSerializer(serializers.ModelSerializer):
     created_time = DateTimeField(
         default_timezone=ZoneInfo("UTC"),
@@ -623,6 +640,8 @@ class SignUpSerializer(
             self._validate_price_group(registration, data, validated_data, errors)
 
             if validated_data.get("create_payment"):
+                _validate_signups_for_payment([validated_data], errors, "price_group")
+
                 _validate_contact_person_for_payment(
                     validated_data.get("contact_person"), errors
                 )
@@ -1611,6 +1630,8 @@ class SignUpGroupCreateSerializer(
             )
 
         if validated_data.get("create_payment"):
+            _validate_signups_for_payment(validated_data["signups"], errors, "signups")
+
             _validate_contact_person_for_payment(
                 contact_person,
                 errors,

--- a/registrations/tests/test_signup_delete.py
+++ b/registrations/tests/test_signup_delete.py
@@ -1338,9 +1338,16 @@ def test_send_email_with_payment_link_when_moving_participant_from_waitlist_for_
     )
 
 
+@pytest.mark.parametrize(
+    "price,expected_attendee_status,expected_mailbox_count",
+    [
+        (None, SignUp.AttendeeStatus.WAITING_LIST, 1),
+        (Decimal("0"), SignUp.AttendeeStatus.ATTENDING, 2),
+    ],
+)
 @pytest.mark.django_db
-def test_email_with_payment_link_sent_when_moving_participant_with_zero_price(
-    api_client,
+def test_email_with_payment_link_not_sent_when_moving_participant_if_price_missing(
+    api_client, price, expected_attendee_status, expected_mailbox_count
 ):
     language = LanguageFactory(pk="en", service_language=True)
 
@@ -1352,12 +1359,7 @@ def test_email_with_payment_link_sent_when_moving_participant_with_zero_price(
     user = create_user_by_role("registration_admin", registration.publisher)
     api_client.force_authenticate(user)
 
-    RegistrationWebStoreProductMappingFactory(registration=registration)
-
-    zero_price = Decimal("0.00")
-    registration_price_group = RegistrationPriceGroupFactory(
-        registration=registration, price=zero_price
-    )
+    registration_price_group = RegistrationPriceGroupFactory(registration=registration)
 
     signup = SignUpFactory(
         registration=registration, attendee_status=SignUp.AttendeeStatus.ATTENDING
@@ -1376,9 +1378,14 @@ def test_email_with_payment_link_sent_when_moving_participant_with_zero_price(
         email="test@test.com",
         service_language=language,
     )
-    SignUpPriceGroupFactory(
-        signup=signup2, registration_price_group=registration_price_group
-    )
+
+    if price is not None:
+        registration_price_group.price = price
+        registration_price_group.save()
+
+        SignUpPriceGroupFactory(
+            signup=signup2, registration_price_group=registration_price_group
+        )
 
     assert SignUpPayment.objects.count() == 0
 
@@ -1386,30 +1393,28 @@ def test_email_with_payment_link_sent_when_moving_participant_with_zero_price(
         translation.override(language.pk),
         requests_mock.Mocker() as req_mock,
     ):
-        req_mock.post(
-            f"{settings.WEB_STORE_API_BASE_URL}order/",
-            json=DEFAULT_GET_ORDER_DATA,
-        )
+        req_mock.post(f"{settings.WEB_STORE_API_BASE_URL}order/")
 
         assert_delete_signup(
             api_client, signup.id, signup_count=2, contact_person_count=2
         )
 
-        assert req_mock.call_count == 1
+        assert req_mock.call_count == 0
 
-    assert SignUpPayment.objects.count() == 1
-    assert SignUpPayment.objects.first().amount == zero_price
+    assert SignUpPayment.objects.count() == 0
 
     signup2.refresh_from_db()
-    assert signup2.attendee_status == SignUp.AttendeeStatus.ATTENDING
+    assert signup2.attendee_status == expected_attendee_status
 
-    assert len(mail.outbox) == 2
-    assert mail.outbox[0].to[0] == contact_person2.email
-    assert (
-        mail.outbox[0].subject == "Payment required for registration confirmation - Foo"
-    )
-    assert mail.outbox[1].to[0] == contact_person.email
-    assert mail.outbox[1].subject == "Registration cancelled - Foo"
+    assert len(mail.outbox) == expected_mailbox_count
+    if expected_mailbox_count == 1:
+        assert mail.outbox[0].to[0] == contact_person.email
+        assert mail.outbox[0].subject == "Registration cancelled - Foo"
+    else:
+        assert mail.outbox[0].to[0] == contact_person2.email
+        assert mail.outbox[0].subject == "Registration confirmation - Foo"
+        assert mail.outbox[1].to[0] == contact_person.email
+        assert mail.outbox[1].subject == "Registration cancelled - Foo"
 
 
 @pytest.mark.parametrize(

--- a/registrations/tests/test_signup_group_post.py
+++ b/registrations/tests/test_signup_group_post.py
@@ -719,18 +719,18 @@ def test_create_signup_group_payment_contact_person_name_missing(
     )
 
 
+@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-10")])
 @pytest.mark.django_db
-def test_create_signup_payment_with_zero_price(api_client, registration):
+def test_create_signup_payment_with_zero_or_negative_price(
+    api_client, registration, price
+):
     reservation = SeatReservationCodeFactory(seats=2, registration=registration)
 
     LanguageFactory(pk="fi", service_language=True)
     LanguageFactory(pk="en", service_language=True)
 
-    RegistrationWebStoreProductMappingFactory(registration=registration)
-
-    zero_price = Decimal("0.00")
     registration_price_group = RegistrationPriceGroupFactory(
-        registration=registration, price=zero_price
+        registration=registration, price=price
     )
 
     user = create_user_by_role("registration_admin", registration.publisher)
@@ -757,18 +757,15 @@ def test_create_signup_payment_with_zero_price(api_client, registration):
 
     assert SignUpPayment.objects.count() == 0
 
-    with requests_mock.Mocker() as req_mock:
-        req_mock.post(
-            f"{settings.WEB_STORE_API_BASE_URL}order/",
-            json=DEFAULT_GET_ORDER_DATA,
-        )
+    response = create_signup_group(api_client, signup_group_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        assert_create_signup_group(api_client, signup_group_data)
+    assert SignUpPayment.objects.count() == 0
 
-        assert req_mock.call_count == 1
-
-    assert SignUpPayment.objects.count() == 1
-    assert SignUpPayment.objects.first().amount == zero_price
+    assert response.data["signups"][0] == (
+        "Participants must have a price group with price greater than 0 "
+        "selected to make a payment."
+    )
 
 
 @pytest.mark.parametrize("maximum_attendee_capacity", [0, 1])

--- a/registrations/tests/test_signup_post.py
+++ b/registrations/tests/test_signup_post.py
@@ -625,16 +625,15 @@ def test_create_signup_payment_contact_person_name_missing(
     )
 
 
+@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-10")])
 @pytest.mark.django_db
-def test_create_signup_payment_with_zero_price(api_client, registration):
+def test_create_signup_payment_with_zero_or_negative_price(
+    api_client, registration, price
+):
     LanguageFactory(pk="fi", service_language=True)
     reservation = SeatReservationCodeFactory(seats=1, registration=registration)
-
-    RegistrationWebStoreProductMappingFactory(registration=registration)
-
-    zero_price = Decimal("0.00")
     registration_price_group = RegistrationPriceGroupFactory(
-        registration=registration, price=zero_price
+        registration=registration, price=price
     )
 
     user = create_user_by_role("registration_admin", registration.publisher)
@@ -656,18 +655,15 @@ def test_create_signup_payment_with_zero_price(api_client, registration):
 
     assert SignUpPayment.objects.count() == 0
 
-    with requests_mock.Mocker() as req_mock:
-        req_mock.post(
-            f"{settings.WEB_STORE_API_BASE_URL}order/",
-            json=DEFAULT_GET_ORDER_DATA,
-        )
+    response = create_signups(api_client, signups_data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        assert_create_signups(api_client, signups_data)
+    assert SignUpPayment.objects.count() == 0
 
-        assert req_mock.call_count == 1
-
-    assert SignUpPayment.objects.count() == 1
-    assert SignUpPayment.objects.first().amount == zero_price
+    assert response.data["signups"][0]["price_group"][0] == (
+        "Participants must have a price group with price greater than 0 "
+        "selected to make a payment."
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description
Since Talpa doesn't currently support zero-priced payments or refunds, it was decided to revert the changes that made the API allow zero-priced signups. This will block making such payments and therefore there won't be problems with refunds either.

This reverts commit 9a3e03527b28777069591fe85d713dc5adba4808.
## Reverts
[LINK-2131](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2131)

[LINK-2131]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ