### PR TITLE
LINK-2203 | fix(events): use django qs functions in max_* and min_duration filters

### DIFF
--- a/events/tests/test_event_filters.py
+++ b/events/tests/test_event_filters.py
@@ -147,3 +147,33 @@ def test_get_event_list_ongoing(ongoing):
         assert event_end_after in qs
     else:
         assert event_end_before in qs
+
+
+@pytest.mark.django_db
+def test_get_event_list_min_duration():
+    EventFactory(start_time=timezone.now(), end_time=timezone.now())
+    event_long = EventFactory(
+        start_time=timezone.now(), end_time=timezone.now() + timedelta(hours=1)
+    )
+
+    filter_set = EventFilter()
+
+    qs = filter_set.filter_min_duration(Event.objects.all(), "min_duration", "1h")
+
+    assert qs.count() == 1
+    assert event_long in qs
+
+
+@pytest.mark.django_db
+def test_get_event_list_max_duration():
+    event_short = EventFactory(start_time=timezone.now(), end_time=timezone.now())
+    EventFactory(
+        start_time=timezone.now(), end_time=timezone.now() + timedelta(hours=1)
+    )
+
+    filter_set = EventFilter()
+
+    qs = filter_set.filter_max_duration(Event.objects.all(), "max_duration", "1h")
+
+    assert qs.count() == 1
+    assert event_short in qs


### PR DESCRIPTION
There were `ProgrammingError` thrown when using `max `or `min_duration` filter with `hide_recurring_children` filter. This was because the `min_*` and `max_duration` filters were defined to use custom sql `WHERE` clauses without referring to which table the fields in the `WHERE` clause was referring to and there were other tables joined to the query by `hide_recurring_children` filter.

Solution was to convert these max and min_duration filters to be using django qs functions.

Also refactors the `max_` and `min_duration` filters away from `api.py` to filters.

Refs LINK-2203