### PR TITLE
chore: create empty requirements-dev.txt to fix dependabot

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+# This file is intentionally left empty


### PR DESCRIPTION
It appears, that dependabot still has a cached version of requirements-dev.txt and it keeps opening new alerts based on this. Testing if adding an empty requirements-dev.txt allows dependabot to clear it's dependency tree.

Refs: RATY-363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency configuration to indicate that no development dependencies are currently required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->