### PR TITLE
Update unused permissions removal to use "last_api_use"-timestamp

### DIFF
--- a/events/importer/espoo.py
+++ b/events/importer/espoo.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin, urlparse
 import requests
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import Exists, Model, OuterRef
+from django.db.models import Model
 from django.utils import timezone
 from django_orghierarchy.models import Organization
 from requests.adapters import HTTPAdapter
@@ -636,7 +636,7 @@ class EspooImporter(Importer):
         # Mark Organizations which are referenced in any Espoo event still in the DB
         # to avoid deletion.
         for org in Organization.objects.filter(
-                data_source=self.data_source, published_events__in=surviving_event_ids
+            data_source=self.data_source, published_events__in=surviving_event_ids
         ).iterator():
             org_syncher.mark(org)
 

--- a/events/management/commands/remove_unused_permissions.py
+++ b/events/management/commands/remove_unused_permissions.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             months=settings.EVENT_ADMIN_EXPIRATION_MONTHS
         )
         for user in User.objects.filter(
-            last_login__lt=threshold_time, admin_organizations__isnull=False
+            last_api_use__lt=threshold_time, admin_organizations__isnull=False
         ):
             user.admin_organizations.clear()
             admins_count += 1
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             months=settings.FINANCIAL_ADMIN_EXPIRATION_MONTHS
         )
         for user in User.objects.filter(
-            last_login__lt=threshold_time, financial_admin_organizations__isnull=False
+            last_api_use__lt=threshold_time, financial_admin_organizations__isnull=False
         ):
             user.financial_admin_organizations.clear()
             admins_count += 1
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             months=settings.REGISTRATION_ADMIN_EXPIRATION_MONTHS
         )
         for user in User.objects.filter(
-            last_login__lt=threshold_time,
+            last_api_use__lt=threshold_time,
             registration_admin_organizations__isnull=False,
         ):
             user.registration_admin_organizations.clear()

--- a/events/tests/management/test_remove_unused_permissions.py
+++ b/events/tests/management/test_remove_unused_permissions.py
@@ -20,14 +20,14 @@ def _test_remove_unused_admin_permissions(
     expired_months_ago = now - relativedelta(months=expiration_months + 1)
     active_months_ago = now - relativedelta(months=expiration_months, days=-1)
 
-    expired_admin = UserFactory(last_login=expired_months_ago)
+    expired_admin = UserFactory(last_api_use=expired_months_ago)
     getattr(expired_admin, admin_relation).add(organization)
 
-    expired_admin2 = UserFactory(last_login=expired_months_ago)
+    expired_admin2 = UserFactory(last_api_use=expired_months_ago)
     getattr(expired_admin2, admin_relation).add(organization)
     getattr(expired_admin2, admin_relation).add(organization2)
 
-    active_admin = UserFactory(last_login=active_months_ago)
+    active_admin = UserFactory(last_api_use=active_months_ago)
     getattr(active_admin, admin_relation).add(organization)
 
     assert getattr(expired_admin, admin_relation).count() == 1


### PR DESCRIPTION
Previously used "last_login"-timestamp was not enough for the unused permissions deletion, because it only takes logins into account.

Update deletion to use "last_api_use"-timestamp instead to make it better.

Refs: [LINK-2521](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2521)

[LINK-2521]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ