### PR TITLE
Mark search endpoint as deprecated

### DIFF
--- a/events/api.py
+++ b/events/api.py
@@ -3367,6 +3367,7 @@ class SearchViewSet(
     @extend_schema(
         summary="Search through events and places",
         description=render_to_string("swagger/search_list_description.html"),
+        tags=["search (deprecated)"],
         auth=[],
         parameters=[
             OpenApiParameter(

--- a/events/templates/swagger/search_list_description.html
+++ b/events/templates/swagger/search_list_description.html
@@ -1,3 +1,10 @@
+## Deprecated!
+
+**This endpoint will be removed in a future release.**
+
+For event searches, use `/event/?full_text=...` instead. You may also specify
+`full_text_language`; it defaults to `fi`. For place searches, use `/place/?text=...`.
+
 <h2 id="using-search-endpoint">Using the search endpoint</h2>
 <p>This is the supposedly intelligent Elasticsearch Finnish full-text search for both events and places. The results are sorted by relevance score shown in the <code>score</code> field. The search parameter is <code>?q=</code>.
 

--- a/helevents/templates/rest_framework/search_list.html
+++ b/helevents/templates/rest_framework/search_list.html
@@ -1,5 +1,13 @@
 <div class="panel panel-default">
     <div class="panel-body">
+        <div class="alert alert-warning" role="alert">
+            <h2>Deprecated!</h2>
+            <p>This endpoint will be removed in a future release.</p>
+            <p>For event searches, use <code>/event/?full_text=...</code> instead. You may also specify
+                <code>full_text_language</code>; it defaults to <code>fi</code>. For place searches, use
+                <code>/place/?text=...</code>.</p>
+        </div>
+
         <h2 id="using-search-endpoint">Using the search endpoint</h2>
         <p>This is the supposedly intelligent Elasticsearch Finnish full-text search for both events and places.
             The results are sorted by relevance score shown in the <code>score</code> field. The search parameter

--- a/linkedevents/settings.py
+++ b/linkedevents/settings.py
@@ -953,7 +953,10 @@ SPECTACULAR_SETTINGS = {
     },
     "TAGS": [
         {"name": "event", "description": "Search and edit events"},
-        {"name": "search", "description": "Fulltext search through events and places"},
+        {
+            "name": "search (deprecated)",
+            "description": "Fulltext search through events and places",
+        },
         {"name": "image", "description": "Get and upload images"},
         {"name": "keyword", "description": "Search and edit keywords"},
         {"name": "keyword_set", "description": "Search and edit keyword sets"},


### PR DESCRIPTION
Add deprecation notices to [the browsable API](https://linkedevents-pr1254.api.dev.hel.ninja/v1/search/) and [OpenAPI documentation](https://linkedevents-pr1254.api.dev.hel.ninja/api-docs/#tag/search-(deprecated)).

<img width="1197" height="581" alt="Screenshot 2026-09-07 at 14 59 38" src="https://github.com/user-attachments/assets/ff189764-ccd2-4469-8b04-50d276e151ed" />

<img width="1602" height="522" alt="Screenshot 2026-09-07 at 15 00 33" src="https://github.com/user-attachments/assets/15e2a37d-d18e-4ea9-9bf7-35deab8e13d9" />

Refs: LINK-2604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added prominent deprecation notices to the search API documentation.
  - Search endpoint documentation now directs event searches to `/event/?full_text=...` and place searches to `/place/?text=...`.
  - Event searches may optionally specify `full_text_language` (default: `fi`).
  - Updated the API documentation label to clearly identify the search endpoint as deprecated and note its planned future removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->