### PR TITLE
fix: use django's static root in swagger schema url config

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import subprocess
 from datetime import datetime, timedelta
+from urllib.parse import urljoin
 
 import bleach
 import environ
@@ -813,7 +814,9 @@ SPECTACULAR_SETTINGS = {
     ],
 }
 if SWAGGER_USE_STATIC_SCHEMA:
-    SPECTACULAR_SETTINGS["SWAGGER_UI_SETTINGS"]["url"] = "/static/openapi_schema.yaml"
+    SPECTACULAR_SETTINGS["SWAGGER_UI_SETTINGS"]["url"] = urljoin(
+        STATIC_URL, "openapi_schema.yaml"
+    )
 if WEB_STORE_INTEGRATION_ENABLED:
     SPECTACULAR_SETTINGS["TAGS"].append(
         {


### PR DESCRIPTION
There were some issues pointing out the schema in different envs with different url and static configuration. 
This ditches the hardcoded static and uses django's static root for pointing the swagger-ui's schema file.


Refs LINK-2198
