### PR TITLE
fix(events): use espoo api days back conf as int

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -84,7 +84,7 @@ env = environ.Env(
             "keyword": "yso:p2787",
         },
     ),
-    ESPOO_API_EVENT_START_DAYS_BACK=(str, 180),
+    ESPOO_API_EVENT_START_DAYS_BACK=(int, 180),
     ESPOO_API_PUBLISHERS=(
         list,
         [


### PR DESCRIPTION
ESPOO_API_EVENT_START_DAYS_BACK in conf was configured to be str. That caused errors and should be read as int.