### PR TITLE
Add Enkora place data for Kivikko ice hall

### DIFF
--- a/events/importer/enkora.py
+++ b/events/importer/enkora.py
@@ -648,6 +648,15 @@ class EnkoraImporter(Importer):
             "epsg:4326": (60.24545426653339, 24.99044444303867),
             "keywords": set(),
         },
+        330: {
+            "enkora-name": "Kivikon jäähalli",
+            "tprek-id": None,
+            "street-address": "Savikiekontie 4",
+            "city": "Helsinki",
+            "zip-code": "00940",
+            "epsg:4326": (60.238055556, 25.052222222),
+            "keywords": {SPORT_ICE_HOCKEY},
+        },
     }
 
     description_word_map = {


### PR DESCRIPTION
There is a new Enkora course that needs this place. Tested by running the Enkora importer locally.

Refs: [LINK-2362](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2362)

[LINK-2362]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ