### PR TITLE
Use common release-please reusable workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,12 +7,9 @@ on:
   schedule:
     - cron: '1 0 * * *'
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: google-github-actions/release-please-action@v4
+    uses: City-of-Helsinki/.github/.github/workflows/release-please.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Started using the common release-please reusable workflow. Also moved permissions to job level for better least-privilege scoping.

Refs: LINK-2532