### PR TITLE
fix: import Mapping from collections.abc instead of collections

### DIFF
--- a/events/utils.py
+++ b/events/utils.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import logging
 import re
 import warnings
@@ -57,7 +57,7 @@ def update(d, u):
     values at all levels of dict u
     """
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             r = update(d.get(k, {}), v)
             d[k] = r
         else:


### PR DESCRIPTION
Removed in Python 3.10

refs: LINK-2389