### PR TITLE
LINK-2188: Update CORS variable naming

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -482,7 +482,7 @@ REST_FRAMEWORK = {
     "VIEW_NAME_FUNCTION": "linkedevents.utils.get_view_name",
 }
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = (
     *default_headers,
     "baggage",


### PR DESCRIPTION
Use latest CORS variable naming convention from: https://pypi.org/project/django-cors-headers/

Refs: LINK-2188