### PR TITLE
build: use BUILDER_REGISTRY param in Dockerfile

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,8 +1,9 @@
 ARG PYTHON_VERSION=3.9
 ARG IMAGE_VARIANT=slim
+ARG BUILDER_REGISTRY=docker.io
 
 # ==============================
-FROM helsinkitest/python:${PYTHON_VERSION}-${IMAGE_VARIANT} AS appbase
+FROM ${BUILDER_REGISTRY}/helsinkitest/python:${PYTHON_VERSION}-${IMAGE_VARIANT} AS appbase
 # ==============================
 RUN mkdir /entrypoint
 


### PR DESCRIPTION
Use BUILDER_REGISTRY parameter to get configurable image registry.

Refs LINK-2204
