### PR TITLE
feat: use django-helsinki-health-endpoints for readiness and healthz

### DIFF
--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -5,7 +5,7 @@ Django settings module for linkedevents project.
 import importlib.util
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import timedelta
 from urllib.parse import urljoin
 
 import bleach
@@ -317,6 +317,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "logger_extra",
     "resilient_logger",
+    "helsinki_health_endpoints",
     # Local apps
     "linkedevents",
     "helevents",
@@ -378,11 +379,14 @@ EVENT_SCRUBBER = EventScrubber(
     pii_denylist=SENTRY_PII_DENYLIST,
 )
 
+# For helsinki-health-endpoints
+SENTRY_RELEASE = env("SENTRY_RELEASE")
+
 if env("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=env("SENTRY_DSN"),
         environment=env("SENTRY_ENVIRONMENT"),
-        release=env("SENTRY_RELEASE"),
+        release=SENTRY_RELEASE,
         integrations=[DjangoIntegration()],
         event_scrubber=EVENT_SCRUBBER,
         traces_sampler=sentry_traces_sampler,
@@ -998,8 +1002,6 @@ if os.path.exists(f):
     sys.modules[module_name] = module
     exec(open(f, "rb").read())
 
-# get build time from a file in docker image
-APP_BUILD_TIME = datetime.fromtimestamp(os.path.getmtime(__file__))
 
 # list of (base) urls that are never proxied
 SKIP_PROXY_URLS = env("SKIP_PROXY_URLS")

--- a/linkedevents/tests/test_urls.py
+++ b/linkedevents/tests/test_urls.py
@@ -1,7 +1,6 @@
+import pytest
 import yaml
 from drf_spectacular.validation import validate_schema
-
-from linkedevents import __version__
 
 
 def test_healthz(client):
@@ -10,16 +9,13 @@ def test_healthz(client):
     assert response.status_code == 200
 
 
+@pytest.mark.django_db
 def test_readiness(client, settings):
     response = client.get("/readiness")
-
     data = response.json()
     assert response.status_code == 200
     assert len(data) == 4
     assert data["status"] == "ok"
-    assert data["packageVersion"] == __version__
-    assert data["commitHash"] == settings.COMMIT_HASH
-    assert "buildTime" in data
 
 
 def test_openapi_schema(client):

--- a/linkedevents/urls.py
+++ b/linkedevents/urls.py
@@ -1,13 +1,11 @@
 from django.conf import settings
 from django.conf.urls import include
 from django.contrib import admin
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.urls import path, re_path
 from django.views.decorators.http import require_GET
 from django.views.generic import RedirectView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView
-
-from linkedevents import __version__
 
 from .api import CustomSpectacularSwaggerView, LinkedEventsAPIRouter
 
@@ -66,15 +64,6 @@ def healthz(*args, **kwargs):
     return HttpResponse(status=200)
 
 
-@require_GET
-def readiness(*args, **kwargs):
-    response_json = {
-        "status": "ok",
-        "packageVersion": __version__,
-        "commitHash": settings.COMMIT_HASH,
-        "buildTime": settings.APP_BUILD_TIME.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
-    }
-    return JsonResponse(response_json, status=200)
-
-
-urlpatterns += [path("healthz", healthz), path("readiness", readiness)]
+urlpatterns += [
+    path("", include("helsinki_health_endpoints.urls")),
+]

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ django-environ
 django-filter
 django-haystack
 django-helusers
+django-helsinki-health-endpoints
 django-image-cropping
 django-jinja
 django-leaflet

--- a/requirements.txt
+++ b/requirements.txt
@@ -296,6 +296,7 @@ django==5.2.12 \
     #   django-cors-headers
     #   django-filter
     #   django-haystack
+    #   django-helsinki-health-endpoints
     #   django-helusers
     #   django-jinja
     #   django-js-asset
@@ -349,6 +350,10 @@ django-filter==25.1 \
     #   djangorestframework-gis
 django-haystack==3.3.0 \
     --hash=sha256:e3ceed6b8000625da14d409eb4dac69894905e2ac8ac18f9bfdb59323ca02eab
+    # via -r requirements.in
+django-helsinki-health-endpoints==1.0.0 \
+    --hash=sha256:75670113e99bfd1fc23e317a3a22cff563140f495655c2a5f6ab219389dafd52 \
+    --hash=sha256:eebf1baa6917d7b0e11123aec191df773883102ec1653025a86d7037dba389e2
     # via -r requirements.in
 django-helusers==1.0.0 \
     --hash=sha256:0e33e238347a4088927675574a7dad179ee1f9d9e958daecfa4862ad6f63f79c \


### PR DESCRIPTION
Make use of django-helsinki-health-endpoints library to publish readiness and healthz endpoints.
Add SENTRY_RELEASE to django settings from env for the library and make sure that pyproject.toml isn't excluded from the container. Those are requisite for the readiness data.

Refs: KEH-242