### PR TITLE
fix: always update offer info_url when creating new registration

### DIFF
--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -8,11 +7,7 @@ from registrations.utils import get_signup_create_url, move_waitlisted_to_attend
 
 
 def _create_signup_link_for_event(registration: Registration) -> None:
-    registration.event.offers.filter(
-        (Q(info_url_fi=None) | Q(info_url_fi=""))
-        & (Q(info_url_sv=None) | Q(info_url_sv=""))
-        & (Q(info_url_en=None) | Q(info_url_en=""))
-    ).update(
+    registration.event.offers.update(
         info_url_fi=get_signup_create_url(registration, "fi"),
         info_url_sv=get_signup_create_url(registration, "sv"),
         info_url_en=get_signup_create_url(registration, "en"),

--- a/registrations/tests/test_registration_post.py
+++ b/registrations/tests/test_registration_post.py
@@ -79,21 +79,12 @@ def test_create_registration(user, api_client, event):
     assert_create_registration(api_client, registration_data)
 
 
-@pytest.mark.parametrize(
-    "info_url_fi,info_url_sv,info_url_en",
-    [
-        (None, None, None),
-        (None, None, ""),
-        (None, "", ""),
-        ("", None, None),
-        ("", "", None),
-        ("", "", ""),
-    ],
-)
 @pytest.mark.django_db
-def test_signup_url_is_linked_to_event_offer_without_info_url(
-    user_api_client, event, info_url_fi, info_url_sv, info_url_en
-):
+def test_signup_url_is_linked_to_event_offer(user_api_client, event):
+    info_url_fi = None
+    info_url_sv = ""
+    info_url_en = "https://test.com"
+
     offer = OfferFactory(
         event=event,
         info_url_fi=info_url_fi,
@@ -113,43 +104,6 @@ def test_signup_url_is_linked_to_event_offer_without_info_url(
     assert offer.info_url_fi == get_signup_create_url(registration, "fi")
     assert offer.info_url_sv == get_signup_create_url(registration, "sv")
     assert offer.info_url_en == get_signup_create_url(registration, "en")
-
-
-@pytest.mark.parametrize(
-    "info_url_field,info_url_value,blank_value",
-    [
-        ("info_url_fi", "https://test.com", None),
-        ("info_url_sv", "https://test.com", None),
-        ("info_url_en", "https://test.com", None),
-        ("info_url_fi", "https://test.com", ""),
-        ("info_url_sv", "https://test.com", ""),
-        ("info_url_en", "https://test.com", ""),
-    ],
-)
-@pytest.mark.django_db
-def test_signup_url_is_not_linked_to_event_offer_with_info_url(
-    user_api_client, event, info_url_field, info_url_value, blank_value
-):
-    fields = ("info_url_fi", "info_url_sv", "info_url_en")
-
-    offer_kwargs = {info_url_field: info_url_value}
-    for field in fields:
-        if field != info_url_field:
-            offer_kwargs[field] = blank_value
-
-    offer = OfferFactory(event=event, **offer_kwargs)
-    assert getattr(offer, info_url_field) == info_url_value
-
-    registration_data = get_minimal_required_registration_data(event.id)
-    assert_create_registration(user_api_client, registration_data)
-
-    offer.refresh_from_db()
-    assert getattr(offer, info_url_field) == info_url_value
-
-    blank_values = (blank_value,)
-    for field in fields:
-        if field != info_url_field:
-            assert getattr(offer, field) in blank_values
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The original behaviour is seen as problematic when using old events as templates with new ones as an existing (old) info_url will prevent automatic updating when creating a new registration for the event.

refs: [LINK-2219](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2219)

[LINK-2219]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ