### PR TITLE
Add support for newer Sentry features

### DIFF
--- a/config_dev.env.example
+++ b/config_dev.env.example
@@ -138,7 +138,17 @@ STATIC_URL=/static/
 
 # Sentry environment is an optional tag that can be included in sentry
 # reports. It is used to separate deployments within Sentry UI
-SENTRY_ENVIRONMENT=local-development-unconfigured
+SENTRY_ENVIRONMENT=local
+
+# Sentry profile session sample rate determines the percentage of profiling sessions
+# that are sampled for performance monitoring. Set as a float between 0.0 (0%) and 1.0 (100%).
+# You probably want to use a lower rate in production.
+# SENTRY_PROFILE_SESSION_SAMPLE_RATE=1.0
+
+# Sentry traces sample rate determines the percentage of transactions that are sampled
+# for performance monitoring. Set as a float between 0.0 (0%) and 1.0 (100%).
+# You probably want to use a lower rate in production.
+# SENTRY_TRACES_SAMPLE_RATE=1.0
 
 # Lippupiste has a private API for accessing event data. If you have
 # access to this API, enter your access URL here. Note that you will

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -11,6 +11,7 @@ from urllib.parse import urljoin
 import bleach
 import environ
 import sentry_sdk
+from corsheaders.defaults import default_headers
 from django.conf.global_settings import LANGUAGES as GLOBAL_LANGUAGES
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
@@ -152,7 +153,10 @@ env = environ.Env(
     SECRET_KEY=(str, ""),
     SECURE_PROXY_SSL_HEADER=(tuple, None),
     SENTRY_DSN=(str, ""),
-    SENTRY_ENVIRONMENT=(str, "development"),
+    SENTRY_ENVIRONMENT=(str, "local"),
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE=(float, None),
+    SENTRY_RELEASE=(str, None),
+    SENTRY_TRACES_SAMPLE_RATE=(float, None),
     SOCIAL_AUTH_TUNNISTAMO_KEY=(str, "linkedevents-api-dev"),
     SOCIAL_AUTH_TUNNISTAMO_SECRET=(str, ""),
     SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT=(str, ""),
@@ -320,9 +324,12 @@ if env("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=env("SENTRY_DSN"),
         environment=env("SENTRY_ENVIRONMENT"),
-        release=COMMIT_HASH,
+        release=env("SENTRY_RELEASE"),
         integrations=[DjangoIntegration()],
         event_scrubber=EventScrubber(denylist=SENTRY_DENYLIST),
+        traces_sample_rate=env("SENTRY_TRACES_SAMPLE_RATE"),
+        profile_session_sample_rate=env("SENTRY_PROFILE_SESSION_SAMPLE_RATE"),
+        profile_lifecycle="trace",
     )
 
 MIDDLEWARE = [
@@ -464,6 +471,11 @@ REST_FRAMEWORK = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "baggage",
+    "sentry-trace",
+)
 CSRF_COOKIE_NAME = "%s-csrftoken" % env("COOKIE_PREFIX")
 SESSION_COOKIE_NAME = "%s-sessionid" % env("COOKIE_PREFIX")
 

--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ rdflib==6.3.2
 regex
 requests-cache
 requests
-sentry-sdk
+sentry-sdk[django]
 social-auth-app-django
 social-auth-core
 ujson

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,6 +79,7 @@ django==4.2.20
     #   drf-spectacular
     #   easy-thumbnails
     #   helsinki-profile-gdpr-api
+    #   sentry-sdk
     #   social-auth-app-django
 django-admin-autocomplete-filter==0.7.1
     # via -r requirements.in
@@ -308,7 +309,7 @@ rpds-py==0.24.0
     #   referencing
 rsa==4.9.1
     # via python-jose
-sentry-sdk==2.27.0
+sentry-sdk[django]==2.27.0
     # via -r requirements.in
 six==1.17.0
     # via


### PR DESCRIPTION
Added new environment variables for configuring Sentry tracing, profiling and release string. Also changed Sentry environment to default to "local" in order to differentiate local and development envs in the future.

Refs: LINK-2323