### PR TITLE
LINK-2378: Update full text sorting

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3193,7 +3193,7 @@ class EventViewSet(
                     "<code>registration__enrolment_start_time</code>, "
                     "<code>registration__enrolment_end_time</code>, <code>enrolment_start</code> "  # noqa: E501
                     "and <code>enrolment_end</code>. The default ordering is "
-                    "<code>-last_modified_time</code>."
+                    "<code>-rank,id</code>."
                 ),
             ),
         ],

--- a/events/templates/swagger/event_list_description.html
+++ b/events/templates/swagger/event_list_description.html
@@ -334,7 +334,7 @@ Use <code>local_ongoing_AND=lapset,musiikki</code> to search for the events with
 <pre><code>event/?include=location,keywords</code></pre>
 
 <h2 id="ordering">Ordering</h2>
-<p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order  results by <code>start_time</code>, <code>end_time</code>, <code>name</code>, <code>duration</code>, <code>enrolment_start_time</code>, <code>enrolment_end_time</code>, <code>registration__enrolment_start_time</code>, <code>registration__enrolment_end_time</code>, <code>enrolment_start</code> and <code>enrolment_end</code>. Descending order is denoted by adding <code>-</code> in front of the parameter, default order is ascending.</p>
+<p>Default normal search ordering is descending order by <code>-last_modified_time</code>. Default full text search ordering is based on search relevance rank and id (<code>-rank,id</code>). You may also order results by <code>start_time</code>, <code>end_time</code>, <code>name</code>, <code>duration</code>, <code>enrolment_start_time</code>, <code>enrolment_end_time</code>, <code>registration__enrolment_start_time</code>, <code>registration__enrolment_end_time</code>, <code>enrolment_start</code> and <code>enrolment_end</code>. Descending order is denoted by adding <code>-</code> in front of the parameter, default order is ascending.</p>
 <p>For example:</p>
 <pre><code>event/?sort=-end_time</code></pre>
 

--- a/helevents/templates/rest_framework/event_list.html
+++ b/helevents/templates/rest_framework/event_list.html
@@ -527,8 +527,9 @@
         <p><a href="?include=location,keywords" title="json">See the result</a></p>
 
         <h2 id="ordering">Ordering</h2>
-        <p>Default ordering is descending order by <code>-last_modified_time</code>. You may also order
-            results by <code>start_time</code>, <code>end_time</code>, <code>name</code>,
+        <p>Default normal search ordering is descending order by <code>-last_modified_time</code>.
+            Default full text search ordering is based on search relevance rank and id (<code>-rank,id</code>).
+            You may also order results by <code>start_time</code>, <code>end_time</code>, <code>name</code>,
             <code>duration</code>, <code>enrolment_start_time</code>, <code>enrolment_end_time</code>,
             <code>registration__enrolment_start_time</code>, <code>registration__enrolment_end_time</code>,
             <code>enrolment_start</code> and <code>enrolment_end</code>. Descending order is denoted by


### PR DESCRIPTION
Allow full text searches to be sorted with `sort`-parameter explicitly.

Default to `-rank,id` sorting.

Update tests and documentation.

Refs: LINK-2378