### PR TITLE
chore(commitlint): use latest commitlint (9.18.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: isort
         exclude: "migrations"
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.10.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg, manual]


### PR DESCRIPTION
When using js commitlint config it requires version 9.13.0
and newer
