### PR TITLE
LINK-2187 | fix(registration): order signups by id

### DIFF
--- a/registrations/api.py
+++ b/registrations/api.py
@@ -582,8 +582,8 @@ class SignUpViewSet(
         ActionDependingBackend,
         filters.OrderingFilter,
     ]
-    ordering_fields = ("first_name", "last_name")
-    ordering = ("first_name", "last_name")
+    ordering_fields = ("id", "first_name", "last_name")
+    ordering = ("id",)
     filterset_class = SignUpFilter
     permission_classes = [CanAccessSignup]
 


### PR DESCRIPTION
Order signups by the id in the signup endpoint to achieve correct ordering in the UI for the attendee list and waitlist listing.
Reason for use the ID for ordering is that the waitlist logic uses the id for ordering waitlist queue. Other solution would be to change it to be using created_time.

Refs LINK-2187
