### PR TITLE
LINK-2373: Use plain lists in fulltext search vectors

### DIFF
--- a/events/filters.py
+++ b/events/filters.py
@@ -517,7 +517,7 @@ class EventFilter(django_filters.rest_framework.FilterSet):
             )
         # replace non-word characters with space
         search_value = re.sub(r"\W", " ", value)
-        words = set()
+        words = []
         extract_word_bases(search_value, words, language)
         search_value = " ".join(words)
         search_vector_name = f"full_text__search_vector_{language}"
@@ -531,7 +531,7 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         return (
             qs.filter(**{search_vector_name: search_query})
             .annotate(rank=search_rank)
-            .order_by("-rank")
+            .order_by("-rank", "id")
         )
 
     def filter_x_ongoing(self, qs, name, ongoing: Optional[bool]):

--- a/events/search_index/postgres.py
+++ b/events/search_index/postgres.py
@@ -22,8 +22,8 @@ class EventSearchIndexService:
     """
 
     @classmethod
-    def get_words(cls, event: Event, lang: str, weight: str = "A") -> set:
-        words = set()
+    def get_words(cls, event: Event, lang: str, weight: str = "A") -> list:
+        words = []
         for column in Event.get_words_fields(lang, weight):
             row_content = get_field_attr(event, column)
             if row_content:

--- a/events/search_index/utils.py
+++ b/events/search_index/utils.py
@@ -41,18 +41,18 @@ def analyze_word(word: str) -> list:
     return voikko.analyze(word)
 
 
-def get_word_bases(word: str) -> set:
+def get_word_bases(word: str) -> list:
     """
     Returns a list of word bases of the word.
     :param word: the word to split
     :return: a list of word bases
     """
-    words = set()
+    words = []
     word = word.strip()
     analysis = analyze_word(word)
     if len(analysis) == 0:
         # if the word can't be analyzed, return the word itself
-        words.add(word)
+        words.append(word)
         return words
     for item in analysis:
         if check_stop_words and "CLASS" in item and item["CLASS"] in stop_word_classes:
@@ -64,19 +64,19 @@ def get_word_bases(word: str) -> set:
             for base in word_bases:
                 # remove non-word characters
                 base = re.sub(r"\W", "", base)
-                words.add(base)
+                words.append(base)
         else:
-            words.add(word)
+            words.append(word)
     return words
 
 
-def extract_word_bases(text: str, words: set, lang: str = "fi") -> set:
+def extract_word_bases(text: str, words: list, lang: str = "fi") -> list:
     """
     Splits the word into its bases and adds them to the set of words.
     :param text: the text to split
-    :param words: the set of words to add the bases to
+    :param words: the list of words to add the bases to
     :param lang: the language of the word (default: "fi")
-    :return: the set of words
+    :return: a list of extracted words
     """
     # remove html tags and newlines
     cleaned_text = clean_text(
@@ -87,30 +87,36 @@ def extract_word_bases(text: str, words: set, lang: str = "fi") -> set:
     cleaned_words = cleaned_text.split() if cleaned_text else []
     for word in cleaned_words:
         # convert numbers to words
-        words.update(convert_numbers(word, lang=lang))
+        numbers = convert_numbers(word, lang=lang)
+        if numbers:
+            words.extend(numbers)
         # if the word is in Finnish, get its bases
         word_bases = get_word_bases(word) if lang == "fi" else {word}
-        words.update(word_bases)
+        if word_bases:
+            words.extend(word_bases)
     return words
 
 
-def convert_numbers(word: str, lang: str = "fi") -> set:
+def convert_numbers(word: str, lang: str = "fi") -> list:
     """
     Converts numbers in the word to textual words.
     :param word: the word to process
     :param lang: the language to convert to (default: "fi")
-    :return: a set of words
+    :return: a list of converted words
     """
-    words = set()
+    words = []
     numbers = re.sub(r"\D+", " ", word).split()
+    if numbers:
+        # add numbers itself also
+        words.extend(numbers)
     for number in numbers:
         # convert the number to language-specific words
         try:
-            words.add(num2words(number, lang=lang))
+            num = num2words(number, lang=lang)
+            if num:
+                words.append(num)
         except NotImplementedError:
             pass
-    # add numbers itself also
-    words.update(numbers)
     return words
 
 

--- a/events/tests/test_search_index.py
+++ b/events/tests/test_search_index.py
@@ -12,46 +12,46 @@ from events.tests.factories import EventFactory, PlaceFactory
 @pytest.mark.parametrize(
     "word, expected_result",
     [
-        ("lentokone", {"lentää", "kone"}),
-        ("lentokoneen", {"lentää", "kone"}),
-        ("lentokoneita", {"lentää", "kone"}),
-        ("päiväkoti", {"päivä", "koti"}),
-        ("kissoja", {"kissa"}),
-        ("saippuakivimittakaava", {"saippua", "kivi", "mitta", "kaava"}),
-        ("kokonaisvaltainen", {"koko", "nainen", "kokonainen", "valta"}),
-        ("ei ole olemassa", {"olla"}),
-        ("ja hei huomenna ennen sitä sinä hyppäät yli riman", {"hypätä", "rima"}),
+        ("lentokone", ["lentää", "kone"]),
+        ("lentokoneen", ["lentää", "kone"]),
+        ("lentokoneita", ["lentää", "kone"]),
+        ("päiväkoti", ["päivä", "koti"]),
+        ("kissoja", ["kissa"]),
+        ("saippuakivimittakaava", ["saippua", "kivi", "mitta", "kaava"]),
+        ("kokonaisvaltainen", ["koko", "nainen", "valta", "kokonainen", "valta"]),
+        ("ei ole olemassa", ["olla", "olla", "olla"]),
+        ("ja hei huomenna ennen sitä sinä hyppäät yli riman", ["hypätä", "rima"]),
         (
             "<h1>Otsikko</h1> jälkeen tulee tekstiä ja<br>rivinvaihto",
-            {"otsikko", "jälki", "tulla", "teksti", "rivi", "vaihto"},
+            ["otsikko", "jälki", "tulla", "teksti", "rivi", "vaihto"],
         ),
     ],
 )
 def test_extract_word_bases(word, expected_result):
-    result = extract_word_bases(word, set())
+    result = extract_word_bases(word, [])
     assert result == expected_result
 
 
 @pytest.mark.parametrize(
     "word, expected_result",
     [
-        ("0", {"nolla", "0"}),
-        ("1", {"yksi", "1"}),
-        ("22", {"kaksikymmentäkaksi", "22"}),
-        ("300", {"kolmesataa", "300"}),
-        ("4000", {"neljätuhatta", "4000"}),
-        ("Vuosi 2025", {"kaksituhatta kaksikymmentäviisi", "2025"}),
+        ("0", ["0", "nolla"]),
+        ("1", ["1", "yksi"]),
+        ("22", ["22", "kaksikymmentäkaksi"]),
+        ("300", ["300", "kolmesataa"]),
+        ("4000", ["4000", "neljätuhatta"]),
+        ("Vuosi 2025", ["2025", "kaksituhatta kaksikymmentäviisi"]),
         (
             "Eka 123 toka 456",
-            {"satakaksikymmentäkolme", "neljäsataaviisikymmentäkuusi", "123", "456"},
+            ["123", "456", "satakaksikymmentäkolme", "neljäsataaviisikymmentäkuusi"],
         ),
         (
             "Numero 1234567890",
-            {
+            [
+                "1234567890",
                 "miljardi kaksisataakolmekymmentäneljämiljoonaa "
                 "viisisataakuusikymmentäseitsemäntuhatta kahdeksansataayhdeksänkymmentä",
-                "1234567890",
-            },
+            ],
         ),
     ],
 )


### PR DESCRIPTION
Fulltext-search works more accurately,
when plain lists are used instead of sets.

Updated ordering to use "id" as secondary order.
This will guarantee same default order always.

Added and updated tests.

Refs: LINK-2373