### PR TITLE
LINK-2210: fix randomly failing tests

### DIFF
--- a/registrations/models.py
+++ b/registrations/models.py
@@ -654,7 +654,7 @@ class Registration(CreatedModifiedBaseModel):
                 Q(signup__registration_id=self.pk)
                 | Q(signup_group__registration_id=self.pk)
             )
-        ):
+        ).order_by("-pk"):
             contact_person.send_notification(
                 SignUpNotificationType.EVENT_CANCELLATION,
                 is_sub_event_cancellation=is_sub_event_cancellation,


### PR DESCRIPTION
This was causing random failures with two tests (`test_recurring_sub_event_put_cancellation_emails_sent_payments_not_refunded_for_super_event` and `test_recurring_sub_event_put_cancellation_emails_sent_signups_not_cancelled_for_super_event`) which assume that the notifications were sent in a certain order (desc pk). However, if an order is not specified, Postgres cannot guarantee an order, and that's exactly what happened here.

There were two ways of resolving this; either guarantee an order or change the test to be order-agnostic. In this case, I chose the path of least resistance.

I've no clue how to default order works, but it's probably related to the underlying data structures. It would also explain why the tests were failing randomly since there is some random data involved in the tests (e.g. factories & Faker).

I was able to replicate the issue locally (using Docker) by running only the two tests with the same database (i.e. `--reuse-db` flag with pytest, need to do the first run with `--create-db` to recreate the database) 20 times in a row. From the 21st run onward, the two tests start to fail. I realize this sounds more like an urban legend than actual steps for replicating this, but I was able to do this consistently. Not sure if it works on every machine since Postgres' default order is something of a mystery (or for me, at least).

Also fixed a misnamed init file.