### PR TITLE
fix: hide_recurring_children_sub_events performance

### DIFF
--- a/events/filters.py
+++ b/events/filters.py
@@ -624,13 +624,11 @@ class EventFilter(django_filters.rest_framework.FilterSet):
         ):
             # If sub_events is set to true, we need to include the super events.
             super_events = Event.objects.filter(
-                Exists(
+                Exists(queryset.filter(super_event=OuterRef("pk")))
+                | Exists(
                     queryset.filter(
-                        Q(super_event=OuterRef("pk"))
-                        | Q(
-                            eventaggregatemember__event_aggregate__super_event=OuterRef(
-                                "pk"
-                            )
+                        eventaggregatemember__event_aggregate__super_event=OuterRef(
+                            "pk"
                         )
                     )
                 )


### PR DESCRIPTION
The earlier version of hide_recurring_children_sub_events does not work with production amounts of data. In fact, queries were running multiple days with no end in sight.

The fix is somewhat black magic. I suppose having two Exists clauses simplifies the situation to the query planner.

refs: LINK-2383