### PR TITLE
LINK-2260 | Add sub_events filter to pair with hide_recurring_children 

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2406,17 +2406,14 @@ class EventViewSet(
         """
         TODO: convert to use proper filter framework
         """
-        original_queryset = super().filter_queryset(queryset)
         if self.action == "list":
             # we cannot use distinct for performance reasons
-            public_queryset = original_queryset.filter(
+            public_queryset = queryset.filter(
                 publication_status=PublicationStatus.PUBLIC
             )
-            editable_queryset = original_queryset.none()
+            editable_queryset = queryset.none()
             if self.request.user.is_authenticated:
-                editable_queryset = self.request.user.get_editable_events(
-                    original_queryset
-                )
+                editable_queryset = self.request.user.get_editable_events(queryset)
             # by default, only public events are shown in the event list
             queryset = public_queryset
             # however, certain query parameters allow customizing the listing for
@@ -2464,7 +2461,7 @@ class EventViewSet(
 
                 queryset = self.request.user.get_editable_events(original_queryset)
 
-        return queryset.filter()
+        return super().filter_queryset(queryset)
 
     def allow_bulk_destroy(self, qs, filtered):
         return False

--- a/events/exporter/city_sdk.py
+++ b/events/exporter/city_sdk.py
@@ -1,14 +1,13 @@
-import datetime
 import json
 import re
 
-import pytz
 import requests
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import CommandError
 from django.core.serializers.json import DjangoJSONEncoder
+from django.utils import timezone
 from httmock import HTTMock, all_requests, response
 from icalendar import Calendar
 from icalendar import Event as CalendarEvent
@@ -305,9 +304,7 @@ class CitySDKExporter(Exporter):
             qs = klass.objects.exclude(**imported)
         for model in qs:
             citysdk_model = generate(model)
-            citysdk_model["created"] = datetime.datetime.utcnow().replace(
-                tzinfo=pytz.utc
-            )
+            citysdk_model["created"] = timezone.now()
             if model_name == "Keyword":
                 data = {"list": "event", "category": citysdk_model}
             else:

--- a/events/filters.py
+++ b/events/filters.py
@@ -6,7 +6,6 @@ from typing import Iterable, Optional
 from zoneinfo import ZoneInfo
 
 import django_filters
-import pytz
 from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
@@ -569,7 +568,7 @@ class EventFilter(django_filters.rest_framework.FilterSet):
             postponed_q = Q()
 
         # Inconsistent behaviour, see test_inconsistent_tz_default
-        dt = utils.parse_time(value, default_tz=pytz.timezone(settings.TIME_ZONE))[0]
+        dt = utils.parse_time(value, default_tz=ZoneInfo(settings.TIME_ZONE))[0]
 
         # only return events with specified end times, or unspecified start times, during the whole of the event  # noqa: E501
         # this gets of rid pesky one-day events with no known end time (but known
@@ -582,9 +581,7 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         )
 
     def filter_end(self, queryset, name, value):
-        dt = utils.parse_end_time(value, default_tz=pytz.timezone(settings.TIME_ZONE))[
-            0
-        ]
+        dt = utils.parse_end_time(value, default_tz=ZoneInfo(settings.TIME_ZONE))[0]
         return queryset.filter(Q(end_time__lt=dt) | Q(start_time__lte=dt))
 
     def filter_hide_recurring_children_sub_events(

--- a/events/importer/base.py
+++ b/events/importer/base.py
@@ -4,8 +4,8 @@ import operator
 import os
 from collections import defaultdict, namedtuple
 from functools import partial
+from zoneinfo import ZoneInfo
 
-import pytz
 from django.conf import settings
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import Point, Polygon
@@ -28,7 +28,7 @@ EXTENSION_COURSE_FIELDS = (
     "minimum_attendee_capacity",
     "remaining_attendee_capacity",
 )
-LOCAL_TZ = pytz.timezone(settings.TIME_ZONE)
+LOCAL_TZ = ZoneInfo(settings.TIME_ZONE)
 
 
 # Using a recursive default dictionary
@@ -376,7 +376,7 @@ class Importer(object):
         if not info["has_start_time"]:
             # Event start time is not exactly defined.
             # Use midnight in event timezone, or, if given in utc, local timezone
-            if info["start_time"].tzinfo == pytz.utc:
+            if info["start_time"].tzinfo == ZoneInfo("UTC"):
                 info["start_time"] = info["start_time"].astimezone(LOCAL_TZ)
             info["start_time"] = info["start_time"].replace(hour=0, minute=0, second=0)
 
@@ -393,7 +393,7 @@ class Importer(object):
         if not info["has_end_time"]:
             # Event end time is not exactly defined.
             # Use midnight in event timezone, or, if given in utc, local timezone
-            if info["end_time"].tzinfo == pytz.utc:
+            if info["end_time"].tzinfo == ZoneInfo("UTC"):
                 info["end_time"] = info["start_time"].astimezone(LOCAL_TZ)
             info["end_time"] = utils.start_of_next_day(info["end_time"])
 

--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -1245,7 +1245,7 @@ class EnkoraImporter(Importer):
 
         # Section 0:
         # Meta section
-        now = datetime.utcnow()
+        now = timezone.now()
         now_str = now.strftime("%Y-%m-%d %H:%M UTC")
         doc.add_paragraph(f"Document generated at: {now_str}")
         doc.add_paragraph(f"Git commit: {commit_sha}")

--- a/events/importer/kulke.py
+++ b/events/importer/kulke.py
@@ -7,6 +7,7 @@ from datetime import datetime, time, timedelta
 from posixpath import join as urljoin
 from textwrap import dedent
 from typing import Iterator, Sequence, Union
+from zoneinfo import ZoneInfo
 
 import dateutil
 import requests
@@ -14,9 +15,9 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import Count, Q
+from django.utils import timezone
 from django_orghierarchy.models import Organization
 from lxml import etree
-from pytz import timezone
 
 from events.keywords import KeywordMatcher
 from events.models import (
@@ -229,7 +230,7 @@ KEYWORDS_TO_ADD_TO_AUDIENCE = ["yso:{}".format(i) for i in KEYWORDS_TO_ADD_TO_AU
 # category text replacements for keyword determination
 CATEGORY_TEXT_REPLACEMENTS = [("jumppa", "voimistelu"), ("Stoan", "Stoa")]
 
-LOCAL_TZ = timezone("Europe/Helsinki")
+LOCAL_TZ = ZoneInfo("Europe/Helsinki")
 
 
 def make_kulke_id(num):
@@ -622,7 +623,7 @@ class KulkeImporter(Importer):
                 start_time = start_time.astimezone(LOCAL_TZ)
                 event["has_start_time"] = True
             else:
-                start_time = LOCAL_TZ.localize(start_time)
+                start_time = timezone.make_aware(start_time, timezone=LOCAL_TZ)
                 event["has_start_time"] = False
         else:
             start_time = start_time.astimezone(LOCAL_TZ)
@@ -643,7 +644,7 @@ class KulkeImporter(Importer):
                     event["has_end_time"] = True
 
                 else:
-                    end_time = LOCAL_TZ.localize(end_time)
+                    end_time = timezone.make_aware(end_time, timezone=LOCAL_TZ)
                     event["has_end_time"] = False
             else:
                 end_time = end_time.astimezone(LOCAL_TZ)

--- a/events/importer/mikkelinyt.py
+++ b/events/importer/mikkelinyt.py
@@ -4,8 +4,8 @@ import os
 import re
 from datetime import datetime
 from html import unescape
+from zoneinfo import ZoneInfo
 
-import pytz
 import requests
 import requests_cache
 from django_orghierarchy.models import Organization
@@ -38,7 +38,7 @@ class MikkeliNytImporter(Importer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timezone = pytz.timezone("Europe/Helsinki")
+        self.timezone = ZoneInfo("Europe/Helsinki")
 
     def items_from_url(self, url):
         logger.info(url)

--- a/events/management/commands/populate_local_event_cache.py
+++ b/events/management/commands/populate_local_event_cache.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-
-import pytz
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management import BaseCommand
+from django.utils import timezone
 
 from events.models import Event
 from linkedevents.settings import MUNIGEO_MUNI
@@ -19,7 +17,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         local_events = Event.objects.filter(
             location__divisions__ocd_id__endswith=MUNIGEO_MUNI,
-            end_time__gte=datetime.utcnow().replace(tzinfo=pytz.utc),
+            end_time__gte=timezone.now(),
             deleted=False,
         ).values_list(
             "id",
@@ -60,7 +58,7 @@ class Command(BaseCommand):
 
         inet_events = Event.objects.filter(
             location__id__endswith="internet",
-            end_time__gte=datetime.utcnow().replace(tzinfo=pytz.utc),
+            end_time__gte=timezone.now(),
             deleted=False,
         ).values_list(
             "id",

--- a/events/models.py
+++ b/events/models.py
@@ -17,10 +17,8 @@ schema_org_type can be used to define custom types. Override jsonld_context
 attribute to change @context when need to define schemas for custom fields.
 """
 
-import datetime
 import logging
 
-import pytz
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -395,7 +393,7 @@ class BaseModel(models.Model):
 
     @staticmethod
     def now():
-        return datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+        return timezone.now()
 
     def __str__(self):
         return self.name
@@ -471,7 +469,7 @@ class KeywordLabel(TranslatableSerializableMixin):
 
 class UpcomingEventsUpdater(BaseSerializableManager):
     def has_upcoming_events_update(self):
-        now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+        now = timezone.now()
         qs = self.model.objects.filter(n_events__gte=1)
         if self.model.__name__ == "Keyword":
             qs = qs.filter(deprecated=False)

--- a/events/templates/swagger/event_list_description.html
+++ b/events/templates/swagger/event_list_description.html
@@ -215,6 +215,13 @@ Use <code>local_ongoing_AND=lapset,musiikki</code> to search for the events with
 <p>Example:</p>
 <pre><code>event/?hide_recurring_children=true</code></pre>
 
+<h4 id="sub-events">Sub events</h4>
+<p>You may use the query parameter <code>hide_recurring_children_sub_events</code> in pair with <code>hide_recurring_children</code> to apply other filters to child events.</p>
+<p>If you want to get only super_events of weekend events then pair <code>hide_recurring_children</code> and <code>hide_recurring_children_sub_events</code> with
+    <code>weekday=6,7</code></p>
+<p>Example:</p>
+<pre><code>event/?hide_recurring_children=true&hide_recurring_children_sub_events=true&weekday=6,7</code></pre>
+
 <h3 id="event-registration">Event with registration</h3>
 <p>To find out events with or without a registration, use the query parameter<code>registration</code>.</p>
 <p>Example:</p>

--- a/events/tests/importers/test_enkora.py
+++ b/events/tests/importers/test_enkora.py
@@ -1,9 +1,9 @@
 import json
 from datetime import datetime
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from django.core import serializers
 from django.utils import timezone
 
@@ -2397,11 +2397,9 @@ class TestEnkoraImporter:
             created = datetime(
                 2023, 6, 16, 11, 32, 23, microsecond=1
             )  # Note: will transform into .000Z
-            event.created_time = timezone.make_aware(
-                created, timezone=pytz.timezone("UTC")
-            )
+            event.created_time = timezone.make_aware(created, timezone=ZoneInfo("UTC"))
             event.last_modified_time = timezone.make_aware(
-                created, timezone=pytz.timezone("UTC")
+                created, timezone=ZoneInfo("UTC")
             )
 
         # Expect 1 event with 10 sub-events
@@ -2418,8 +2416,12 @@ class TestEnkoraImporter:
             "name_ru": None,
             "name_ar": None,
             "origin_id": "50148",
-            "created_time": datetime(2023, 6, 16, 11, 32, 23, 1, tzinfo=pytz.UTC),
-            "last_modified_time": datetime(2023, 6, 16, 11, 32, 23, 1, tzinfo=pytz.UTC),
+            "created_time": datetime(
+                2023, 6, 16, 11, 32, 23, 1, tzinfo=ZoneInfo("UTC")
+            ),
+            "last_modified_time": datetime(
+                2023, 6, 16, 11, 32, 23, 1, tzinfo=ZoneInfo("UTC")
+            ),
             "created_by": None,
             "last_modified_by": None,
             "user_name": None,
@@ -2456,7 +2458,7 @@ class TestEnkoraImporter:
             "short_description_zh_hans": None,
             "short_description_ru": None,
             "short_description_ar": None,
-            "date_published": datetime(2023, 3, 26, 21, 0, tzinfo=pytz.UTC),
+            "date_published": datetime(2023, 3, 26, 21, 0, tzinfo=ZoneInfo("UTC")),
             "headline": None,
             "headline_fi": None,
             "headline_sv": None,
@@ -2498,8 +2500,8 @@ class TestEnkoraImporter:
             "location_extra_info_ru": None,
             "location_extra_info_ar": None,
             "environment": None,
-            "start_time": datetime(2023, 6, 5, 7, 0, tzinfo=pytz.UTC),
-            "end_time": datetime(2023, 6, 16, 7, 0, tzinfo=pytz.UTC),
+            "start_time": datetime(2023, 6, 5, 7, 0, tzinfo=ZoneInfo("UTC")),
+            "end_time": datetime(2023, 6, 16, 7, 0, tzinfo=ZoneInfo("UTC")),
             "has_start_time": True,
             "has_end_time": True,
             "audience_min_age": 7,
@@ -2511,8 +2513,10 @@ class TestEnkoraImporter:
             "replaced_by": None,
             "maximum_attendee_capacity": 8,
             "minimum_attendee_capacity": None,
-            "enrolment_start_time": datetime(2023, 4, 12, 13, 0, tzinfo=pytz.UTC),
-            "enrolment_end_time": datetime(2023, 6, 15, 21, 0, tzinfo=pytz.UTC),
+            "enrolment_start_time": datetime(
+                2023, 4, 12, 13, 0, tzinfo=ZoneInfo("UTC")
+            ),
+            "enrolment_end_time": datetime(2023, 6, 15, 21, 0, tzinfo=ZoneInfo("UTC")),
             "local": False,
             "keywords": list(EnkoraImporter.ALL_COURSES_KEYWORDS)
             + [

--- a/events/tests/importers/test_espoo.py
+++ b/events/tests/importers/test_espoo.py
@@ -1,10 +1,10 @@
 import io
 from http.client import HTTPMessage, HTTPResponse
 from unittest.mock import Mock, patch
+from zoneinfo import ZoneInfo
 
 import factory
 import pytest
-import pytz
 from django.conf import settings as django_settings
 from django.utils import timezone
 from django_orghierarchy.models import Organization
@@ -289,19 +289,19 @@ def event_mock_data(
     external_links = external_links or []
 
     faker = Faker()
-    end_time = end_time or faker.date_time(tzinfo=pytz.utc)
+    end_time = end_time or faker.date_time(tzinfo=ZoneInfo("UTC"))
     return {
         "id": _id,
         "data_source": "espoo",
-        "created_time": faker.iso8601(tzinfo=pytz.utc),
-        "date_published": faker.iso8601(tzinfo=pytz.utc),
+        "created_time": faker.iso8601(tzinfo=ZoneInfo("UTC")),
+        "date_published": faker.iso8601(tzinfo=ZoneInfo("UTC")),
         "deleted": False,
         "end_time": end_time.isoformat(),
-        "last_modified_time": faker.iso8601(tzinfo=pytz.utc),
+        "last_modified_time": faker.iso8601(tzinfo=ZoneInfo("UTC")),
         "start_time": (
             start_time.isoformat()
             if start_time
-            else faker.iso8601(tzinfo=pytz.utc, end_datetime=end_time)
+            else faker.iso8601(tzinfo=ZoneInfo("UTC"), end_datetime=end_time)
         ),
         "super_event_type": None,
         "name": {

--- a/events/tests/test_event_filters.py
+++ b/events/tests/test_event_filters.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -530,3 +530,69 @@ def test_get_event_list_over_week_event(iso_weekday, name, api_client):
 
     assert len(data) == 1
     assert data[0]["name"]["fi"] == "long event"
+
+
+@pytest.mark.django_db
+def test_get_event_list_hide_recurring_children_weekday_matches_sub_events(api_client):
+    monday_event = EventFactory(start_time=datetime(2025, 1, 6))
+    tuesday_event = EventFactory(
+        data_source=monday_event.data_source, start_time=datetime(2025, 1, 7)
+    )
+    create_super_event([monday_event, tuesday_event], monday_event.data_source)
+
+    thursday = timezone.datetime(2025, 3, 6, 12, tzinfo=timezone.utc)
+    event_3 = EventFactory(start_time=thursday, end_time=thursday + timedelta(hours=1))
+    super_of_thursday = create_super_event([event_3], event_3.data_source)
+
+    resp = get_list(
+        api_client,
+        query_string="weekday=4&hide_recurring_children=true&hide_recurring_children_sub_events=true",
+    )
+    data = resp.data["data"]
+
+    assert len(data) == 1
+    assert data[0]["id"] == super_of_thursday.id
+
+
+@pytest.mark.django_db
+def test_get_event_list_hide_recurring_children_start_matches_sub_events(api_client):
+    event_1 = EventFactory(start_time=datetime(2025, 1, 6))
+    event_2 = EventFactory(start_time=datetime(2025, 1, 7))
+    create_super_event([event_1, event_2], event_1.data_source)
+
+    thursday = timezone.datetime(2025, 3, 6, 12, tzinfo=timezone.utc)
+    event_3 = EventFactory(start_time=thursday, end_time=thursday + timedelta(hours=1))
+    super_2 = create_super_event([event_3], event_3.data_source)
+
+    resp = get_list(
+        api_client,
+        query_string="start=2025-03-06&hide_recurring_children=true&hide_recurring_children_sub_events=true",
+    )
+    data = resp.data["data"]
+
+    assert len(data) == 1
+    assert data[0]["id"] == super_2.id
+
+
+@pytest.mark.django_db
+def test_get_event_list_hide_recurring_children_publisher_match_sub_events_and_non_sub(
+    api_client,
+):
+    event_1 = EventFactory()
+    event_2 = EventFactory()
+    super_1 = create_super_event([event_1, event_2], event_1.data_source)
+
+    event_3 = EventFactory()
+    create_super_event([event_3], event_3.data_source)
+    event_4 = EventFactory(publisher=event_1.publisher)
+
+    resp = get_list(
+        api_client,
+        query_string=f"publisher={event_1.publisher_id}&hide_recurring_children=true&hide_recurring_children_sub_events=true",
+    )
+    data = resp.data["data"]
+
+    assert len(data) == 2
+    event_ids = [event["id"] for event in data]
+    assert super_1.id in event_ids
+    assert event_4.id in event_ids

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -1,8 +1,8 @@
 from collections import Counter
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from dateutil import parser
 from django.conf import settings
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
@@ -1342,8 +1342,8 @@ def test_suitable_for_certain_age(
     # not suitable, neither of age limits defined
     event5 = make_event(
         "5",
-        datetime.now().astimezone(pytz.timezone("UTC")),
-        datetime.now().astimezone(pytz.timezone("UTC")) + timedelta(hours=1),
+        datetime.now().astimezone(ZoneInfo("UTC")),
+        datetime.now().astimezone(ZoneInfo("UTC")) + timedelta(hours=1),
     )
     event5.audience_min_age = None
     event5.audience_max_age = None
@@ -1351,8 +1351,8 @@ def test_suitable_for_certain_age(
     # suitable
     event6 = make_event(
         "6",
-        datetime.now().astimezone(pytz.timezone("UTC")),
-        datetime.now().astimezone(pytz.timezone("UTC")) + timedelta(hours=1),
+        datetime.now().astimezone(ZoneInfo("UTC")),
+        datetime.now().astimezone(ZoneInfo("UTC")) + timedelta(hours=1),
     )
     event6.audience_min_age = 11
     event6.audience_max_age = None

--- a/events/tests/test_event_get.py
+++ b/events/tests/test_event_get.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib.gis.gdal import CoordTransform, SpatialReference
 from django.contrib.gis.geos import Point
 from django.db import DEFAULT_DB_ALIAS, connections
-from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from django.utils.timezone import localtime
@@ -1961,76 +1960,3 @@ def test_event_list_shows_image_and_its_license(event, image):
     response = get_list(api_client)
     license_url = response.data["data"][0]["images"][0]["license_url"]
     assert license_url == "http://urltothe.license"
-
-
-class FilterEventsByRegistrationCapacitiesV1TestCase(TestCase, EventsListTestCaseMixin):
-    @classmethod
-    def setUpTestData(cls):
-        cls.list_url = reverse("event-list", version="v1")
-
-    def test_get_event_list_registration_remaining_attendee_capacity_gte(self):
-        registration = RegistrationFactory(remaining_attendee_capacity=10)
-        registration2 = RegistrationFactory(remaining_attendee_capacity=5)
-        registration3 = RegistrationFactory(remaining_attendee_capacity=1)
-
-        for capacity, events in [
-            (1, [registration.event, registration2.event, registration3.event]),
-            (5, [registration.event, registration2.event]),
-            (10, [registration.event]),
-            (11, []),
-        ]:
-            with self.subTest():
-                self._get_list_and_assert_events(
-                    f"registration__remaining_attendee_capacity__gte={capacity}", events
-                )
-
-    def test_get_event_list_registration_remaining_waiting_list_capacity_gte(self):
-        registration = RegistrationFactory(remaining_waiting_list_capacity=10)
-        registration2 = RegistrationFactory(remaining_waiting_list_capacity=5)
-        registration3 = RegistrationFactory(remaining_waiting_list_capacity=1)
-
-        for capacity, events in [
-            (1, [registration.event, registration2.event, registration3.event]),
-            (5, [registration.event, registration2.event]),
-            (10, [registration.event]),
-            (11, []),
-        ]:
-            with self.subTest():
-                self._get_list_and_assert_events(
-                    f"registration__remaining_waiting_list_capacity__gte={capacity}",
-                    events,
-                )
-
-    def test_get_event_list_registration_remaining_attendee_capacity_isnull(self):
-        registration = RegistrationFactory(remaining_attendee_capacity=10)
-        registration2 = RegistrationFactory(remaining_attendee_capacity=None)
-        registration3 = RegistrationFactory(remaining_attendee_capacity=1)
-
-        for capacity, events in [
-            (1, [registration2.event]),
-            (0, [registration.event, registration3.event]),
-            (True, [registration2.event]),
-            (False, [registration.event, registration3.event]),
-        ]:
-            with self.subTest():
-                self._get_list_and_assert_events(
-                    f"registration__remaining_attendee_capacity__isnull={capacity}",
-                    events,
-                )
-
-    def test_get_event_list_registration_remaining_waiting_list_capacity_isnull(self):
-        registration = RegistrationFactory(remaining_waiting_list_capacity=10)
-        registration2 = RegistrationFactory(remaining_waiting_list_capacity=None)
-        registration3 = RegistrationFactory(remaining_waiting_list_capacity=1)
-
-        for capacity, events in [
-            (1, [registration2.event]),
-            (0, [registration.event, registration3.event]),
-            (True, [registration2.event]),
-            (False, [registration.event, registration3.event]),
-        ]:
-            with self.subTest():
-                self._get_list_and_assert_events(
-                    f"registration__remaining_waiting_list_capacity__isnull={capacity}",
-                    events,
-                )

--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 from django.core.management import call_command
@@ -68,7 +68,9 @@ def test__create_a_minimal_event_with_naive_datetime(
 
     # API should have assumed UTC datetime
     minimal_event_dict["start_time"] = (
-        pytz.utc.localize(dateutil_parse(minimal_event_dict["start_time"]))
+        timezone.make_aware(
+            dateutil_parse(minimal_event_dict["start_time"]), timezone=ZoneInfo("UTC")
+        )
         .isoformat()
         .replace("+00:00", "Z")
     )
@@ -339,7 +341,7 @@ def test__autopopulated_fields_at_create(
     # events are automatically marked as ending at midnight, local time
     assert event.end_time == timezone.localtime(
         timezone.now() + timedelta(days=2)
-    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(ZoneInfo("UTC"))
     assert event.has_end_time is False
 
 
@@ -369,7 +371,7 @@ def test__autopopulated_fields_at_create_dst(
     # events are automatically marked as ending at midnight, local time
     assert event.end_time == timezone.localtime(
         timezone.now() + timedelta(days=2)
-    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(ZoneInfo("UTC"))
     assert event.has_end_time is False
 
 

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 from django.core.management import call_command
@@ -197,7 +197,7 @@ def test__update_minimal_event_with_autopopulated_fields_with_put(
     # events are automatically marked as ending at midnight, local time
     assert event.end_time == timezone.localtime(
         timezone.now() + timedelta(days=2)
-    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(ZoneInfo("UTC"))
     assert event.has_end_time is False
 
 
@@ -227,7 +227,7 @@ def test__update_minimal_event_with_autopopulated_fields_with_put_dst(
     # events are automatically marked as ending at midnight, local time
     assert event.end_time == timezone.localtime(
         timezone.now() + timedelta(days=2)
-    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(pytz.utc)
+    ).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(ZoneInfo("UTC"))
     assert event.has_end_time is False
 
 
@@ -324,7 +324,9 @@ def test__update_an_event_with_naive_datetime(api_client, minimal_event_dict, us
 
     # API should have assumed UTC datetime
     data2["start_time"] = (
-        pytz.utc.localize(dateutil_parse(data2["start_time"]))
+        timezone.make_aware(
+            dateutil_parse(data2["start_time"]), timezone=ZoneInfo("UTC")
+        )
         .isoformat()
         .replace("+00:00", "Z")
     )

--- a/events/tests/test_events_search.py
+++ b/events/tests/test_events_search.py
@@ -1,10 +1,10 @@
 import datetime
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import haystack
 from django.conf import settings
 from django.test import TestCase
-from pytz import timezone
 from rest_framework import status
 
 # from haystack.management.commands import rebuild_index, clear_index
@@ -35,8 +35,8 @@ class EventSearchTests(TestCase, TestDataMixin):
             name="dummy event",
             data_source=self.test_ds,
             publisher=self.test_org,
-            start_time=datetime.datetime.now().astimezone(timezone("UTC")),
-            end_time=datetime.datetime.now().astimezone(timezone("UTC")),
+            start_time=datetime.datetime.now().astimezone(ZoneInfo("UTC")),
+            end_time=datetime.datetime.now().astimezone(ZoneInfo("UTC")),
         )
         self.dummy.save()
 

--- a/events/tests/test_filter_by_registration_capacities.py
+++ b/events/tests/test_filter_by_registration_capacities.py
@@ -1,0 +1,78 @@
+from django.test import TestCase
+
+from events.tests.test_event_get import EventsListTestCaseMixin
+from events.tests.utils import versioned_reverse as reverse
+from registrations.tests.factories import RegistrationFactory
+
+
+class FilterEventsByRegistrationCapacitiesV1TestCase(TestCase, EventsListTestCaseMixin):
+    @classmethod
+    def setUpTestData(cls):
+        cls.list_url = reverse("event-list", version="v1")
+
+    def test_get_event_list_registration_remaining_attendee_capacity_gte(self):
+        registration = RegistrationFactory(remaining_attendee_capacity=10)
+        registration2 = RegistrationFactory(remaining_attendee_capacity=5)
+        registration3 = RegistrationFactory(remaining_attendee_capacity=1)
+
+        for capacity, events in [
+            (1, [registration.event, registration2.event, registration3.event]),
+            (5, [registration.event, registration2.event]),
+            (10, [registration.event]),
+            (11, []),
+        ]:
+            with self.subTest():
+                self._get_list_and_assert_events(
+                    f"registration__remaining_attendee_capacity__gte={capacity}", events
+                )
+
+    def test_get_event_list_registration_remaining_waiting_list_capacity_gte(self):
+        registration = RegistrationFactory(remaining_waiting_list_capacity=10)
+        registration2 = RegistrationFactory(remaining_waiting_list_capacity=5)
+        registration3 = RegistrationFactory(remaining_waiting_list_capacity=1)
+
+        for capacity, events in [
+            (1, [registration.event, registration2.event, registration3.event]),
+            (5, [registration.event, registration2.event]),
+            (10, [registration.event]),
+            (11, []),
+        ]:
+            with self.subTest():
+                self._get_list_and_assert_events(
+                    f"registration__remaining_waiting_list_capacity__gte={capacity}",
+                    events,
+                )
+
+    def test_get_event_list_registration_remaining_attendee_capacity_isnull(self):
+        registration = RegistrationFactory(remaining_attendee_capacity=10)
+        registration2 = RegistrationFactory(remaining_attendee_capacity=None)
+        registration3 = RegistrationFactory(remaining_attendee_capacity=1)
+
+        for capacity, events in [
+            (1, [registration2.event]),
+            (0, [registration.event, registration3.event]),
+            (True, [registration2.event]),
+            (False, [registration.event, registration3.event]),
+        ]:
+            with self.subTest():
+                self._get_list_and_assert_events(
+                    f"registration__remaining_attendee_capacity__isnull={capacity}",
+                    events,
+                )
+
+    def test_get_event_list_registration_remaining_waiting_list_capacity_isnull(self):
+        registration = RegistrationFactory(remaining_waiting_list_capacity=10)
+        registration2 = RegistrationFactory(remaining_waiting_list_capacity=None)
+        registration3 = RegistrationFactory(remaining_waiting_list_capacity=1)
+
+        for capacity, events in [
+            (1, [registration2.event]),
+            (0, [registration.event, registration3.event]),
+            (True, [registration2.event]),
+            (False, [registration.event, registration3.event]),
+        ]:
+            with self.subTest():
+                self._get_list_and_assert_events(
+                    f"registration__remaining_waiting_list_capacity__isnull={capacity}",
+                    events,
+                )

--- a/events/tests/utils.py
+++ b/events/tests/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
-import pytz
 from django.conf import settings
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
@@ -156,7 +156,7 @@ def put_event(api_client, event, event_data):
 
 def datetime_zone_aware(year, month, day, hour, minute):
     return datetime(year, month, day, hour, minute).astimezone(
-        pytz.timezone(settings.TIME_ZONE)
+        ZoneInfo(settings.TIME_ZONE)
     )
 
 

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -366,6 +366,14 @@
         <pre><code>event/?hide_recurring_children=true</code></pre>
         <p><a href="?hide_recurring_children=true" title="json">See the result</a></p>
 
+        <h4 id="sub-events">Sub events</h4>
+        <p>You may use the query parameter <code>hide_recurring_children_sub_events</code> in pair with <code>hide_recurring_children</code> to apply other filters to child events.</p>
+        <p>If you want to get only super_events of weekend events then pair <code>hide_recurring_children</code> and <code>hide_recurring_children_sub_events</code> with
+            <code>weekday=6,7</code></p>
+        <p>Example:</p>
+        <pre><code>event/?hide_recurring_children=true&hide_recurring_children_sub_events=true&weekday=6,7</code></pre>
+        <p><a href="?hide_recurring_children=true&hide_recurring_children_sub_events=true&weekday=6,7" title="json">See the result</a></p>
+
         <h3 id="event-registration">Event with registration</h3>
         <p>To find out events with or without a registration, use the query parameter<code>registration</code>.</p>
         <p>Example:</p>

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -1,7 +1,7 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from django.utils import timezone
 from django.utils.translation import activate
 
@@ -111,7 +111,7 @@ def test_notification_template_format_datetime(notification_template):
     notification_template.body_en = "{{ datetime|format_datetime('en') }}"
     notification_template.save()
 
-    dt = datetime(2020, 2, 22, 12, 0, 0, 0, pytz.utc)
+    dt = datetime(2020, 2, 22, 12, 0, 0, 0, ZoneInfo("UTC"))
 
     context = {
         "subject_var": "bar",
@@ -119,7 +119,7 @@ def test_notification_template_format_datetime(notification_template):
         "html_body_var": "foo <b>bar</b> baz",
     }
 
-    timezone.activate(pytz.timezone("Europe/Helsinki"))
+    timezone.activate(ZoneInfo("Europe/Helsinki"))
 
     rendered = render_notification_template(NotificationType.TEST, context, "en")
     assert rendered["body"] == "22 Feb 2020 at 14:00"

--- a/registrations/tests/test_utils.py
+++ b/registrations/tests/test_utils.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 from unittest.mock import patch
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 import freezegun
 import pytest
-import pytz
 import requests_mock
 from django.conf import settings as django_settings
 from django.test import override_settings
@@ -792,7 +792,7 @@ def test_create_web_store_api_order_expiration_datetime(
         )
 
     localized_expiration_datetime = localtime().astimezone(
-        pytz.timezone(expiration_datetime_timezone)
+        ZoneInfo(expiration_datetime_timezone)
     )
     with patch(
         "web_store.order.clients.WebStoreOrderAPIClient.create_order"

--- a/requirements.in
+++ b/requirements.in
@@ -44,7 +44,6 @@ psycopg2
 pyYAML
 python-dateutil
 python-docx
-pytz
 rdflib==6.3.2
 regex
 requests-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -268,8 +268,6 @@ python-jose==3.4.0
     # via django-helusers
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2025.2
-    # via -r requirements.in
 pyyaml==6.0.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
Adds `sub_events` filter to events which to be pair with `hide_recurring_children` to include other selected filtering to the sub events of supers.

+ refactors pytz out 
+ some miney tests refactor

Refs: LINK-2260
