### PR TITLE
LINK-2373: Cache get_word_bases-function results

### DIFF
--- a/events/search_index/utils.py
+++ b/events/search_index/utils.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from functools import cache
+from functools import lru_cache
 from operator import itemgetter
 from typing import Generator
 
@@ -40,7 +40,6 @@ def get_field_attr(obj: object, field: str) -> str:
 _structure_item_getter = itemgetter("STRUCTURE")
 
 
-@cache
 def analyze_word(word: str) -> list:
     results = voikko.analyze(word)
     # Voikko appears to not return the results in a stable manner
@@ -51,6 +50,7 @@ def analyze_word(word: str) -> list:
     return results
 
 
+@lru_cache
 def get_word_bases(word: str) -> list:
     """
     Returns a list of word bases of the word.

--- a/events/tests/test_search_index.py
+++ b/events/tests/test_search_index.py
@@ -48,8 +48,6 @@ def test_extract_word_bases(word, expected_result):
     ],
 )
 def test_voikko_analysis_order_is_sorted(expected_return_value, voikko_return_value):
-    analyze_word.cache_clear()
-
     with patch("events.search_index.utils.voikko.analyze") as mock_analyze:
         mock_analyze.return_value = voikko_return_value
         assert expected_return_value == analyze_word(None)


### PR DESCRIPTION
Optimize cache to use `get_word_bases` instead of `analyze_word`.
This should improve overall caching performance.

Also use `lru_cache` instead of `cache`.

Refs: LINK-2373