### PR TITLE
Improve multi-event Haystack indexing

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -2765,7 +2765,15 @@ class EventViewSet(
             with suppress_search_index_updates():
                 super().perform_create(serializer)
             EventSearchIndexService.bulk_update_search_indexes(serializer.instance)
-            HaystackSearchIndexService.bulk_update_search_indexes(serializer.instance)
+            # Haystack only indexes public events, so omit newly created drafts
+            # instead of trying to remove documents that cannot exist yet.
+            HaystackSearchIndexService.bulk_update_search_indexes(
+                [
+                    event
+                    for event in serializer.instance
+                    if event.publication_status == PublicationStatus.PUBLIC
+                ]
+            )
         else:
             super().perform_create(serializer)
 
@@ -2775,10 +2783,30 @@ class EventViewSet(
             and len(serializer.validated_data) > 1
             and settings.EVENT_SEARCH_INDEX_SIGNALS_ENABLED
         ):
+            # Capture this before saving: after the update, a public event changed
+            # to draft is indistinguishable from an event that was already a draft.
+            previously_public_event_ids = set(
+                serializer.instance.filter(
+                    publication_status=PublicationStatus.PUBLIC,
+                    deleted=False,
+                ).values_list("pk", flat=True)
+            )
             with suppress_search_index_updates():
                 super().perform_update(serializer)
             EventSearchIndexService.bulk_update_search_indexes(serializer.instance)
-            HaystackSearchIndexService.bulk_update_search_indexes(serializer.instance)
+            # Index active public events and remove only documents that may have
+            # existed before the update; already-draft events need no Haystack call.
+            HaystackSearchIndexService.bulk_update_search_indexes(
+                [
+                    event
+                    for event in serializer.instance
+                    if (
+                        event.publication_status == PublicationStatus.PUBLIC
+                        and not event.deleted
+                    )
+                    or event.pk in previously_public_event_ids
+                ]
+            )
         else:
             super().perform_update(serializer)
 

--- a/events/tests/test_event_post.py
+++ b/events/tests/test_event_post.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from events.api import KeywordSerializer
 from events.auth import ApiKeyUser
 from events.models import Event, EventSearchIndex, Keyword, Place
+from events.search_index.haystack import HaystackSearchIndexService
 from events.search_index.postgres import EventSearchIndexService
 from events.tests.utils import assert_event_data_is_equal
 from registrations.enums import VatPercentage
@@ -91,6 +92,30 @@ def test__bulk_event_creation_batches_search_index_updates(
     assert len(bulk_update_search_indexes.call_args.args[0]) == 2
     assert EventSearchIndex.objects.count() == 2
     assert EventSearchIndex.objects.filter(search_vector_fi__isnull=False).count() == 2
+
+
+@pytest.mark.django_db
+@override_settings(EVENT_SEARCH_INDEX_SIGNALS_ENABLED=True)
+def test__bulk_draft_event_creation_skips_haystack_updates(
+    api_client, minimal_event_dict, user
+):
+    api_client.force_authenticate(user=user)
+    first_event = deepcopy(minimal_event_dict)
+    second_event = deepcopy(minimal_event_dict)
+    first_event["publication_status"] = "draft"
+    second_event["publication_status"] = "draft"
+
+    with patch.object(
+        HaystackSearchIndexService,
+        "bulk_update_search_indexes",
+        wraps=HaystackSearchIndexService.bulk_update_search_indexes,
+    ) as bulk_update_search_indexes:
+        response = api_client.post(
+            reverse("event-list"), [first_event, second_event], format="json"
+        )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+    bulk_update_search_indexes.assert_called_once_with([])
 
 
 @pytest.mark.django_db

--- a/events/tests/test_event_put.py
+++ b/events/tests/test_event_put.py
@@ -413,6 +413,37 @@ def test__bulk_update_public_event_to_draft_removes_haystack_document(
 
 
 @pytest.mark.django_db
+@override_settings(EVENT_SEARCH_INDEX_SIGNALS_ENABLED=True)
+def test__bulk_update_already_draft_events_skips_haystack_removal(
+    api_client, minimal_event_dict, user
+):
+    api_client.force_authenticate(user=user)
+    first_event = deepcopy(minimal_event_dict)
+    second_event = deepcopy(minimal_event_dict)
+    first_event["publication_status"] = "draft"
+    second_event["publication_status"] = "draft"
+    second_event["start_time"] = (
+        dateutil_parse(second_event["start_time"]) + timedelta(hours=1)
+    ).isoformat()
+
+    response = api_client.post(
+        reverse("event-list"), [first_event, second_event], format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+
+    updated_events = deepcopy(response.data)
+    for event in updated_events:
+        event["name"]["fi"] = f"{event['name']['fi']} updated"
+    backend = connections["default"].get_backend()
+
+    with patch.object(backend, "remove") as remove:
+        response = api_client.put(reverse("event-list"), updated_events, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.content
+    remove.assert_not_called()
+
+
+@pytest.mark.django_db
 def test__update_an_event_with_naive_datetime(api_client, minimal_event_dict, user):
     # create an event
     api_client.force_authenticate(user=user)


### PR DESCRIPTION
This PR improves multi-event create/update performance by avoiding unnecessary Haystack removals for draft events. 

Refs: LINK-2516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Draft events are no longer added to search results during creation.
  * Bulk updates correctly preserve and refresh search visibility for public events.
  * Events that become drafts are removed from search indexing when appropriate.
  * Improved handling of bulk event creation and updates without unnecessary search-index operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->