### PR TITLE
fix(release-please): update uv.lock TOML JSONPath

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
     ".": {
       "release-type": "python",
       "package-name": "linkedevents",
-      "extra-files": ["pyproject.toml"],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
@@ -19,6 +18,13 @@
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "build", "section": "Build System", "hidden": true},
         {"type": "ci", "section": "Continuous Integration", "hidden": true}
+      ],
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='linkedevents')].version"
+        }
       ]
     }
   },


### PR DESCRIPTION
Updates:
- Fix the uv.lock TOML JSONPath from @.name to @.name.value, which matches release-please’s tagged TOML parser.
- Remove the redundant pyproject.toml extra-files entry. The python release type already updates pyproject.toml.

Refs: [LINK-2580](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2580)

[LINK-2580]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ