### PR TITLE
Handle too long image URL properly in the API

### DIFF
--- a/events/serializers.py
+++ b/events/serializers.py
@@ -247,6 +247,7 @@ class ImageSerializer(EditableLinkedEventsObjectSerializer):
         {"version": "v1"},
         required=False,
         allow_null=True,
+        max_length=400,
         help_text="The image file URL.",
     )
 

--- a/events/tests/test_event_images_v1.py
+++ b/events/tests/test_event_images_v1.py
@@ -574,6 +574,17 @@ def test_upload_an_invalid_dict(api_client, list_url, user, organization):
 
 
 @pytest.mark.django_db
+def test_upload_a_url_too_long(api_client, list_url, user, organization):
+    organization.admin_users.add(user)
+    api_client.force_authenticate(user)
+
+    too_long_url = "https://example.com/" + "a" * 400
+    response = api_client.post(list_url, {"url": too_long_url})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "url" in response.data
+
+
+@pytest.mark.django_db
 def test_image_upload_cannot_set_arbitrary_publisher(
     api_client, external_user, list_url, image_data, organization
 ):


### PR DESCRIPTION
Add max_length=400 to the ProxyURLField in ImageSerializer so that overly long URLs are rejected with a 400 validation error instead of raising a DataError from the database constraint.

Refs: LINK-2501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * I̶m̶a̶g̶e̶ ̶U̶R̶L̶s̶ ̶a̶r̶e̶ ̶n̶o̶w̶ ̶l̶i̶m̶i̶t̶e̶d̶ ̶t̶o̶ ̶4̶0̶0̶ ̶c̶h̶a̶r̶a̶c̶t̶e̶r̶s̶.̶ (The URLs were already limited to 400, this fix is about error handling)
  * Invalid image URLs exceeding the limit return a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->