### PR TITLE
feat(events): add space separator to html tags

### DIFF
--- a/events/importer/utils.py
+++ b/events/importer/utils.py
@@ -11,10 +11,10 @@ from events.models import Place
 logger = logging.getLogger(__name__)
 
 
-def clean_text(text, strip_newlines=False, parse_html=False):
+def clean_text(text, strip_newlines=False, parse_html=False, separator: str = ""):
     if parse_html:
         soup = BeautifulSoup(text, features="html.parser")
-        text = soup.get_text()
+        text = soup.get_text(separator=separator)
     # remove non-breaking spaces and separators
     text = text.replace("\xa0", " ").replace("\x1f", "")
     # remove nil bytes and tabs

--- a/events/search_index/utils.py
+++ b/events/search_index/utils.py
@@ -79,7 +79,9 @@ def extract_word_bases(text: str, words: set, lang: str = "fi") -> set:
     :return: the set of words
     """
     # remove html tags and newlines
-    cleaned_text = clean_text(text or "", strip_newlines=True, parse_html=True)
+    cleaned_text = clean_text(
+        text or "", strip_newlines=True, parse_html=True, separator=" "
+    )
     # replace non-word characters with space
     cleaned_text = re.sub(r"\W", " ", cleaned_text)
     cleaned_words = cleaned_text.split() if cleaned_text else []

--- a/events/tests/test_search_index.py
+++ b/events/tests/test_search_index.py
@@ -21,6 +21,10 @@ from events.tests.factories import EventFactory, PlaceFactory
         ("kokonaisvaltainen", {"koko", "nainen", "kokonainen", "valta"}),
         ("ei ole olemassa", {"olla"}),
         ("ja hei huomenna ennen sitä sinä hyppäät yli riman", {"hypätä", "rima"}),
+        (
+            "<h1>Otsikko</h1> jälkeen tulee tekstiä ja<br>rivinvaihto",
+            {"otsikko", "jälki", "tulla", "teksti", "rivi", "vaihto"},
+        ),
     ],
 )
 def test_extract_word_bases(word, expected_result):


### PR DESCRIPTION
When cleaning text to EventSearchIndex there were some issues with text with html tags that it did not separate words for tags like "`this<br/>would<br/>a<br/>single<br/>word`".
This adds spacing between to html tags so that the words can be extracted

Refs: LNK-2315