### PR TITLE
Optimize indexing for multi-event create and update

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -95,6 +95,9 @@ from events.permissions import (
     UserIsAdminInAnyOrganization,
 )
 from events.renderers import DOCXRenderer
+from events.search_index.haystack import HaystackSearchIndexService
+from events.search_index.postgres import EventSearchIndexService
+from events.search_index.signals import suppress_search_index_updates
 from events.serializers import (
     DataSourceSerializer,
     EventSerializer,
@@ -2602,7 +2605,7 @@ class EventViewSet(
                 raise DRFPermissionDenied()
 
         try:
-            super().perform_update(serializer)
+            self.perform_update(serializer)
         except WebStoreAPIError as exc:
             raise serializers.ValidationError(exc.messages)
 
@@ -2758,7 +2761,26 @@ class EventViewSet(
             ):
                 raise DRFPermissionDenied()
 
-        super().perform_create(serializer)
+        if len(event_data_list) > 1 and settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED:
+            with suppress_search_index_updates():
+                super().perform_create(serializer)
+            EventSearchIndexService.bulk_update_search_indexes(serializer.instance)
+            HaystackSearchIndexService.bulk_update_search_indexes(serializer.instance)
+        else:
+            super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        if (
+            isinstance(serializer.validated_data, list)
+            and len(serializer.validated_data) > 1
+            and settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED
+        ):
+            with suppress_search_index_updates():
+                super().perform_update(serializer)
+            EventSearchIndexService.bulk_update_search_indexes(serializer.instance)
+            HaystackSearchIndexService.bulk_update_search_indexes(serializer.instance)
+        else:
+            super().perform_update(serializer)
 
     @extend_schema(
         summary="Delete an event",

--- a/events/management/commands/rebuild_event_search_index.py
+++ b/events/management/commands/rebuild_event_search_index.py
@@ -18,7 +18,6 @@ class Command(BaseCommand):
         logger.info("Cleaning the search index...")
         self.delete_index_in_batches()
         EventSearchIndexService.bulk_update_search_indexes()
-        EventSearchIndexService.update_index_search_vectors()
 
     @transaction.atomic
     def delete_index_in_batches(self):

--- a/events/models.py
+++ b/events/models.py
@@ -1436,7 +1436,6 @@ class Event(
         from events.search_index.postgres import EventSearchIndexService
 
         EventSearchIndexService.update_search_index(self)
-        EventSearchIndexService.update_index_search_vectors(self)
 
     @property
     def is_created_with_apikey(self) -> bool:

--- a/events/search_index/haystack.py
+++ b/events/search_index/haystack.py
@@ -1,0 +1,68 @@
+import logging
+
+from django.apps import apps
+from haystack import connections
+from haystack.signals import RealtimeSignalProcessor
+
+from events.models import Event, PublicationStatus
+from events.search_index.signals import search_index_updates_suppressed
+
+logger = logging.getLogger(__name__)
+
+
+class ScopedRealtimeSignalProcessor(RealtimeSignalProcessor):
+    """Skip Haystack realtime updates only inside a bulk operation."""
+
+    def handle_save(self, sender, instance, **kwargs):
+        if search_index_updates_suppressed():
+            return
+        return super().handle_save(sender, instance, **kwargs)
+
+    def handle_delete(self, sender, instance, **kwargs):
+        if search_index_updates_suppressed():
+            return
+        return super().handle_delete(sender, instance, **kwargs)
+
+
+class HaystackSearchIndexService:
+    """Service class for managing Haystack search indexes."""
+
+    @classmethod
+    def bulk_update_search_indexes(cls, events: list[Event]) -> int:
+        """Update or remove supplied events in Haystack indexes in bulk."""
+        if not events:
+            return 0
+
+        event_ids = [event.pk for event in events]
+        event_queryset = (
+            Event.objects.filter(pk__in=event_ids)
+            .select_related("location")
+            .order_by("pk")
+        )
+        public_event_queryset = event_queryset.filter(
+            publication_status=PublicationStatus.PUBLIC,
+            deleted=False,
+        )
+        events_to_remove = event_queryset.exclude(
+            publication_status=PublicationStatus.PUBLIC,
+            deleted=False,
+        )
+        processor = apps.get_app_config("haystack").signal_processor
+        backends = processor.connection_router.for_write(instance=events[0])
+
+        for using in backends:
+            connection = connections[using]
+            index = connection.get_unified_index().get_index(Event)
+            backend = connection.get_backend()
+            backend.update(index, public_event_queryset)
+            for event in events_to_remove:
+                backend.remove(event)
+
+        event_count = public_event_queryset.count()
+        logger.info(
+            "Haystack index updated for %s public Events and removed %s "
+            "non-public or deleted Events",
+            event_count,
+            len(events_to_remove),
+        )
+        return event_count

--- a/events/search_index/postgres.py
+++ b/events/search_index/postgres.py
@@ -73,22 +73,27 @@ class EventSearchIndexService:
                     **cls.get_weighted_words(event),
                 },
             )
+            cls._update_index_search_vectors([event.id])
             logger.info(f"Updated search index for event: {event.id}")
 
     @classmethod
-    def bulk_update_search_indexes(cls) -> int:
+    def bulk_update_search_indexes(cls, events: list[Event] | None = None) -> int:
         """
         Bulk update the search index for events.
         Create a new EventSearchIndex object for each event
         and saves it to the database.
         Use bulk_create to improve performance.
+
+        If events are provided, only those events are updated and their search
+        vectors are refreshed. Otherwise, the configured rebuild scope is used
+        and all search vectors are refreshed.
         """
         num_updated = 0
         logger.info("Updating search indexes...")
-        # only include events that are less than rebuild time limit
-        # or those without end_time
-        event_qs = (
-            Event.objects.filter(
+        if events is None:
+            # Only include events that are less than the rebuild time limit
+            # or those without end_time.
+            event_qs = Event.objects.filter(
                 Q(
                     end_time__gte=timezone.now()
                     - relativedelta(
@@ -97,7 +102,14 @@ class EventSearchIndexService:
                 )
                 | Q(end_time=None)
             )
-            .select_related("location")
+        else:
+            event_ids = [event.pk for event in events]
+            if not event_ids:
+                return 0
+            event_qs = Event.objects.filter(pk__in=event_ids)
+
+        event_qs = (
+            event_qs.select_related("location")
             .prefetch_related("keywords", "audience")
             .order_by("pk")
         )
@@ -140,22 +152,27 @@ class EventSearchIndexService:
                     *words_fields,
                 ],
             )
+
+        if events is None:
+            cls._update_index_search_vectors()
+        else:
+            cls._update_index_search_vectors(event_ids)
         logger.info(f"Search index updated for {num_updated} Events")
         return num_updated
 
     @classmethod
-    def update_index_search_vectors(cls, event: Event | None = None) -> None:
+    def _update_index_search_vectors(cls, event_ids: list[int] | None = None) -> None:
         """
-        Update search vectors for the search index.
+        Update search vectors for the supplied event IDs, or all index rows.
+        """
+        if event_ids is not None and not event_ids:
+            return
 
-        If event is given, only update that event's search vectors.
-        Otherwise, update all events' search vectors.
-        """
         logger.info("Updating search vectors...")
-        if event:
-            qs = EventSearchIndex.objects.filter(event=event)
-        else:
+        if event_ids is None:
             qs = EventSearchIndex.objects.all()
+        else:
+            qs = EventSearchIndex.objects.filter(event_id__in=event_ids)
 
         qs.update(
             **{

--- a/events/search_index/signals.py
+++ b/events/search_index/signals.py
@@ -1,4 +1,6 @@
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 from django.conf import settings
 from django.db.models.signals import m2m_changed, post_save
@@ -8,6 +10,29 @@ from events.models import Event, Keyword, Place
 
 logger = logging.getLogger(__name__)
 
+_search_index_updates_suppressed = ContextVar(
+    "search_index_updates_suppressed", default=False
+)
+
+
+def event_search_index_updates_active() -> bool:
+    return settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED and not (
+        search_index_updates_suppressed()
+    )
+
+
+def search_index_updates_suppressed() -> bool:
+    return _search_index_updates_suppressed.get()
+
+
+@contextmanager
+def suppress_search_index_updates():
+    token = _search_index_updates_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _search_index_updates_suppressed.reset(token)
+
 
 @receiver(
     post_save,
@@ -15,7 +40,7 @@ logger = logging.getLogger(__name__)
     dispatch_uid="event_post_save",
 )
 def event_post_save(sender: type[Event], instance: Event, **kwargs: dict) -> None:
-    if settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED:
+    if event_search_index_updates_active():
         instance.update_search_index()
 
 
@@ -25,7 +50,7 @@ def event_post_save(sender: type[Event], instance: Event, **kwargs: dict) -> Non
     dispatch_uid="place_post_save",
 )
 def place_post_save(sender: type[Place], instance: Place, **kwargs: dict) -> None:
-    if settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED:
+    if event_search_index_updates_active():
         for event in instance.events.all():
             event.update_search_index()
 
@@ -36,7 +61,7 @@ def place_post_save(sender: type[Place], instance: Place, **kwargs: dict) -> Non
     dispatch_uid="keyword_post_save",
 )
 def keyword_post_save(sender: type[Keyword], instance: Keyword, **kwargs: dict) -> None:
-    if settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED:
+    if event_search_index_updates_active():
         for event in instance.events.all():
             event.update_search_index()
 
@@ -47,7 +72,7 @@ def keyword_post_save(sender: type[Keyword], instance: Keyword, **kwargs: dict) 
     dispatch_uid="event_keywords_m2m_changed",
 )
 def event_keywords_m2m_changed(sender, instance, action, **kwargs):
-    if settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED:
+    if event_search_index_updates_active():
         if action in ["post_add", "post_remove", "post_clear"]:
             if isinstance(instance, Event):
                 instance.update_search_index()

--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -1,12 +1,14 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 from django.core.management import call_command
+from django.test import override_settings
 from django.utils import timezone, translation
 from django.utils.encoding import force_str
 from resilient_logger.models import ResilientLogEntry
@@ -14,7 +16,8 @@ from rest_framework import status
 
 from events.api import KeywordSerializer
 from events.auth import ApiKeyUser
-from events.models import Event, Keyword, Place
+from events.models import Event, EventSearchIndex, Keyword, Place
+from events.search_index.postgres import EventSearchIndexService
 from events.tests.utils import assert_event_data_is_equal
 from registrations.enums import VatPercentage
 from registrations.models import OfferPriceGroup, PriceGroup
@@ -56,6 +59,38 @@ def test__create_a_minimal_event_with_post(api_client, minimal_event_dict, user)
     api_client.force_authenticate(user=user)
     response = create_with_post(api_client, minimal_event_dict)
     assert_event_data_is_equal(minimal_event_dict, response.data)
+
+
+@pytest.mark.django_db
+@override_settings(EVENT_SEARCH_INDEX_SIGNALS_ENABLED=True)
+def test__bulk_event_creation_batches_search_index_updates(
+    api_client, minimal_event_dict, user
+):
+    api_client.force_authenticate(user=user)
+    first_event = deepcopy(minimal_event_dict)
+    second_event = deepcopy(minimal_event_dict)
+    second_event["start_time"] = (
+        dateutil_parse(second_event["start_time"]) + timedelta(hours=1)
+    ).isoformat()
+
+    with (
+        patch.object(Event, "update_search_index") as update_search_index,
+        patch.object(
+            EventSearchIndexService,
+            "bulk_update_search_indexes",
+            wraps=EventSearchIndexService.bulk_update_search_indexes,
+        ) as bulk_update_search_indexes,
+    ):
+        response = api_client.post(
+            reverse("event-list"), [first_event, second_event], format="json"
+        )
+
+    assert response.status_code == 201, response.content
+    assert update_search_index.call_count == 0
+    bulk_update_search_indexes.assert_called_once()
+    assert len(bulk_update_search_indexes.call_args.args[0]) == 2
+    assert EventSearchIndex.objects.count() == 2
+    assert EventSearchIndex.objects.filter(search_vector_fi__isnull=False).count() == 2
 
 
 @pytest.mark.django_db

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -1,18 +1,23 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from decimal import Decimal
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 from django.core.management import call_command
+from django.test import override_settings
 from django.utils import timezone
+from haystack import connections
 from resilient_logger.models import ResilientLogEntry
 from rest_framework import status
 
 from events.auth import ApiKeyUser
-from events.models import Event, Image, Keyword, Offer, Place
+from events.models import Event, EventSearchIndex, Image, Keyword, Offer, Place
+from events.search_index.haystack import HaystackSearchIndexService
+from events.search_index.postgres import EventSearchIndexService
 from events.tests.test_event_post import create_with_post
 from events.tests.utils import assert_event_data_is_equal
 from registrations.enums import VatPercentage
@@ -307,6 +312,104 @@ def test__bulk_update_single_event(api_client, complex_event_dict, user):
     data3 = [data2]
     response2 = api_client.put("http://testserver/v1/event/", data3, format="json")
     assert_event_data_is_equal(data3, response2.data)
+
+
+@pytest.mark.django_db
+@override_settings(EVENT_SEARCH_INDEX_SIGNALS_ENABLED=True)
+def test__bulk_update_multiple_events_batches_search_index_updates(
+    api_client, minimal_event_dict, user
+):
+    api_client.force_authenticate(user=user)
+    first_event = deepcopy(minimal_event_dict)
+    second_event = deepcopy(minimal_event_dict)
+    second_event["start_time"] = (
+        dateutil_parse(second_event["start_time"]) + timedelta(hours=1)
+    ).isoformat()
+
+    response = api_client.post(
+        reverse("event-list"), [first_event, second_event], format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+
+    updated_events = deepcopy(response.data)
+    for event in updated_events:
+        event["name"]["fi"] = f"{event['name']['fi']} updated"
+
+    with (
+        patch.object(Event, "update_search_index") as update_search_index,
+        patch.object(
+            EventSearchIndexService,
+            "bulk_update_search_indexes",
+            wraps=EventSearchIndexService.bulk_update_search_indexes,
+        ) as postgres_bulk_update,
+        patch.object(
+            HaystackSearchIndexService,
+            "bulk_update_search_indexes",
+            wraps=HaystackSearchIndexService.bulk_update_search_indexes,
+        ) as haystack_bulk_update,
+    ):
+        response = api_client.put(reverse("event-list"), updated_events, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    update_search_index.assert_not_called()
+    postgres_bulk_update.assert_called_once()
+    haystack_bulk_update.assert_called_once()
+    assert len(postgres_bulk_update.call_args.args[0]) == 2
+    assert len(haystack_bulk_update.call_args.args[0]) == 2
+    assert EventSearchIndex.objects.filter(search_vector_fi__isnull=False).count() == 2
+    assert all(
+        "updated" in str(index.search_vector_fi)
+        for index in EventSearchIndex.objects.all()
+    )
+
+
+@pytest.mark.django_db
+@override_settings(EVENT_SEARCH_INDEX_SIGNALS_ENABLED=True)
+def test__bulk_update_public_event_to_draft_removes_haystack_document(
+    api_client, minimal_event_dict, user
+):
+    api_client.force_authenticate(user=user)
+    first_event = deepcopy(minimal_event_dict)
+    second_event = deepcopy(minimal_event_dict)
+    second_event["start_time"] = (
+        dateutil_parse(second_event["start_time"]) + timedelta(hours=1)
+    ).isoformat()
+
+    response = api_client.post(
+        reverse("event-list"), [first_event, second_event], format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+
+    updated_event = deepcopy(response.data)
+    updated_event[0]["publication_status"] = "draft"
+    event_ids = [event["id"] for event in response.data]
+    searchable_event_ids = set(event_ids)
+    backend = connections["default"].get_backend()
+
+    with (
+        patch.object(
+            backend,
+            "update",
+            side_effect=lambda _index, public_events: searchable_event_ids.update(
+                public_events.values_list("pk", flat=True)
+            ),
+        ) as update,
+        patch.object(
+            backend,
+            "remove",
+            side_effect=lambda removed_event: searchable_event_ids.discard(
+                removed_event.pk
+            ),
+        ) as remove,
+    ):
+        response = api_client.put(reverse("event-list"), updated_event, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    update.assert_called_once()
+    remove.assert_called_once()
+    assert remove.call_args.args[0].pk == event_ids[0]
+    assert event_ids[0] not in searchable_event_ids
+    assert event_ids[1] in searchable_event_ids
 
 
 @pytest.mark.django_db

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -661,7 +661,7 @@ def dummy_haystack_connection_for_lang(language_code):
     }
 
 
-HAYSTACK_SIGNAL_PROCESSOR = "haystack.signals.RealtimeSignalProcessor"
+HAYSTACK_SIGNAL_PROCESSOR = "events.search_index.haystack.ScopedRealtimeSignalProcessor"
 
 HAYSTACK_CONNECTIONS = {
     "default": {


### PR DESCRIPTION
Suppress per-event search-index signals during multi-event POST and PUT requests to avoid the overhead of indexing each event separately, then update PostgreSQL and Haystack indexes in bulk.

Also, PostgreSQL search-vector refreshing is now performed as part of the search-index update operations instead of as a separate step.

Refs: LINK-2516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search indexing for bulk event creation and updates.
  * Synchronized PostgreSQL and Haystack search indexes for more consistent results.
  * Added bulk rebuilding of event search indexes.
* **Bug Fixes**
  * Reduced duplicate and unnecessary indexing during bulk operations.
  * Limited search results to eligible public, non-deleted events.
  * Removed search entries when published events become drafts.
  * Improved updates to search data for affected events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->