### PR TITLE
LINK-2331|fix: audit log production urls

### DIFF
--- a/audit_log/middleware.py
+++ b/audit_log/middleware.py
@@ -4,7 +4,9 @@ from django.conf import settings
 
 from audit_log.utils import commit_to_audit_log
 
-_AUDIT_LOGGED_ENDPOINTS_RE = re.compile(r"^/(v1|v0.1|gdpr-api|data-analytics)/")
+_AUDIT_LOGGED_ENDPOINTS_RE = re.compile(
+    r"^(/linkedevents)?/(v1|v0.1|gdpr-api|data-analytics)/"
+)
 
 
 class AuditLogMiddleware:

--- a/audit_log/tests/test_middleware.py
+++ b/audit_log/tests/test_middleware.py
@@ -24,12 +24,14 @@ def test_middleware_audit_log_setting(settings, audit_log_enabled):
         assert mocked.called is audit_log_enabled
 
 
+@pytest.mark.parametrize("path_prefix", ["", "/linkedevents"])
 @pytest.mark.parametrize(
     "path,expected_called",
     [
         ("/v1/signup/", True),
         ("/v0.1/signup/", True),
         ("/gdpr-api/v1/user/uuid/", True),
+        ("/nope/v1/signup/", False),
         ("/admin/", False),
         ("/pysocial/", False),
         ("/helusers/", False),
@@ -37,10 +39,10 @@ def test_middleware_audit_log_setting(settings, audit_log_enabled):
     ],
 )
 @pytest.mark.django_db
-def test_middleware_audit_logged_paths(settings, path, expected_called):
+def test_middleware_audit_logged_paths(settings, path_prefix, path, expected_called):
     settings.AUDIT_LOG_ENABLED = True
 
     with patch("audit_log.middleware.commit_to_audit_log") as mocked:
         middleware = AuditLogMiddleware(_get_response)
-        middleware(Mock(path=path))
+        middleware(Mock(path=path_prefix + path))
         assert mocked.called is expected_called


### PR DESCRIPTION
In production requests path begins with /linkedevents/

Refs: LINK-2331